### PR TITLE
fix: add compile-time env vars to release-plz workflow

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - master
 
+# Compile-time env vars needed by cargo package --verify
+# (release-plz runs cargo package during version detection)
+env:
+  API_BASE_URL: "/api"
+  HANKO_API_URL: "https://placeholder.hanko.io"
+
 jobs:
   release-plz-release:
     name: Release-plz release
@@ -43,6 +49,8 @@ jobs:
           persist-credentials: false
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - name: Install wasm32 target
+        run: rustup target add wasm32-unknown-unknown
       - name: Run release-plz
         uses: release-plz/action@v0.5
         with:


### PR DESCRIPTION
## Summary
- Add `API_BASE_URL` and `HANKO_API_URL` as workflow-level env vars with dummy values
- Add `wasm32-unknown-unknown` target installation for frontend compilation
- release-plz runs `cargo package --verify` during version detection, which compiles workspace crates that require these env vars at compile time via `env!()`

## Root cause
`publish = false` in Cargo.toml and `release = false` in release-plz.toml were not sufficient — release-plz still runs `cargo package` on `kartoteka-shared`, and the verify step triggers compilation of dependent crates.

## Test plan
- [ ] Verify release-plz workflow passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)