### PR TITLE
fix: add version to path deps for release-plz

### DIFF
--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
-kartoteka-shared = { path = "../shared" }
+kartoteka-shared = { path = "../shared", version = "0.1.0" }
 worker = { version = "0.7", features = ["d1"] }
 sqlx-d1 = { version = "0.3", features = ["macros"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/frontend/Cargo.toml
+++ b/crates/frontend/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
-kartoteka-shared = { path = "../shared" }
+kartoteka-shared = { path = "../shared", version = "0.1.0" }
 leptos = { version = "0.7", features = ["csr"] }
 leptos_router = "0.7"
 gloo-net = { version = "0.6", features = ["http"] }


### PR DESCRIPTION
## Summary
- Add `version = "0.1.0"` to `kartoteka-shared` path dependencies in api and frontend crates
- `cargo package` requires version on path deps — release-plz runs this during version detection even with `publish = false`

## Test plan
- [ ] Verify release-plz workflow passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)