### PR TITLE
fix: add Cargo cache to release-plz PR job

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -51,6 +51,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: Install wasm32 target
         run: rustup target add wasm32-unknown-unknown
+      - name: Cache Cargo registry and build
+        uses: Swatinem/rust-cache@v2
       - name: Run release-plz
         uses: release-plz/action@v0.5
         with:


### PR DESCRIPTION
## Summary
- Adds `Swatinem/rust-cache@v2` to the release-plz PR job to cache Cargo registry and build artifacts
- First run will still be ~4min, subsequent runs should drop to ~30-60s

## Note
Also need to enable **Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"** to fix the 403 error on PR creation.

## Test plan
- [ ] Merge and verify next release-plz PR run completes faster
- [ ] Confirm the 403 is gone after enabling the repo setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)