### PR TITLE
fix: mark shared crate as publish=false to fix release-plz

### DIFF
--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kartoteka-shared"
 version.workspace = true
 edition.workspace = true
+publish = false
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary
- Add `publish = false` to `kartoteka-shared/Cargo.toml`
- All crates are private — none are published to crates.io
- Without this, `cargo package --verify` on shared triggers full workspace compilation, which fails because api requires `HANKO_API_URL` at compile time

## Test plan
- [ ] Verify release-plz workflow passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)