### PR TITLE
feat: clickable tag pills with full path display

### DIFF
--- a/crates/frontend/src/components/date_item_row.rs
+++ b/crates/frontend/src/components/date_item_row.rs
@@ -1,8 +1,7 @@
 use kartoteka_shared::{Item, Tag};
 use leptos::prelude::*;
 
-use super::tag_badge::TagBadge;
-use super::tag_selector::TagSelector;
+use super::tag_list::TagList;
 
 pub fn get_today_string() -> String {
     let today = js_sys::Date::new_0();
@@ -194,37 +193,12 @@ pub fn DateItemRow(
                 />
                 <span class=title_class>{item.title}</span>
 
-                // Tag badges
-                {if !item_tag_ids.is_empty() {
-                    let item_tags: Vec<Tag> = all_tags.iter()
-                        .filter(|t| item_tag_ids.contains(&t.id))
-                        .cloned()
-                        .collect();
-                    view! {
-                        <div class="flex flex-wrap gap-1">
-                            {item_tags.into_iter().map(|t| {
-                                match on_tag_toggle {
-                                    Some(cb) => view! { <TagBadge tag=t on_remove=cb/> }.into_any(),
-                                    None => view! { <TagBadge tag=t/> }.into_any(),
-                                }
-                            }).collect::<Vec<_>>()}
-                        </div>
-                    }.into_any()
-                } else {
-                    view! {}.into_any()
-                }}
-                // Tag selector
-                {if let Some(toggle_cb) = on_tag_toggle {
-                    view! {
-                        <TagSelector
-                            all_tags=all_tags.clone()
-                            selected_tag_ids=item_tag_ids.clone()
-                            on_toggle=toggle_cb
-                        />
-                    }.into_any()
-                } else {
-                    view! {}.into_any()
-                }}
+                // Tags
+                <TagList
+                    all_tags=all_tags.clone()
+                    selected_tag_ids=item_tag_ids.clone()
+                    on_toggle=on_tag_toggle
+                />
 
                 <div class=date_color>
                     {date_display.map(|d| view! { <div class="font-medium">{d}</div> })}

--- a/crates/frontend/src/components/item_row.rs
+++ b/crates/frontend/src/components/item_row.rs
@@ -1,8 +1,7 @@
 use kartoteka_shared::{Item, Tag};
 use leptos::prelude::*;
 
-use super::tag_badge::TagBadge;
-use super::tag_selector::TagSelector;
+use super::tag_list::TagList;
 
 #[component]
 pub fn ItemRow(
@@ -147,29 +146,13 @@ pub fn ItemRow(
 
             // Row 2: Tags (below title, indented)
             {if has_tags {
-                let item_tags: Vec<Tag> = all_tags.iter()
-                    .filter(|t| item_tag_ids.contains(&t.id))
-                    .cloned()
-                    .collect();
                 view! {
-                    <div class="flex flex-wrap items-center gap-1 pl-14 pb-1">
-                        {item_tags.into_iter().map(|t| {
-                            match on_tag_toggle {
-                                Some(cb) => view! { <TagBadge tag=t on_remove=cb/> }.into_any(),
-                                None => view! { <TagBadge tag=t/> }.into_any(),
-                            }
-                        }).collect::<Vec<_>>()}
-                        {if let Some(toggle_cb) = on_tag_toggle {
-                            view! {
-                                <TagSelector
-                                    all_tags=all_tags.clone()
-                                    selected_tag_ids=item_tag_ids.clone()
-                                    on_toggle=toggle_cb
-                                />
-                            }.into_any()
-                        } else {
-                            view! {}.into_any()
-                        }}
+                    <div class="pl-14 pb-1">
+                        <TagList
+                            all_tags=all_tags.clone()
+                            selected_tag_ids=item_tag_ids.clone()
+                            on_toggle=on_tag_toggle
+                        />
                     </div>
                 }.into_any()
             } else {

--- a/crates/frontend/src/components/list_card.rs
+++ b/crates/frontend/src/components/list_card.rs
@@ -2,8 +2,7 @@ use kartoteka_shared::{List, ListType, Tag};
 use leptos::prelude::*;
 use leptos_router::hooks::use_navigate;
 
-use crate::components::tag_badge::TagBadge;
-use crate::components::tag_selector::TagSelector;
+use crate::components::tag_list::TagList;
 
 pub fn list_type_label(lt: &ListType) -> &'static str {
     match lt {
@@ -40,11 +39,7 @@ pub fn ListCard(
     let navigate = use_navigate();
     let href_clone = href.clone();
 
-    let assigned_tags: Vec<Tag> = all_tags
-        .iter()
-        .filter(|t| list_tag_ids.contains(&t.id))
-        .cloned()
-        .collect();
+    let has_tags = !list_tag_ids.is_empty() || on_tag_toggle.is_some();
 
     let list_id_for_delete = list.id.clone();
     let on_delete_clone = on_delete.clone();
@@ -75,29 +70,17 @@ pub fn ListCard(
             <div class="card-body p-4">
                 <h3 class="card-title text-base">{list.name.clone()}</h3>
                 <span class="text-sm text-base-content/60">{icon} " " {label}</span>
-                {if on_tag_toggle.is_some() || !assigned_tags.is_empty() {
+                {if has_tags {
                     view! {
                         <div
-                            class="tag-list mt-2"
+                            class="tag-list mt-2 overflow-visible"
                             on:click=|ev: web_sys::MouseEvent| ev.stop_propagation()
                         >
-                            {assigned_tags.into_iter().map(|t| {
-                                let tid = t.id.clone();
-                                let cb = on_tag_toggle.clone();
-                                if let Some(c) = cb {
-                                    let remove_cb = Callback::new(move |_: String| c.run(tid.clone()));
-                                    view! { <TagBadge tag=t on_remove=remove_cb /> }.into_any()
-                                } else {
-                                    view! { <TagBadge tag=t /> }.into_any()
-                                }
-                            }).collect::<Vec<_>>()}
-                            {on_tag_toggle.map(|cb| view! {
-                                <TagSelector
-                                    all_tags=all_tags.clone()
-                                    selected_tag_ids=list_tag_ids.clone()
-                                    on_toggle=cb
-                                />
-                            })}
+                            <TagList
+                                all_tags=all_tags.clone()
+                                selected_tag_ids=list_tag_ids.clone()
+                                on_toggle=on_tag_toggle
+                            />
                         </div>
                     }.into_any()
                 } else {

--- a/crates/frontend/src/components/list_tag_bar.rs
+++ b/crates/frontend/src/components/list_tag_bar.rs
@@ -1,7 +1,6 @@
 use leptos::prelude::*;
 
-use super::tag_badge::TagBadge;
-use super::tag_selector::TagSelector;
+use super::tag_list::TagList;
 use kartoteka_shared::Tag;
 
 /// Displays assigned tags as badges with remove, plus a tag selector to add more.
@@ -11,35 +10,13 @@ pub fn ListTagBar(
     assigned_tag_ids: Vec<String>,
     on_toggle: Callback<String>,
 ) -> impl IntoView {
-    let assigned: Vec<Tag> = all_tags
-        .iter()
-        .filter(|t| assigned_tag_ids.contains(&t.id))
-        .cloned()
-        .collect();
-
     view! {
-        <div class="flex flex-wrap items-center gap-1 mb-3">
-            {assigned.into_iter().map(|t| {
-                let tid = t.id.clone();
-                let cb = on_toggle;
-                view! {
-                    <TagBadge
-                        tag=t
-                        on_remove=Callback::new(move |_: String| cb.run(tid.clone()))
-                    />
-                }
-            }).collect::<Vec<_>>()}
-            {if !all_tags.is_empty() {
-                view! {
-                    <TagSelector
-                        all_tags=all_tags
-                        selected_tag_ids=assigned_tag_ids
-                        on_toggle=on_toggle
-                    />
-                }.into_any()
-            } else {
-                ().into_any()
-            }}
+        <div class="mb-3">
+            <TagList
+                all_tags=all_tags
+                selected_tag_ids=assigned_tag_ids
+                on_toggle=Some(on_toggle)
+            />
         </div>
     }
 }

--- a/crates/frontend/src/components/mod.rs
+++ b/crates/frontend/src/components/mod.rs
@@ -16,5 +16,6 @@ pub mod editable_description;
 pub mod editable_title;
 pub mod list_tag_bar;
 pub mod tag_filter_bar;
+pub mod tag_list;
 pub mod tag_tree;
 pub mod toast_container;

--- a/crates/frontend/src/components/tag_badge.rs
+++ b/crates/frontend/src/components/tag_badge.rs
@@ -1,14 +1,21 @@
+use crate::components::tag_tree::build_breadcrumb;
 use kartoteka_shared::Tag;
 use leptos::prelude::*;
+use leptos_router::components::A;
 use std::time::Duration;
 
 #[component]
-pub fn TagBadge(tag: Tag, #[prop(optional)] on_remove: Option<Callback<String>>) -> impl IntoView {
+pub fn TagBadge(
+    tag: Tag,
+    #[prop(optional)] on_remove: Option<Callback<String>>,
+    #[prop(default = vec![])] all_tags: Vec<Tag>,
+) -> impl IntoView {
     let tag_id = tag.id.clone();
     let confirming = RwSignal::new(false);
 
     let handle_remove_click = move |ev: web_sys::MouseEvent| {
         ev.stop_propagation();
+        ev.prevent_default();
         if confirming.get() {
             if let Some(cb) = on_remove {
                 cb.run(tag_id.clone());
@@ -20,12 +27,48 @@ pub fn TagBadge(tag: Tag, #[prop(optional)] on_remove: Option<Callback<String>>)
         }
     };
 
+    let color = tag.color.clone();
+    let tag_id_link = tag.id.clone();
+
+    // Build breadcrumb path if all_tags is provided
+    let breadcrumb = if !all_tags.is_empty() {
+        build_breadcrumb(&all_tags, &tag.id)
+    } else {
+        vec![tag.clone()]
+    };
+
+    let has_path = breadcrumb.len() > 1 || !all_tags.is_empty();
+
     view! {
         <span
             class=move || if confirming.get() { "tag-badge confirming" } else { "tag-badge" }
-            style=format!("background: {}; color: white;", tag.color)
+            style=format!("background: {}; color: white;", color)
         >
-            {tag.name.clone()}
+            {if has_path {
+                // Clickable path: each segment links to its tag detail page
+                breadcrumb.iter().enumerate().map(|(i, bt)| {
+                    let bt_id = bt.id.clone();
+                    let bt_name = bt.name.clone();
+                    let is_last = i == breadcrumb.len() - 1;
+                    view! {
+                        <A href=format!("/tags/{bt_id}") attr:class="tag-badge-link" attr:style="color: inherit; text-decoration: none;">
+                            {bt_name}
+                        </A>
+                        {if !is_last {
+                            view! { <span class="tag-badge-sep">" › "</span> }.into_any()
+                        } else {
+                            view! {}.into_any()
+                        }}
+                    }
+                }).collect_view().into_any()
+            } else {
+                // Simple: just tag name, link to detail
+                view! {
+                    <A href=format!("/tags/{tag_id_link}") attr:class="tag-badge-link" attr:style="color: inherit; text-decoration: none;">
+                        {tag.name.clone()}
+                    </A>
+                }.into_any()
+            }}
             {if on_remove.is_some() {
                 view! {
                     <button

--- a/crates/frontend/src/components/tag_list.rs
+++ b/crates/frontend/src/components/tag_list.rs
@@ -1,0 +1,48 @@
+use kartoteka_shared::Tag;
+use leptos::prelude::*;
+
+use super::tag_badge::TagBadge;
+use super::tag_selector::TagSelector;
+
+/// Shared component for rendering a list of tag badges with optional tag selector.
+/// Replaces duplicated tag rendering pattern in ItemRow, DateItemRow, and ListCard.
+#[component]
+pub fn TagList(
+    all_tags: Vec<Tag>,
+    selected_tag_ids: Vec<String>,
+    on_toggle: Option<Callback<String>>,
+) -> impl IntoView {
+    let item_tags: Vec<Tag> = all_tags
+        .iter()
+        .filter(|t| selected_tag_ids.contains(&t.id))
+        .cloned()
+        .collect();
+
+    let has_content = !item_tags.is_empty() || on_toggle.is_some();
+
+    if !has_content {
+        return view! {}.into_any();
+    }
+
+    view! {
+        <div class="flex flex-wrap items-center gap-1">
+            {item_tags.into_iter().map(|t| {
+                match on_toggle {
+                    Some(cb) => view! { <TagBadge tag=t on_remove=cb all_tags=all_tags.clone()/> }.into_any(),
+                    None => view! { <TagBadge tag=t all_tags=all_tags.clone()/> }.into_any(),
+                }
+            }).collect::<Vec<_>>()}
+            {if let Some(toggle_cb) = on_toggle {
+                view! {
+                    <TagSelector
+                        all_tags=all_tags.clone()
+                        selected_tag_ids=selected_tag_ids.clone()
+                        on_toggle=toggle_cb
+                    />
+                }.into_any()
+            } else {
+                view! {}.into_any()
+            }}
+        </div>
+    }.into_any()
+}

--- a/crates/frontend/src/components/tag_selector.rs
+++ b/crates/frontend/src/components/tag_selector.rs
@@ -55,13 +55,13 @@ fn TagSelectorNode(
     let tid = tag.id.clone();
     let tid_toggle = tag.id.clone();
     let tid_expand = tag.id.clone();
-    let padding = format!("padding-left: {}rem;", depth as f64 * 0.75);
+    let margin = format!("margin-left: {}rem;", depth as f64 * 0.75);
 
     view! {
-        <div>
+        <div style=margin>
             <label
                 class="flex items-center gap-1.5 px-2 py-1.5 text-sm rounded cursor-pointer hover:bg-base-300"
-                style=format!("{padding} border-left: 3px solid {color};")
+                style=format!("border-left: 3px solid {color};")
             >
                 {has_children.then(|| {
                     let tid_e = tid_expand.clone();


### PR DESCRIPTION
## Summary
- **Clickable tag pills** — tag badges now show full hierarchical path (e.g. "Parent › Child") with each segment linking to its tag detail page
- **TagList component** — extracted shared tag rendering pattern (filter + badges + selector) from ItemRow, DateItemRow, and ListCard into reusable `TagList` component
- **TagSelector fix** — fixed left border misalignment on nested tags by separating `margin-left` (indentation) from `border-left` (color indicator)

## Test plan
- [ ] Tag pills show full path on list page and today page
- [ ] Clicking a tag pill navigates to `/tags/:id`
- [ ] Clicking parent segment in path navigates to parent tag detail
- [ ] Remove button on tags still works (doesn't navigate)
- [ ] TagSelector dropdown: left border stays aligned at nested depths
- [ ] `just check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)