### PR TITLE
fix: mark api/frontend as publish=false for release-plz

### DIFF
--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kartoteka-api"
 version.workspace = true
 edition.workspace = true
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/crates/frontend/Cargo.toml
+++ b/crates/frontend/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kartoteka-frontend"
 version.workspace = true
 edition.workspace = true
+publish = false
 
 [dependencies]
 kartoteka-shared = { path = "../shared", version = "0.1.0" }


### PR DESCRIPTION
## Summary
- Add `publish = false` to `Cargo.toml` of `kartoteka-api` and `kartoteka-frontend`
- `cargo package kartoteka-shared` was verifying all workspace members including frontend (which needs wasm32 + env vars) — causing release-plz to fail
- `publish = false` in Cargo.toml tells cargo to skip these crates entirely during packaging

## Test plan
- [ ] Verify release-plz workflow passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)