### PR TITLE
feat: richer time semantics (M4)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,22 +3,11 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       pull-requests: write
@@ -39,6 +28,14 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-
+          show_full_output: true
+          claude_args: |
+            --max-turns 15
+            --model claude-sonnet-4-6
+          settings: |
+            {
+              "permissions": {
+                "allow": ["Read", "Glob", "Grep"],
+                "deny": ["Edit", "Write", "Bash", "WebFetch", "WebSearch"]
+              }
+            }

--- a/crates/api/migrations/0008_richer_dates.sql
+++ b/crates/api/migrations/0008_richer_dates.sql
@@ -1,0 +1,8 @@
+-- M4: Richer time semantics - new date columns on items
+ALTER TABLE items ADD COLUMN start_date TEXT;
+ALTER TABLE items ADD COLUMN start_time TEXT;
+ALTER TABLE items ADD COLUMN hard_deadline TEXT;
+
+-- Rename existing due_date/due_time to deadline/deadline_time
+ALTER TABLE items RENAME COLUMN due_date TO deadline;
+ALTER TABLE items RENAME COLUMN due_time TO deadline_time;

--- a/crates/api/migrations/0009_deadlines_feature.sql
+++ b/crates/api/migrations/0009_deadlines_feature.sql
@@ -1,0 +1,23 @@
+-- M4: Migrate feature slice due_date -> deadlines
+-- Cannot UPDATE in-place because old CHECK constraint blocks 'deadlines' value.
+-- Instead: create new table, INSERT with transformation, drop old, rename.
+
+CREATE TABLE list_features_new (
+    list_id TEXT NOT NULL REFERENCES lists(id) ON DELETE CASCADE,
+    feature_name TEXT NOT NULL CHECK(feature_name IN ('quantity', 'deadlines')),
+    config TEXT NOT NULL DEFAULT '{}',
+    PRIMARY KEY (list_id, feature_name)
+);
+
+-- Copy quantity features as-is
+INSERT INTO list_features_new (list_id, feature_name, config)
+SELECT list_id, feature_name, config FROM list_features WHERE feature_name = 'quantity';
+
+-- Migrate due_date -> deadlines with new config
+INSERT INTO list_features_new (list_id, feature_name, config)
+SELECT list_id, 'deadlines', '{"has_start_date": false, "has_deadline": true, "has_hard_deadline": false}'
+FROM list_features WHERE feature_name = 'due_date';
+
+DROP TABLE list_features;
+ALTER TABLE list_features_new RENAME TO list_features;
+CREATE INDEX idx_list_features_list ON list_features(list_id);

--- a/crates/api/src/handlers/items.rs
+++ b/crates/api/src/handlers/items.rs
@@ -2,6 +2,14 @@ use kartoteka_shared::*;
 use wasm_bindgen::JsValue;
 use worker::*;
 
+/// Common SELECT columns for Item struct
+const ITEM_COLS: &str = "id, list_id, title, description, completed, position, quantity, actual_quantity, unit, start_date, start_time, deadline, deadline_time, hard_deadline, created_at, updated_at";
+
+/// Common SELECT columns for DateItem struct (with list info)
+const DATE_ITEM_COLS: &str = "i.id, i.list_id, i.title, i.description, i.completed, i.position, \
+    i.quantity, i.actual_quantity, i.unit, i.start_date, i.start_time, i.deadline, i.deadline_time, i.hard_deadline, \
+    i.created_at, i.updated_at, l.name as list_name, l.list_type";
+
 pub async fn list_all(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let list_id = ctx
@@ -20,14 +28,11 @@ pub async fn list_all(_req: Request, ctx: RouteContext<String>) -> Result<Respon
         return Response::error("Not found", 404);
     }
 
-    let result = d1
-        .prepare(
-            "SELECT id, list_id, title, description, completed, position, quantity, actual_quantity, unit, due_date, due_time, created_at, updated_at \
-             FROM items WHERE list_id = ?1 ORDER BY completed ASC, position ASC, created_at ASC",
-        )
-        .bind(&[list_id.into()])?
-        .all()
-        .await?;
+    let query = format!(
+        "SELECT {} FROM items WHERE list_id = ?1 ORDER BY completed ASC, position ASC, created_at ASC",
+        ITEM_COLS
+    );
+    let result = d1.prepare(&query).bind(&[list_id.into()])?.all().await?;
     let items = result.results::<Item>()?;
     Response::from_json(&items)
 }
@@ -63,39 +68,32 @@ pub async fn create(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
         .unwrap_or(-1);
     let position = (max_pos + 1) as i32;
 
-    let desc_val: JsValue = match &body.description {
-        Some(d) => d.as_str().into(),
-        None => JsValue::NULL,
+    let opt_str = |v: &Option<String>| -> JsValue {
+        match v {
+            Some(s) => JsValue::from(s.as_str()),
+            None => JsValue::NULL,
+        }
     };
 
+    let desc_val = opt_str(&body.description);
     let quantity_val: JsValue = match body.quantity {
         Some(q) => q.into(),
         None => JsValue::NULL,
     };
-
     let actual_quantity_val: JsValue = match body.quantity {
         Some(_) => 0i32.into(),
         None => JsValue::NULL,
     };
-
-    let unit_val: JsValue = match &body.unit {
-        Some(u) => JsValue::from(u.as_str()),
-        None => JsValue::NULL,
-    };
-
-    let due_date_val: JsValue = match &body.due_date {
-        Some(d) => JsValue::from(d.as_str()),
-        None => JsValue::NULL,
-    };
-
-    let due_time_val: JsValue = match &body.due_time {
-        Some(t) => JsValue::from(t.as_str()),
-        None => JsValue::NULL,
-    };
+    let unit_val = opt_str(&body.unit);
+    let start_date_val = opt_str(&body.start_date);
+    let start_time_val = opt_str(&body.start_time);
+    let deadline_val = opt_str(&body.deadline);
+    let deadline_time_val = opt_str(&body.deadline_time);
+    let hard_deadline_val = opt_str(&body.hard_deadline);
 
     d1.prepare(
-        "INSERT INTO items (id, list_id, title, description, position, quantity, actual_quantity, unit, due_date, due_time) \
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+        "INSERT INTO items (id, list_id, title, description, position, quantity, actual_quantity, unit, start_date, start_time, deadline, deadline_time, hard_deadline) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
     )
     .bind(&[
         id.clone().into(),
@@ -106,17 +104,18 @@ pub async fn create(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
         quantity_val,
         actual_quantity_val,
         unit_val,
-        due_date_val,
-        due_time_val,
+        start_date_val,
+        start_time_val,
+        deadline_val,
+        deadline_time_val,
+        hard_deadline_val,
     ])?
     .run()
     .await?;
 
+    let select_query = format!("SELECT {} FROM items WHERE id = ?1", ITEM_COLS);
     let item = d1
-        .prepare(
-            "SELECT id, list_id, title, description, completed, position, quantity, actual_quantity, unit, due_date, due_time, created_at, updated_at \
-             FROM items WHERE id = ?1",
-        )
+        .prepare(&select_query)
         .bind(&[id.into()])?
         .first::<Item>(None)
         .await?
@@ -125,6 +124,16 @@ pub async fn create(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
     let mut resp = Response::from_json(&item)?;
     resp = resp.with_status(201);
     Ok(resp)
+}
+
+/// Helper to handle Option<Option<String>> date fields in update:
+/// None = don't change, Some(None) = set NULL, Some(Some(v)) = set value
+fn update_nullable_str(outer: &Option<Option<String>>) -> Option<JsValue> {
+    match outer {
+        None => None, // don't change
+        Some(None) => Some(JsValue::NULL),
+        Some(Some(s)) => Some(JsValue::from(s.as_str())),
+    }
 }
 
 pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
@@ -221,25 +230,31 @@ pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
             .await?;
     }
 
-    if let Some(due_date) = &body.due_date {
-        d1.prepare("UPDATE items SET due_date = ?1, updated_at = datetime('now') WHERE id = ?2")
-            .bind(&[JsValue::from(due_date.as_str()), id.clone().into()])?
-            .run()
-            .await?;
+    // Date fields: Option<Option<String>> — None=skip, Some(None)=NULL, Some(Some(v))=set
+    let date_updates: [(&str, &Option<Option<String>>); 5] = [
+        ("start_date", &body.start_date),
+        ("start_time", &body.start_time),
+        ("deadline", &body.deadline),
+        ("deadline_time", &body.deadline_time),
+        ("hard_deadline", &body.hard_deadline),
+    ];
+
+    for (col, field) in &date_updates {
+        if let Some(js_val) = update_nullable_str(field) {
+            let sql = format!(
+                "UPDATE items SET {} = ?1, updated_at = datetime('now') WHERE id = ?2",
+                col
+            );
+            d1.prepare(&sql)
+                .bind(&[js_val, id.clone().into()])?
+                .run()
+                .await?;
+        }
     }
 
-    if let Some(due_time) = &body.due_time {
-        d1.prepare("UPDATE items SET due_time = ?1, updated_at = datetime('now') WHERE id = ?2")
-            .bind(&[JsValue::from(due_time.as_str()), id.clone().into()])?
-            .run()
-            .await?;
-    }
-
+    let select_query = format!("SELECT {} FROM items WHERE id = ?1", ITEM_COLS);
     let item = d1
-        .prepare(
-            "SELECT id, list_id, title, description, completed, position, quantity, actual_quantity, unit, due_date, due_time, created_at, updated_at \
-             FROM items WHERE id = ?1",
-        )
+        .prepare(&select_query)
         .bind(&[id.into()])?
         .first::<Item>(None)
         .await?
@@ -332,11 +347,9 @@ pub async fn move_item(mut req: Request, ctx: RouteContext<String>) -> Result<Re
     .run()
     .await?;
 
+    let select_query = format!("SELECT {} FROM items WHERE id = ?1", ITEM_COLS);
     let item = d1
-        .prepare(
-            "SELECT id, list_id, title, description, completed, position, quantity, actual_quantity, unit, due_date, due_time, created_at, updated_at \
-             FROM items WHERE id = ?1",
-        )
+        .prepare(&select_query)
         .bind(&[id.into()])?
         .first::<Item>(None)
         .await?
@@ -345,7 +358,7 @@ pub async fn move_item(mut req: Request, ctx: RouteContext<String>) -> Result<Re
     Response::from_json(&item)
 }
 
-/// GET /api/items/by-date?date=YYYY-MM-DD&include_overdue=true
+/// GET /api/items/by-date?date=YYYY-MM-DD&date_field=deadline&include_overdue=true
 pub async fn by_date(req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let url = req.url()?;
@@ -362,42 +375,84 @@ pub async fn by_date(req: Request, ctx: RouteContext<String>) -> Result<Response
         .map(|(_, v)| v != "false")
         .unwrap_or(true);
 
+    let date_field = url
+        .query_pairs()
+        .find(|(k, _)| k == "date_field")
+        .map(|(_, v)| v.to_string())
+        .unwrap_or_else(|| "deadline".to_string());
+
     let d1 = ctx.env.d1("DB")?;
 
-    let result = if include_overdue {
-        d1.prepare(
-            "SELECT i.id, i.list_id, i.title, i.description, i.completed, i.position, \
-             i.quantity, i.actual_quantity, i.unit, i.due_date, i.due_time, \
-             i.created_at, i.updated_at, l.name as list_name, l.list_type \
-             FROM items i \
-             JOIN lists l ON l.id = i.list_id \
+    if date_field == "all" {
+        // UNION ALL across all three date fields
+        let sql = format!(
+            "SELECT {cols}, 'start' as date_type \
+             FROM items i JOIN lists l ON l.id = i.list_id \
+             WHERE l.user_id = ?1 AND l.archived = 0 AND i.start_date = ?2 \
+             UNION ALL \
+             SELECT {cols}, 'deadline' as date_type \
+             FROM items i JOIN lists l ON l.id = i.list_id \
              WHERE l.user_id = ?1 AND l.archived = 0 \
-             AND (i.due_date = ?2 OR (i.due_date < ?2 AND i.completed = 0)) \
-             ORDER BY i.completed ASC, i.due_date ASC, l.name ASC, i.due_time ASC, i.position ASC",
-        )
-        .bind(&[user_id.into(), date.into()])?
-        .all()
-        .await?
+             AND (i.deadline = ?2{overdue}) \
+             UNION ALL \
+             SELECT {cols}, 'hard_deadline' as date_type \
+             FROM items i JOIN lists l ON l.id = i.list_id \
+             WHERE l.user_id = ?1 AND l.archived = 0 AND i.hard_deadline = ?2 \
+             ORDER BY completed ASC, list_name ASC, deadline_time ASC, position ASC",
+            cols = DATE_ITEM_COLS,
+            overdue = if include_overdue {
+                " OR (i.deadline < ?2 AND i.completed = 0)"
+            } else {
+                ""
+            },
+        );
+        let result = d1
+            .prepare(&sql)
+            .bind(&[user_id.into(), date.into()])?
+            .all()
+            .await?;
+        let items = result.results::<DateItem>()?;
+        Response::from_json(&items)
     } else {
-        d1.prepare(
-            "SELECT i.id, i.list_id, i.title, i.description, i.completed, i.position, \
-             i.quantity, i.actual_quantity, i.unit, i.due_date, i.due_time, \
-             i.created_at, i.updated_at, l.name as list_name, l.list_type \
-             FROM items i \
-             JOIN lists l ON l.id = i.list_id \
-             WHERE l.user_id = ?1 AND l.archived = 0 AND i.due_date = ?2 \
-             ORDER BY i.completed ASC, l.name ASC, i.due_time ASC, i.position ASC",
-        )
-        .bind(&[user_id.into(), date.into()])?
-        .all()
-        .await?
-    };
+        // Single date field query
+        let col = match date_field.as_str() {
+            "start_date" => "i.start_date",
+            "hard_deadline" => "i.hard_deadline",
+            _ => "i.deadline",
+        };
 
-    let items = result.results::<DateItem>()?;
-    Response::from_json(&items)
+        let sql = if include_overdue {
+            format!(
+                "SELECT {cols}, NULL as date_type \
+                 FROM items i JOIN lists l ON l.id = i.list_id \
+                 WHERE l.user_id = ?1 AND l.archived = 0 \
+                 AND ({col} = ?2 OR ({col} < ?2 AND i.completed = 0)) \
+                 ORDER BY i.completed ASC, {col} ASC, l.name ASC, i.deadline_time ASC, i.position ASC",
+                cols = DATE_ITEM_COLS,
+                col = col,
+            )
+        } else {
+            format!(
+                "SELECT {cols}, NULL as date_type \
+                 FROM items i JOIN lists l ON l.id = i.list_id \
+                 WHERE l.user_id = ?1 AND l.archived = 0 AND {col} = ?2 \
+                 ORDER BY i.completed ASC, l.name ASC, i.deadline_time ASC, i.position ASC",
+                cols = DATE_ITEM_COLS,
+                col = col,
+            )
+        };
+
+        let result = d1
+            .prepare(&sql)
+            .bind(&[user_id.into(), date.into()])?
+            .all()
+            .await?;
+        let items = result.results::<DateItem>()?;
+        Response::from_json(&items)
+    }
 }
 
-/// GET /api/items/calendar?from=YYYY-MM-DD&to=YYYY-MM-DD&detail=counts|full
+/// GET /api/items/calendar?from=YYYY-MM-DD&to=YYYY-MM-DD&date_field=deadline&detail=counts|full
 pub async fn calendar(req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let url = req.url()?;
@@ -420,57 +475,141 @@ pub async fn calendar(req: Request, ctx: RouteContext<String>) -> Result<Respons
         .map(|(_, v)| v.to_string())
         .unwrap_or_else(|| "counts".to_string());
 
+    let date_field = url
+        .query_pairs()
+        .find(|(k, _)| k == "date_field")
+        .map(|(_, v)| v.to_string())
+        .unwrap_or_else(|| "deadline".to_string());
+
     let d1 = ctx.env.d1("DB")?;
 
     if detail == "full" {
-        let result = d1
-            .prepare(
-                "SELECT i.id, i.list_id, i.title, i.description, i.completed, i.position, \
-                 i.quantity, i.actual_quantity, i.unit, i.due_date, i.due_time, \
-                 i.created_at, i.updated_at, l.name as list_name, l.list_type \
-                 FROM items i \
-                 JOIN lists l ON l.id = i.list_id \
+        if date_field == "all" {
+            let sql = format!(
+                "SELECT {cols}, 'start' as date_type \
+                 FROM items i JOIN lists l ON l.id = i.list_id \
+                 WHERE l.user_id = ?1 AND l.archived = 0 AND i.start_date >= ?2 AND i.start_date <= ?3 \
+                 UNION ALL \
+                 SELECT {cols}, 'deadline' as date_type \
+                 FROM items i JOIN lists l ON l.id = i.list_id \
+                 WHERE l.user_id = ?1 AND l.archived = 0 AND i.deadline >= ?2 AND i.deadline <= ?3 \
+                 UNION ALL \
+                 SELECT {cols}, 'hard_deadline' as date_type \
+                 FROM items i JOIN lists l ON l.id = i.list_id \
+                 WHERE l.user_id = ?1 AND l.archived = 0 AND i.hard_deadline >= ?2 AND i.hard_deadline <= ?3 \
+                 ORDER BY completed ASC, list_name ASC, deadline_time ASC, position ASC",
+                cols = DATE_ITEM_COLS,
+            );
+            let result = d1
+                .prepare(&sql)
+                .bind(&[user_id.into(), from.into(), to.into()])?
+                .all()
+                .await?;
+            let items = result.results::<DateItem>()?;
+
+            // Group by the date relevant to date_type
+            let mut day_map: std::collections::BTreeMap<String, Vec<DateItem>> =
+                std::collections::BTreeMap::new();
+            for item in items {
+                let date = match item.date_type.as_deref() {
+                    Some("start") => item.start_date.clone().unwrap_or_default(),
+                    Some("hard_deadline") => item.hard_deadline.clone().unwrap_or_default(),
+                    _ => item.deadline.clone().unwrap_or_default(),
+                };
+                day_map.entry(date).or_default().push(item);
+            }
+            let day_items: Vec<DayItems> = day_map
+                .into_iter()
+                .map(|(date, items)| DayItems { date, items })
+                .collect();
+
+            Response::from_json(&day_items)
+        } else {
+            let col = match date_field.as_str() {
+                "start_date" => "i.start_date",
+                "hard_deadline" => "i.hard_deadline",
+                _ => "i.deadline",
+            };
+            let sql = format!(
+                "SELECT {cols}, NULL as date_type \
+                 FROM items i JOIN lists l ON l.id = i.list_id \
                  WHERE l.user_id = ?1 AND l.archived = 0 \
-                 AND i.due_date >= ?2 AND i.due_date <= ?3 \
-                 ORDER BY i.due_date ASC, i.completed ASC, l.name ASC, i.due_time ASC, i.position ASC",
-            )
-            .bind(&[user_id.into(), from.into(), to.into()])?
-            .all()
-            .await?;
+                 AND {col} >= ?2 AND {col} <= ?3 \
+                 ORDER BY {col} ASC, i.completed ASC, l.name ASC, i.deadline_time ASC, i.position ASC",
+                cols = DATE_ITEM_COLS,
+                col = col,
+            );
+            let result = d1
+                .prepare(&sql)
+                .bind(&[user_id.into(), from.into(), to.into()])?
+                .all()
+                .await?;
+            let items = result.results::<DateItem>()?;
 
-        let items = result.results::<DateItem>()?;
+            let mut day_map: std::collections::BTreeMap<String, Vec<DateItem>> =
+                std::collections::BTreeMap::new();
+            for item in items {
+                let date = match date_field.as_str() {
+                    "start_date" => item.start_date.clone().unwrap_or_default(),
+                    "hard_deadline" => item.hard_deadline.clone().unwrap_or_default(),
+                    _ => item.deadline.clone().unwrap_or_default(),
+                };
+                day_map.entry(date).or_default().push(item);
+            }
+            let day_items: Vec<DayItems> = day_map
+                .into_iter()
+                .map(|(date, items)| DayItems { date, items })
+                .collect();
 
-        // Group by date
-        let mut day_map: std::collections::BTreeMap<String, Vec<DateItem>> =
-            std::collections::BTreeMap::new();
-        for item in items {
-            let date = item.due_date.clone().unwrap_or_default();
-            day_map.entry(date).or_default().push(item);
+            Response::from_json(&day_items)
         }
-        let day_items: Vec<DayItems> = day_map
-            .into_iter()
-            .map(|(date, items)| DayItems { date, items })
-            .collect();
-
-        Response::from_json(&day_items)
     } else {
-        let result = d1
-            .prepare(
-                "SELECT i.due_date as date, \
+        // Counts mode
+        if date_field == "all" {
+            let sql = "SELECT date, COUNT(DISTINCT id) as total, \
+                 CAST(SUM(CASE WHEN completed = 1 THEN 1 ELSE 0 END) AS INTEGER) as completed \
+                 FROM ( \
+                     SELECT i.id, i.start_date as date, i.completed FROM items i JOIN lists l ON l.id = i.list_id \
+                     WHERE l.user_id = ?1 AND l.archived = 0 AND i.start_date >= ?2 AND i.start_date <= ?3 \
+                     UNION ALL \
+                     SELECT i.id, i.deadline as date, i.completed FROM items i JOIN lists l ON l.id = i.list_id \
+                     WHERE l.user_id = ?1 AND l.archived = 0 AND i.deadline >= ?2 AND i.deadline <= ?3 \
+                     UNION ALL \
+                     SELECT i.id, i.hard_deadline as date, i.completed FROM items i JOIN lists l ON l.id = i.list_id \
+                     WHERE l.user_id = ?1 AND l.archived = 0 AND i.hard_deadline >= ?2 AND i.hard_deadline <= ?3 \
+                 ) GROUP BY date ORDER BY date ASC";
+            let result = d1
+                .prepare(sql)
+                .bind(&[user_id.into(), from.into(), to.into()])?
+                .all()
+                .await?;
+            let summaries = result.results::<DaySummary>()?;
+            Response::from_json(&summaries)
+        } else {
+            let col = match date_field.as_str() {
+                "start_date" => "i.start_date",
+                "hard_deadline" => "i.hard_deadline",
+                _ => "i.deadline",
+            };
+            let sql = format!(
+                "SELECT {col} as date, \
                  COUNT(*) as total, \
                  CAST(SUM(i.completed) AS INTEGER) as completed \
                  FROM items i \
                  JOIN lists l ON l.id = i.list_id \
                  WHERE l.user_id = ?1 AND l.archived = 0 \
-                 AND i.due_date >= ?2 AND i.due_date <= ?3 \
-                 GROUP BY i.due_date \
-                 ORDER BY i.due_date ASC",
-            )
-            .bind(&[user_id.into(), from.into(), to.into()])?
-            .all()
-            .await?;
-
-        let summaries = result.results::<DaySummary>()?;
-        Response::from_json(&summaries)
+                 AND {col} >= ?2 AND {col} <= ?3 \
+                 GROUP BY {col} \
+                 ORDER BY {col} ASC",
+                col = col,
+            );
+            let result = d1
+                .prepare(&sql)
+                .bind(&[user_id.into(), from.into(), to.into()])?
+                .all()
+                .await?;
+            let summaries = result.results::<DaySummary>()?;
+            Response::from_json(&summaries)
+        }
     }
 }

--- a/crates/api/src/handlers/tags.rs
+++ b/crates/api/src/handlers/tags.rs
@@ -390,7 +390,7 @@ pub async fn tag_items(req: Request, ctx: RouteContext<String>) -> Result<Respon
              SELECT t.id FROM tags t JOIN tag_tree tt ON t.parent_tag_id = tt.id WHERE t.user_id = ?2 \
              ) \
              SELECT DISTINCT i.id, i.list_id, i.title, i.description, i.completed, i.position, \
-             i.quantity, i.actual_quantity, i.unit, i.due_date, i.due_time, \
+             i.quantity, i.actual_quantity, i.unit, i.start_date, i.start_time, i.deadline, i.deadline_time, i.hard_deadline, \
              i.created_at, i.updated_at, l.name as list_name \
              FROM items i \
              JOIN item_tags it ON it.item_id = i.id \
@@ -405,7 +405,7 @@ pub async fn tag_items(req: Request, ctx: RouteContext<String>) -> Result<Respon
     } else {
         d1.prepare(
             "SELECT i.id, i.list_id, i.title, i.description, i.completed, i.position, \
-             i.quantity, i.actual_quantity, i.unit, i.due_date, i.due_time, \
+             i.quantity, i.actual_quantity, i.unit, i.start_date, i.start_time, i.deadline, i.deadline_time, i.hard_deadline, \
              i.created_at, i.updated_at, l.name as list_name \
              FROM items i \
              JOIN item_tags it ON it.item_id = i.id \

--- a/crates/frontend/src/api/items.rs
+++ b/crates/frontend/src/api/items.rs
@@ -35,12 +35,17 @@ pub async fn move_item(item_id: &str, target_list_id: &str) -> Result<Item, Stri
     super::patch_json(&format!("{}/items/{item_id}/move", super::API_BASE), &body).await
 }
 
-pub async fn fetch_calendar_counts(from: &str, to: &str) -> Result<Vec<DaySummary>, String> {
+pub async fn fetch_calendar_counts(
+    from: &str,
+    to: &str,
+    date_field: &str,
+) -> Result<Vec<DaySummary>, String> {
     super::get(&format!(
-        "{}/items/calendar?from={}&to={}&detail=counts",
+        "{}/items/calendar?from={}&to={}&detail=counts&date_field={}",
         super::API_BASE,
         from,
-        to
+        to,
+        date_field
     ))
     .send()
     .await
@@ -50,12 +55,17 @@ pub async fn fetch_calendar_counts(from: &str, to: &str) -> Result<Vec<DaySummar
     .map_err(|e| e.to_string())
 }
 
-pub async fn fetch_calendar_full(from: &str, to: &str) -> Result<Vec<DayItems>, String> {
+pub async fn fetch_calendar_full(
+    from: &str,
+    to: &str,
+    date_field: &str,
+) -> Result<Vec<DayItems>, String> {
     super::get(&format!(
-        "{}/items/calendar?from={}&to={}&detail=full",
+        "{}/items/calendar?from={}&to={}&detail=full&date_field={}",
         super::API_BASE,
         from,
-        to
+        to,
+        date_field
     ))
     .send()
     .await
@@ -68,12 +78,14 @@ pub async fn fetch_calendar_full(from: &str, to: &str) -> Result<Vec<DayItems>, 
 pub async fn fetch_items_by_date(
     date: &str,
     include_overdue: bool,
+    date_field: &str,
 ) -> Result<Vec<DateItem>, String> {
     super::get(&format!(
-        "{}/items/by-date?date={}&include_overdue={}",
+        "{}/items/by-date?date={}&include_overdue={}&date_field={}",
         super::API_BASE,
         date,
-        include_overdue
+        include_overdue,
+        date_field
     ))
     .send()
     .await

--- a/crates/frontend/src/components/calendar/week_view.rs
+++ b/crates/frontend/src/components/calendar/week_view.rs
@@ -91,8 +91,11 @@ pub fn WeekView(
                                             quantity: None,
                                             actual_quantity: None,
                                             unit: None,
-                                            due_date: None,
-                                            due_time: None,
+                                            start_date: None,
+                                            start_time: None,
+                                            deadline: None,
+                                            deadline_time: None,
+                                            hard_deadline: None,
                                         };
                                         let _ = api::update_item(&lid, &iid, &req).await;
                                     });

--- a/crates/frontend/src/components/common/date_utils.rs
+++ b/crates/frontend/src/components/common/date_utils.rs
@@ -130,13 +130,25 @@ pub fn is_overdue(item: &Item, today: &str) -> bool {
     if item.completed {
         return false;
     }
-    match item.due_date.as_deref() {
+    match item.deadline.as_deref() {
         None => false,
         Some(d) if d < today => true,
-        Some(d) if d == today => match item.due_time.as_deref() {
+        Some(d) if d == today => match item.deadline_time.as_deref() {
             Some(t) if !t.is_empty() => t < current_time_hhmm().as_str(),
             _ => false,
         },
+        _ => false,
+    }
+}
+
+/// Check overdue for a specific date field type (used in multi-date views)
+pub fn is_overdue_for_date_type(date_val: Option<&str>, completed: bool, today: &str) -> bool {
+    if completed {
+        return false;
+    }
+    match date_val {
+        None => false,
+        Some(d) if d < today => true,
         _ => false,
     }
 }
@@ -145,10 +157,62 @@ pub fn is_upcoming(item: &Item, today: &str) -> bool {
     !item.completed && !is_overdue(item, today)
 }
 
-pub fn sort_by_due_date(items: &mut [Item]) {
+/// A date badge descriptor for consistent rendering across components
+pub struct DateBadge {
+    pub css: &'static str,
+    pub label: String,
+    pub date_type: &'static str,
+}
+
+/// Build date badges for an item's dates. `skip` optionally excludes one date type.
+pub fn item_date_badges(item: &Item, skip: Option<&str>) -> Vec<DateBadge> {
+    let mut badges = Vec::new();
+    if skip != Some("start") {
+        if let Some(ref d) = item.start_date {
+            let time_part = item
+                .start_time
+                .as_ref()
+                .filter(|t| !t.is_empty())
+                .map(|t| format!(" {t}"))
+                .unwrap_or_default();
+            badges.push(DateBadge {
+                css: "badge badge-info badge-sm",
+                label: format!("\u{1F4C5} {}{}", format_date_short(d), time_part),
+                date_type: "start",
+            });
+        }
+    }
+    if skip != Some("deadline") {
+        if let Some(ref d) = item.deadline {
+            let time_part = item
+                .deadline_time
+                .as_ref()
+                .filter(|t| !t.is_empty())
+                .map(|t| format!(" {t}"))
+                .unwrap_or_default();
+            badges.push(DateBadge {
+                css: "badge badge-warning badge-sm",
+                label: format!("\u{23F0} {}{}", format_date_short(d), time_part),
+                date_type: "deadline",
+            });
+        }
+    }
+    if skip != Some("hard_deadline") {
+        if let Some(ref d) = item.hard_deadline {
+            badges.push(DateBadge {
+                css: "badge badge-error badge-sm",
+                label: format!("\u{1F6A8} {}", format_date_short(d)),
+                date_type: "hard_deadline",
+            });
+        }
+    }
+    badges
+}
+
+pub fn sort_by_deadline(items: &mut [Item]) {
     items.sort_by(|a, b| {
-        let da = a.due_date.as_deref().unwrap_or("9999-99-99");
-        let db = b.due_date.as_deref().unwrap_or("9999-99-99");
+        let da = a.deadline.as_deref().unwrap_or("9999-99-99");
+        let db = b.deadline.as_deref().unwrap_or("9999-99-99");
         da.cmp(db)
     });
 }

--- a/crates/frontend/src/components/items/add_item_input.rs
+++ b/crates/frontend/src/components/items/add_item_input.rs
@@ -1,3 +1,5 @@
+use crate::components::common::date_utils::format_date_short;
+use kartoteka_shared::CreateItemRequest;
 use leptos::prelude::*;
 
 /// Helper: get today's date as YYYY-MM-DD
@@ -26,7 +28,7 @@ fn tomorrow_str() -> String {
 /// Helper: get next Monday's date as YYYY-MM-DD
 fn next_monday_str() -> String {
     let d = js_sys::Date::new_0();
-    let dow = d.get_day(); // 0=Sun, 1=Mon, ...
+    let dow = d.get_day();
     let days_until_monday = if dow == 0 { 1 } else { (8 - dow) % 7 };
     let days_until_monday = if days_until_monday == 0 {
         7
@@ -42,29 +44,160 @@ fn next_monday_str() -> String {
     )
 }
 
+/// Expanded date section: quick date buttons + date picker + time stepper (if has_time)
+fn render_date_section(
+    border_color: &'static str,
+    date_signal: RwSignal<String>,
+    hour_signal: Option<RwSignal<Option<u32>>>,
+    min_signal: Option<RwSignal<Option<u32>>>,
+) -> impl IntoView {
+    let has_time = hour_signal.is_some() && min_signal.is_some();
+
+    view! {
+        <div class=format!("flex flex-col gap-1 pl-2 border-l-2 {border_color}")>
+            // Quick date buttons + date picker
+            <div class="flex gap-1 flex-wrap items-center">
+                <button type="button"
+                    class=move || if date_signal.get() == today_str() { "btn btn-xs btn-primary" } else { "btn btn-xs btn-outline" }
+                    on:click=move |_| date_signal.set(today_str())
+                >"Dzi\u{015B}"</button>
+                <button type="button"
+                    class=move || if date_signal.get() == tomorrow_str() { "btn btn-xs btn-primary" } else { "btn btn-xs btn-outline" }
+                    on:click=move |_| date_signal.set(tomorrow_str())
+                >"Jutro"</button>
+                <button type="button"
+                    class=move || if date_signal.get() == next_monday_str() { "btn btn-xs btn-primary" } else { "btn btn-xs btn-outline" }
+                    on:click=move |_| date_signal.set(next_monday_str())
+                >"Pn"</button>
+                <input
+                    type="date"
+                    class="input input-bordered input-xs w-36"
+                    prop:value=date_signal
+                    on:input=move |ev| date_signal.set(event_target_value(&ev))
+                />
+            </div>
+            // Time stepper — only after a date is selected, and only if this type has time
+            {move || {
+                if has_time && !date_signal.get().is_empty() {
+                    let hour = hour_signal.unwrap();
+                    let min = min_signal.unwrap();
+                    view! {
+                        <div class="flex gap-1 flex-wrap items-center">
+                            <button type="button"
+                                class=move || {
+                                    let h = hour.get();
+                                    if h == Some(9) { "btn btn-xs btn-primary" } else { "btn btn-xs btn-outline" }
+                                }
+                                on:click=move |_| { hour.set(Some(9)); min.set(Some(0)); }
+                            >"9:00"</button>
+                            <button type="button"
+                                class=move || {
+                                    let h = hour.get();
+                                    let m = min.get();
+                                    if h == Some(12) && m == Some(0) { "btn btn-xs btn-primary" } else { "btn btn-xs btn-outline" }
+                                }
+                                on:click=move |_| { hour.set(Some(12)); min.set(Some(0)); }
+                            >"12:00"</button>
+                            <button type="button"
+                                class=move || {
+                                    let h = hour.get();
+                                    if h == Some(15) { "btn btn-xs btn-primary" } else { "btn btn-xs btn-outline" }
+                                }
+                                on:click=move |_| { hour.set(Some(15)); min.set(Some(0)); }
+                            >"15:00"</button>
+                            <button type="button"
+                                class=move || {
+                                    let h = hour.get();
+                                    if h == Some(18) { "btn btn-xs btn-primary" } else { "btn btn-xs btn-outline" }
+                                }
+                                on:click=move |_| { hour.set(Some(18)); min.set(Some(0)); }
+                            >"18:00"</button>
+                            <span class="text-base-content/30">"|"</span>
+                            // Manual stepper
+                            <button type="button" class="btn btn-xs btn-ghost"
+                                on:click=move |_| {
+                                    let h = hour.get().unwrap_or(12);
+                                    hour.set(Some(if h == 0 { 23 } else { h - 1 }));
+                                }
+                            >"\u{2212}"</button>
+                            <span class="font-mono text-sm min-w-[2ch] text-center">
+                                {move || hour.get().map_or("--".to_string(), |h| format!("{:02}", h))}
+                            </span>
+                            <span class="font-mono text-sm">":"</span>
+                            <span class="font-mono text-sm min-w-[2ch] text-center">
+                                {move || min.get().map_or("--".to_string(), |m| format!("{:02}", m))}
+                            </span>
+                            <button type="button" class="btn btn-xs btn-ghost"
+                                on:click=move |_| {
+                                    let h = hour.get().unwrap_or(11);
+                                    hour.set(Some((h + 1) % 24));
+                                }
+                            >"+"</button>
+                            <button type="button" class="btn btn-xs btn-ghost"
+                                on:click=move |_| {
+                                    let m = min.get().unwrap_or(45);
+                                    min.set(Some((m + 15) % 60));
+                                }
+                            >"+15m"</button>
+                            {move || {
+                                if hour.get().is_some() || min.get().is_some() {
+                                    view! {
+                                        <button type="button" class="btn btn-xs btn-ghost opacity-50"
+                                            on:click=move |_| { hour.set(None); min.set(None); }
+                                        >"\u{2715}"</button>
+                                    }.into_any()
+                                } else {
+                                    view! {}.into_any()
+                                }
+                            }}
+                        </div>
+                    }.into_any()
+                } else {
+                    view! {}.into_any()
+                }
+            }}
+        </div>
+    }
+}
+
 /// Form for adding a new list item.
-/// Calls `on_submit` with `(title, description, quantity, unit, due_date, due_time)`.
 #[component]
 pub fn AddItemInput(
-    on_submit: Callback<(
-        String,
-        Option<String>,
-        Option<i32>,
-        Option<String>,
-        Option<String>,
-        Option<String>,
-    )>,
+    on_submit: Callback<CreateItemRequest>,
     #[prop(default = false)] has_quantity: bool,
-    #[prop(default = false)] has_due_date: bool,
+    #[prop(default = serde_json::Value::Null)] deadlines_config: serde_json::Value,
 ) -> impl IntoView {
+    let has_start_date = deadlines_config
+        .get("has_start_date")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let has_deadline = deadlines_config
+        .get("has_deadline")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let has_hard_deadline = deadlines_config
+        .get("has_hard_deadline")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let has_any_date = has_start_date || has_deadline || has_hard_deadline;
+
     let title = RwSignal::new(String::new());
     let desc = RwSignal::new(String::new());
     let show_desc = RwSignal::new(false);
     let quantity = RwSignal::new(String::new());
     let unit = RwSignal::new("szt.".to_string());
-    let due_date = RwSignal::new(String::new());
-    let due_hour = RwSignal::new(Option::<u32>::None);
-    let due_min = RwSignal::new(Option::<u32>::None);
+
+    let start_date = RwSignal::new(String::new());
+    let start_hour = RwSignal::new(Option::<u32>::None);
+    let start_min = RwSignal::new(Option::<u32>::None);
+    let deadline_date = RwSignal::new(String::new());
+    let deadline_hour = RwSignal::new(Option::<u32>::None);
+    let deadline_min = RwSignal::new(Option::<u32>::None);
+    let hard_deadline_date = RwSignal::new(String::new());
+
+    let start_expanded = RwSignal::new(false);
+    let deadline_expanded = RwSignal::new(false);
+    let hard_expanded = RwSignal::new(false);
 
     let submit = std::rc::Rc::new(move || {
         let t = title.get();
@@ -83,32 +216,83 @@ pub fn AddItemInput(
         } else {
             None
         };
-        let dd = {
-            let v = due_date.get();
-            if v.trim().is_empty() { None } else { Some(v) }
+
+        let to_opt = |s: String| {
+            if s.trim().is_empty() { None } else { Some(s) }
         };
-        let dt = match (due_hour.get(), due_min.get()) {
+        let time_opt = |h: Option<u32>, m: Option<u32>| match (h, m) {
             (Some(h), Some(m)) => Some(format!("{:02}:{:02}", h, m)),
             (Some(h), None) => Some(format!("{:02}:00", h)),
             _ => None,
         };
+
+        let req = CreateItemRequest {
+            title: t,
+            description: if d.trim().is_empty() { None } else { Some(d) },
+            quantity: q,
+            unit: u,
+            start_date: to_opt(start_date.get()),
+            start_time: time_opt(start_hour.get(), start_min.get()),
+            deadline: to_opt(deadline_date.get()),
+            deadline_time: time_opt(deadline_hour.get(), deadline_min.get()),
+            hard_deadline: to_opt(hard_deadline_date.get()),
+        };
+
         title.set(String::new());
         desc.set(String::new());
         show_desc.set(false);
         quantity.set(String::new());
         unit.set("szt.".to_string());
-        due_date.set(String::new());
-        due_hour.set(None);
-        due_min.set(None);
-        on_submit.run((
-            t,
-            if d.trim().is_empty() { None } else { Some(d) },
-            q,
-            u,
-            dd,
-            dt,
-        ));
+        start_date.set(String::new());
+        start_hour.set(None);
+        start_min.set(None);
+        deadline_date.set(String::new());
+        deadline_hour.set(None);
+        deadline_min.set(None);
+        hard_deadline_date.set(String::new());
+        start_expanded.set(false);
+        deadline_expanded.set(false);
+        hard_expanded.set(false);
+
+        on_submit.run(req);
     });
+
+    /// Render a date chip button
+    fn chip(
+        label_empty: &'static str,
+        icon: &'static str,
+        date_signal: RwSignal<String>,
+        hour_signal: Option<RwSignal<Option<u32>>>,
+        min_signal: Option<RwSignal<Option<u32>>>,
+        expanded: RwSignal<bool>,
+        active_class: &'static str,
+    ) -> impl IntoView {
+        let is_active = move || !date_signal.get().is_empty() || expanded.get();
+        view! {
+            <button type="button"
+                class=move || if is_active() { active_class } else { "btn btn-xs btn-outline btn-ghost" }
+                on:click=move |_| {
+                    if !date_signal.get().is_empty() {
+                        date_signal.set(String::new());
+                        if let Some(h) = hour_signal { h.set(None); }
+                        if let Some(m) = min_signal { m.set(None); }
+                        expanded.set(false);
+                    } else {
+                        expanded.update(|v| *v = !*v);
+                    }
+                }
+            >
+                {move || {
+                    let d = date_signal.get();
+                    if d.is_empty() {
+                        format!("{icon} {label_empty}")
+                    } else {
+                        format!("{icon} {} \u{2715}", format_date_short(&d))
+                    }
+                }}
+            </button>
+        }
+    }
 
     view! {
         <div class="flex gap-2 mb-4">
@@ -130,11 +314,10 @@ pub fn AddItemInput(
                         title="Dodaj opis"
                         on:click=move |_| show_desc.update(|v| *v = !*v)
                     >
-                        {move || if show_desc.get() { "▲" } else { "📝" }}
+                        {move || if show_desc.get() { "\u{25B2}" } else { "\u{1F4DD}" }}
                     </button>
                 </div>
 
-                // Description - collapsible
                 <div style:display=move || if show_desc.get() { "block" } else { "none" }>
                     <input
                         type="text"
@@ -148,7 +331,6 @@ pub fn AddItemInput(
                     />
                 </div>
 
-                // Quantity fields
                 {if has_quantity {
                     view! {
                         <div class="flex gap-1">
@@ -156,7 +338,7 @@ pub fn AddItemInput(
                                 type="number"
                                 min="1"
                                 class="input input-bordered input-sm w-24"
-                                placeholder="Ilość"
+                                placeholder="Ilo\u{015B}\u{0107}"
                                 prop:value=quantity
                                 on:input=move |ev| {
                                     let val = event_target_value(&ev);
@@ -188,77 +370,50 @@ pub fn AddItemInput(
                     view! {}.into_any()
                 }}
 
-                // Date fields with quick buttons
-                {if has_due_date {
+                // Date chips
+                {if has_any_date {
                     view! {
-                        <div class="flex flex-col gap-1">
-                            // Quick date buttons
+                        <div class="flex flex-col gap-1 mt-1">
                             <div class="flex gap-1 flex-wrap">
-                                <button type="button"
-                                    class=move || if due_date.get() == today_str() { "btn btn-xs btn-primary" } else { "btn btn-xs btn-outline" }
-                                    on:click=move |_| due_date.set(today_str())
-                                >"Dziś"</button>
-                                <button type="button"
-                                    class=move || if due_date.get() == tomorrow_str() { "btn btn-xs btn-primary" } else { "btn btn-xs btn-outline" }
-                                    on:click=move |_| due_date.set(tomorrow_str())
-                                >"Jutro"</button>
-                                <button type="button"
-                                    class=move || if due_date.get() == next_monday_str() { "btn btn-xs btn-primary" } else { "btn btn-xs btn-outline" }
-                                    on:click=move |_| due_date.set(next_monday_str())
-                                >"Poniedziałek"</button>
-                                <input
-                                    type="date"
-                                    class="input input-bordered input-xs w-36"
-                                    prop:value=due_date
-                                    on:input=move |ev| due_date.set(event_target_value(&ev))
-                                />
-                            </div>
-                            // Time stepper
-                            <div class="flex items-center gap-1">
-                                <span class="text-xs opacity-50">"Godzina:"</span>
-                                <button type="button" class="btn btn-xs btn-ghost"
-                                    on:click=move |_| {
-                                        let h = due_hour.get().unwrap_or(12);
-                                        due_hour.set(Some(if h == 0 { 23 } else { h - 1 }));
-                                    }
-                                >"−"</button>
-                                <span class="font-mono text-sm min-w-[2ch] text-center">
-                                    {move || due_hour.get().map_or("--".to_string(), |h| format!("{:02}", h))}
-                                </span>
-                                <button type="button" class="btn btn-xs btn-ghost"
-                                    on:click=move |_| {
-                                        let h = due_hour.get().unwrap_or(11);
-                                        due_hour.set(Some((h + 1) % 24));
-                                    }
-                                >"+"</button>
-                                <span class="font-mono text-sm">":"</span>
-                                <button type="button" class="btn btn-xs btn-ghost"
-                                    on:click=move |_| {
-                                        let m = due_min.get().unwrap_or(15);
-                                        due_min.set(Some(if m < 15 { 45 } else { m - 15 }));
-                                    }
-                                >"−"</button>
-                                <span class="font-mono text-sm min-w-[2ch] text-center">
-                                    {move || due_min.get().map_or("--".to_string(), |m| format!("{:02}", m))}
-                                </span>
-                                <button type="button" class="btn btn-xs btn-ghost"
-                                    on:click=move |_| {
-                                        let m = due_min.get().unwrap_or(45);
-                                        due_min.set(Some((m + 15) % 60));
-                                    }
-                                >"+"</button>
-                                {move || {
-                                    if due_hour.get().is_some() || due_min.get().is_some() {
-                                        view! {
-                                            <button type="button" class="btn btn-xs btn-ghost opacity-50"
-                                                on:click=move |_| { due_hour.set(None); due_min.set(None); }
-                                            >"✕"</button>
-                                        }.into_any()
-                                    } else {
-                                        view! {}.into_any()
-                                    }
+                                {if has_start_date {
+                                    chip("Start", "\u{1F4C5}", start_date, Some(start_hour), Some(start_min), start_expanded, "btn btn-xs btn-info").into_any()
+                                } else {
+                                    view! {}.into_any()
+                                }}
+                                {if has_deadline {
+                                    chip("Termin", "\u{23F0}", deadline_date, Some(deadline_hour), Some(deadline_min), deadline_expanded, "btn btn-xs btn-warning").into_any()
+                                } else {
+                                    view! {}.into_any()
+                                }}
+                                {if has_hard_deadline {
+                                    chip("Twardy", "\u{1F6A8}", hard_deadline_date, None, None, hard_expanded, "btn btn-xs btn-error").into_any()
+                                } else {
+                                    view! {}.into_any()
                                 }}
                             </div>
+
+                            // Expanded sections
+                            {move || {
+                                if has_start_date && start_expanded.get() {
+                                    render_date_section("border-info", start_date, Some(start_hour), Some(start_min)).into_any()
+                                } else {
+                                    view! {}.into_any()
+                                }
+                            }}
+                            {move || {
+                                if has_deadline && deadline_expanded.get() {
+                                    render_date_section("border-warning", deadline_date, Some(deadline_hour), Some(deadline_min)).into_any()
+                                } else {
+                                    view! {}.into_any()
+                                }
+                            }}
+                            {move || {
+                                if has_hard_deadline && hard_expanded.get() {
+                                    render_date_section("border-error", hard_deadline_date, None, None).into_any()
+                                } else {
+                                    view! {}.into_any()
+                                }
+                            }}
                         </div>
                     }.into_any()
                 } else {

--- a/crates/frontend/src/components/items/date_editor.rs
+++ b/crates/frontend/src/components/items/date_editor.rs
@@ -1,0 +1,193 @@
+use leptos::prelude::*;
+
+/// Helper: get today's date as YYYY-MM-DD
+fn today_str() -> String {
+    let d = js_sys::Date::new_0();
+    format!(
+        "{:04}-{:02}-{:02}",
+        d.get_full_year(),
+        d.get_month() + 1,
+        d.get_date()
+    )
+}
+
+fn tomorrow_str() -> String {
+    let d = js_sys::Date::new_0();
+    d.set_date(d.get_date() + 1);
+    format!(
+        "{:04}-{:02}-{:02}",
+        d.get_full_year(),
+        d.get_month() + 1,
+        d.get_date()
+    )
+}
+
+fn next_monday_str() -> String {
+    let d = js_sys::Date::new_0();
+    let dow = d.get_day();
+    let days = if dow == 0 { 1 } else { (8 - dow) % 7 };
+    let days = if days == 0 { 7 } else { days };
+    d.set_date(d.get_date() + days);
+    format!(
+        "{:04}-{:02}-{:02}",
+        d.get_full_year(),
+        d.get_month() + 1,
+        d.get_date()
+    )
+}
+
+/// Inline date+time editor. Used for both creating and editing items.
+/// `on_change` fires immediately on every change (date or time).
+/// `on_clear` fires when user removes the date entirely.
+#[component]
+pub fn DateEditor(
+    border_color: &'static str,
+    #[prop(into)] initial_date: Option<String>,
+    #[prop(into)] initial_time: Option<String>,
+    #[prop(default = true)] has_time: bool,
+    /// Fires (date, time) on every change. date="" means cleared.
+    on_change: Callback<(String, Option<String>)>,
+) -> impl IntoView {
+    let date_signal = RwSignal::new(initial_date.unwrap_or_default());
+    let hour = RwSignal::new(Option::<u32>::None);
+    let min = RwSignal::new(Option::<u32>::None);
+
+    // Parse initial time "HH:MM" into hour/min signals
+    if let Some(ref t) = initial_time {
+        if let Some((h, m)) = t.split_once(':') {
+            hour.set(h.parse().ok());
+            min.set(m.parse().ok());
+        }
+    }
+
+    let fire_change = move || {
+        let d = date_signal.get();
+        let t = match (hour.get(), min.get()) {
+            (Some(h), Some(m)) => Some(format!("{:02}:{:02}", h, m)),
+            (Some(h), None) => Some(format!("{:02}:00", h)),
+            _ => None,
+        };
+        on_change.run((d, t));
+    };
+
+    let set_date = move |d: String| {
+        date_signal.set(d);
+        fire_change();
+    };
+
+    let set_time = move |h: u32, m: u32| {
+        hour.set(Some(h));
+        min.set(Some(m));
+        fire_change();
+    };
+
+    view! {
+        <div class=format!("flex flex-col gap-1 pl-2 border-l-2 {border_color}")>
+            // Quick date buttons + date picker
+            <div class="flex gap-1 flex-wrap items-center">
+                <button type="button"
+                    class=move || if date_signal.get() == today_str() { "btn btn-xs btn-primary" } else { "btn btn-xs btn-outline" }
+                    on:click=move |_| set_date(today_str())
+                >"Dzi\u{015B}"</button>
+                <button type="button"
+                    class=move || if date_signal.get() == tomorrow_str() { "btn btn-xs btn-primary" } else { "btn btn-xs btn-outline" }
+                    on:click=move |_| set_date(tomorrow_str())
+                >"Jutro"</button>
+                <button type="button"
+                    class=move || if date_signal.get() == next_monday_str() { "btn btn-xs btn-primary" } else { "btn btn-xs btn-outline" }
+                    on:click=move |_| set_date(next_monday_str())
+                >"Pn"</button>
+                <input
+                    type="date"
+                    class="input input-bordered input-xs w-36"
+                    prop:value=date_signal
+                    on:input=move |ev| set_date(event_target_value(&ev))
+                />
+                // Clear button
+                {move || {
+                    if !date_signal.get().is_empty() {
+                        view! {
+                            <button type="button" class="btn btn-xs btn-ghost opacity-50"
+                                on:click=move |_| {
+                                    date_signal.set(String::new());
+                                    hour.set(None);
+                                    min.set(None);
+                                    on_change.run((String::new(), None));
+                                }
+                            >"\u{1F5D1} Usu\u{0144}"</button>
+                        }.into_any()
+                    } else {
+                        view! {}.into_any()
+                    }
+                }}
+            </div>
+            // Time — only after date is selected
+            {move || {
+                if has_time && !date_signal.get().is_empty() {
+                    view! {
+                        <div class="flex gap-1 flex-wrap items-center">
+                            <button type="button"
+                                class=move || if hour.get() == Some(9) && min.get() == Some(0) { "btn btn-xs btn-primary" } else { "btn btn-xs btn-outline" }
+                                on:click=move |_| set_time(9, 0)
+                            >"9:00"</button>
+                            <button type="button"
+                                class=move || if hour.get() == Some(12) && min.get() == Some(0) { "btn btn-xs btn-primary" } else { "btn btn-xs btn-outline" }
+                                on:click=move |_| set_time(12, 0)
+                            >"12:00"</button>
+                            <button type="button"
+                                class=move || if hour.get() == Some(15) && min.get() == Some(0) { "btn btn-xs btn-primary" } else { "btn btn-xs btn-outline" }
+                                on:click=move |_| set_time(15, 0)
+                            >"15:00"</button>
+                            <button type="button"
+                                class=move || if hour.get() == Some(18) && min.get() == Some(0) { "btn btn-xs btn-primary" } else { "btn btn-xs btn-outline" }
+                                on:click=move |_| set_time(18, 0)
+                            >"18:00"</button>
+                            <span class="text-base-content/30">"|"</span>
+                            <button type="button" class="btn btn-xs btn-ghost"
+                                on:click=move |_| {
+                                    let h = hour.get().unwrap_or(12);
+                                    hour.set(Some(if h == 0 { 23 } else { h - 1 }));
+                                    fire_change();
+                                }
+                            >"\u{2212}"</button>
+                            <span class="font-mono text-sm min-w-[2ch] text-center">
+                                {move || hour.get().map_or("--".to_string(), |h| format!("{:02}", h))}
+                            </span>
+                            <span class="font-mono text-sm">":"</span>
+                            <span class="font-mono text-sm min-w-[2ch] text-center">
+                                {move || min.get().map_or("--".to_string(), |m| format!("{:02}", m))}
+                            </span>
+                            <button type="button" class="btn btn-xs btn-ghost"
+                                on:click=move |_| {
+                                    let h = hour.get().unwrap_or(11);
+                                    hour.set(Some((h + 1) % 24));
+                                    fire_change();
+                                }
+                            >"+"</button>
+                            <button type="button" class="btn btn-xs btn-ghost"
+                                on:click=move |_| {
+                                    let m = min.get().unwrap_or(45);
+                                    min.set(Some((m + 15) % 60));
+                                    fire_change();
+                                }
+                            >"+15m"</button>
+                            {move || {
+                                if hour.get().is_some() || min.get().is_some() {
+                                    view! {
+                                        <button type="button" class="btn btn-xs btn-ghost opacity-50"
+                                            on:click=move |_| { hour.set(None); min.set(None); fire_change(); }
+                                        >"\u{2715}"</button>
+                                    }.into_any()
+                                } else {
+                                    view! {}.into_any()
+                                }
+                            }}
+                        </div>
+                    }.into_any()
+                } else {
+                    view! {}.into_any()
+                }
+            }}
+        </div>
+    }
+}

--- a/crates/frontend/src/components/items/date_item_row.rs
+++ b/crates/frontend/src/components/items/date_item_row.rs
@@ -2,8 +2,9 @@ use kartoteka_shared::{Item, Tag};
 use leptos::prelude::*;
 
 use crate::components::common::date_utils::{
-    format_date_short, get_today_string, is_overdue, relative_date,
+    format_date_short, get_today_string, is_overdue, item_date_badges, relative_date,
 };
+use crate::components::items::date_editor::DateEditor;
 use crate::components::tags::tag_list::TagList;
 
 #[component]
@@ -14,42 +15,77 @@ pub fn DateItemRow(
     #[prop(default = vec![])] all_tags: Vec<Tag>,
     #[prop(default = vec![])] item_tag_ids: Vec<String>,
     #[prop(optional)] on_tag_toggle: Option<Callback<String>>,
+    #[prop(optional)] date_type: Option<String>,
+    /// (item_id, date_type, date_value, time_value)
+    #[prop(optional)]
+    on_date_save: Option<Callback<(String, String, String, Option<String>)>>,
 ) -> impl IntoView {
     let id_toggle = item.id.clone();
     let id_delete = item.id.clone();
+    let id_for_editor = item.id.clone();
     let completed = item.completed;
     let today = get_today_string();
-
     let overdue = is_overdue(&item, &today);
 
     let row_class = if completed {
-        "flex items-center gap-3 py-3 opacity-50"
+        "flex items-center gap-3 py-2 opacity-50"
     } else if overdue {
-        "flex items-center gap-3 py-3 text-error"
+        "flex items-center gap-3 py-2 text-error"
     } else {
-        "flex items-center gap-3 py-3"
+        "flex items-center gap-3 py-2"
     };
 
     let title_class = if completed {
-        "flex-1 line-through text-base-content/50"
+        "flex-1 min-w-0 line-through text-base-content/50"
     } else {
-        "flex-1"
+        "flex-1 min-w-0"
     };
 
-    let date_display = item.due_date.as_ref().map(|d| format_date_short(d));
-    let relative = item.due_date.as_ref().map(|d| relative_date(d, &today));
-    let time_display = item.due_time.clone();
+    let primary_dt = date_type.as_deref().unwrap_or("deadline");
+    let (display_date, display_time) = match primary_dt {
+        "start" => (item.start_date.clone(), item.start_time.clone()),
+        "hard_deadline" => (item.hard_deadline.clone(), None),
+        _ => (item.deadline.clone(), item.deadline_time.clone()),
+    };
+
+    let date_display = display_date.as_ref().map(|d| format_date_short(d));
+    let relative = display_date.as_ref().map(|d| relative_date(d, &today));
+    let time_display = display_time;
 
     let date_color = if completed {
-        "text-right text-sm text-base-content/40"
+        "text-right text-sm text-base-content/40 shrink-0"
     } else if overdue {
-        "text-right text-sm text-error"
+        "text-right text-sm text-error shrink-0"
     } else {
-        "text-right text-sm text-base-content/60"
+        "text-right text-sm text-base-content/60 shrink-0"
     };
+
+    let primary_icon = match primary_dt {
+        "start" => "\u{1F4C5}",
+        "hard_deadline" => "\u{1F6A8}",
+        _ => "\u{23F0}",
+    };
+
+    let secondary_badges = item_date_badges(&item, Some(primary_dt));
+    let has_secondary =
+        !secondary_badges.is_empty() || !item_tag_ids.is_empty() || on_tag_toggle.is_some();
+
+    // Date editing state
+    let editing_date = RwSignal::new(Option::<String>::None);
+
+    // Store initial values for editor
+    let item_start_date = item.start_date.clone();
+    let item_start_time = item.start_time.clone();
+    let item_deadline = item.deadline.clone();
+    let item_deadline_time = item.deadline_time.clone();
+    let item_hard_deadline = item.hard_deadline.clone();
+
+    // Primary date is clickable if on_date_save is available
+    let primary_dt_str = primary_dt.to_string();
 
     view! {
         <div class="border-b border-base-300">
+            // Row 1: checkbox + title + primary date + delete
             <div class=row_class>
                 <input
                     type="checkbox"
@@ -59,18 +95,45 @@ pub fn DateItemRow(
                 />
                 <span class=title_class>{item.title}</span>
 
-                // Tags
-                <TagList
-                    all_tags=all_tags.clone()
-                    selected_tag_ids=item_tag_ids.clone()
-                    on_toggle=on_tag_toggle
-                />
+                // Primary date (clickable for editing)
+                {if on_date_save.is_some() {
+                    let pdt = primary_dt_str.clone();
+                    view! {
+                        <button type="button" class=format!("{date_color} cursor-pointer hover:opacity-80")
+                            on:click=move |_| {
+                                let current = editing_date.get();
+                                if current.as_deref() == Some(pdt.as_str()) {
+                                    editing_date.set(None);
+                                } else {
+                                    editing_date.set(Some(pdt.clone()));
+                                }
+                            }
+                        >
+                            {date_display.as_ref().map(|d| view! {
+                                <div class="flex items-center gap-1 justify-end">
+                                    <span class="opacity-60">{primary_icon}</span>
+                                    <span class="font-medium">{d.clone()}</span>
+                                </div>
+                            })}
+                            {relative.as_ref().map(|r| view! { <div class="text-xs">{r.clone()}</div> })}
+                            {time_display.as_ref().map(|t| view! { <div class="text-xs">{t.clone()}</div> })}
+                        </button>
+                    }.into_any()
+                } else {
+                    view! {
+                        <div class=date_color>
+                            {date_display.map(|d| view! {
+                                <div class="flex items-center gap-1 justify-end">
+                                    <span class="opacity-60">{primary_icon}</span>
+                                    <span class="font-medium">{d}</span>
+                                </div>
+                            })}
+                            {relative.map(|r| view! { <div class="text-xs">{r}</div> })}
+                            {time_display.map(|t| view! { <div class="text-xs">{t}</div> })}
+                        </div>
+                    }.into_any()
+                }}
 
-                <div class=date_color>
-                    {date_display.map(|d| view! { <div class="font-medium">{d}</div> })}
-                    {relative.map(|r| view! { <div class="text-xs">{r}</div> })}
-                    {time_display.map(|t| view! { <div class="text-xs">{t}</div> })}
-                </div>
                 {
                     let confirming = RwSignal::new(false);
                     view! {
@@ -87,11 +150,77 @@ pub fn DateItemRow(
                                 }
                             }
                         >
-                            {move || if confirming.get() { "Na pewno?" } else { "✕" }}
+                            {move || if confirming.get() { "Na pewno?" } else { "\u{2715}" }}
                         </button>
                     }
                 }
             </div>
+
+            // Row 2: tags + secondary date badges (clickable)
+            {if has_secondary {
+                view! {
+                    <div class="flex items-center gap-1 pl-10 pb-1 flex-wrap">
+                        <TagList
+                            all_tags=all_tags.clone()
+                            selected_tag_ids=item_tag_ids.clone()
+                            on_toggle=on_tag_toggle
+                        />
+                        {secondary_badges.into_iter().map(|b| {
+                            if on_date_save.is_some() {
+                                let dt = b.date_type.to_string();
+                                view! {
+                                    <button type="button" class=format!("{} cursor-pointer", b.css)
+                                        on:click=move |_| {
+                                            let current = editing_date.get();
+                                            if current.as_deref() == Some(dt.as_str()) {
+                                                editing_date.set(None);
+                                            } else {
+                                                editing_date.set(Some(dt.clone()));
+                                            }
+                                        }
+                                    >{b.label}</button>
+                                }.into_any()
+                            } else {
+                                view! { <span class=b.css>{b.label}</span> }.into_any()
+                            }
+                        }).collect::<Vec<_>>()}
+                    </div>
+                }.into_any()
+            } else {
+                view! {}.into_any()
+            }}
+
+            // Inline date editor
+            {move || {
+                let dt = editing_date.get();
+                if let (Some(dt), Some(on_save)) = (dt, on_date_save) {
+                    let id_for_save = id_for_editor.clone();
+                    let dt_for_save = dt.clone();
+                    let (border, init_date, init_time, has_time) = match dt.as_str() {
+                        "start" => ("border-info", item_start_date.clone(), item_start_time.clone(), true),
+                        "hard_deadline" => ("border-error", item_hard_deadline.clone(), None, false),
+                        _ => ("border-warning", item_deadline.clone(), item_deadline_time.clone(), true),
+                    };
+                    view! {
+                        <div class="pl-10 pb-2">
+                            <DateEditor
+                                border_color=border
+                                initial_date=init_date
+                                initial_time=init_time
+                                has_time=has_time
+                                on_change=Callback::new(move |(date, time): (String, Option<String>)| {
+                                    on_save.run((id_for_save.clone(), dt_for_save.clone(), date, time));
+                                })
+                            />
+                            <button type="button" class="btn btn-xs btn-ghost mt-1 opacity-50"
+                                on:click=move |_| editing_date.set(None)
+                            >"Zamknij"</button>
+                        </div>
+                    }.into_any()
+                } else {
+                    view! {}.into_any()
+                }
+            }}
         </div>
     }
 }

--- a/crates/frontend/src/components/items/item_actions.rs
+++ b/crates/frontend/src/components/items/item_actions.rs
@@ -5,63 +5,37 @@ use kartoteka_shared::{CreateItemRequest, Item, UpdateItemRequest};
 
 /// All item-level callbacks for a list or sublist.
 pub struct ItemActions {
-    pub on_add: Callback<(
-        String,
-        Option<String>,
-        Option<i32>,
-        Option<String>,
-        Option<String>,
-        Option<String>,
-    )>,
+    pub on_add: Callback<CreateItemRequest>,
     pub on_toggle: Callback<String>,
     pub on_delete: Callback<String>,
     pub on_description_save: Callback<(String, String)>,
     pub on_quantity_change: Callback<(String, i32)>,
+    /// (item_id, date_type, date_value, time_value)
+    /// date_type: "start" | "deadline" | "hard_deadline"
+    /// date_value: "" to clear, "YYYY-MM-DD" to set
+    pub on_date_save: Callback<(String, String, String, Option<String>)>,
 }
 
 /// Create item callbacks bound to a specific list/sublist.
-///
-/// Both `list.rs` and `sublist_section.rs` use this to avoid duplicating
-/// ~100 lines of callback logic.
-///
-/// When `on_error` is `Some`, creation errors are reported via the signal
-/// (used in `list.rs`). When `None`, errors are silently ignored (sublists).
 pub fn create_item_actions(
     items: RwSignal<Vec<Item>>,
     list_id: String,
     on_error: Option<WriteSignal<Option<String>>>,
 ) -> ItemActions {
     let lid_add = list_id.clone();
-    let on_add = Callback::new(
-        move |(title, description, quantity, unit, due_date, due_time): (
-            String,
-            Option<String>,
-            Option<i32>,
-            Option<String>,
-            Option<String>,
-            Option<String>,
-        )| {
-            let lid = lid_add.clone();
-            leptos::task::spawn_local(async move {
-                let req = CreateItemRequest {
-                    title,
-                    description,
-                    quantity,
-                    unit,
-                    due_date,
-                    due_time,
-                };
-                match api::create_item(&lid, &req).await {
-                    Ok(item) => items.update(|list| list.push(item)),
-                    Err(e) => {
-                        if let Some(set_err) = on_error {
-                            set_err.set(Some(e));
-                        }
+    let on_add = Callback::new(move |req: CreateItemRequest| {
+        let lid = lid_add.clone();
+        leptos::task::spawn_local(async move {
+            match api::create_item(&lid, &req).await {
+                Ok(item) => items.update(|list| list.push(item)),
+                Err(e) => {
+                    if let Some(set_err) = on_error {
+                        set_err.set(Some(e));
                     }
                 }
-            });
-        },
-    );
+            }
+        });
+    });
 
     let lid_toggle = list_id.clone();
     let on_toggle = Callback::new(move |item_id: String| {
@@ -88,8 +62,11 @@ pub fn create_item_actions(
                     quantity: None,
                     actual_quantity: None,
                     unit: None,
-                    due_date: None,
-                    due_time: None,
+                    start_date: None,
+                    start_time: None,
+                    deadline: None,
+                    deadline_time: None,
+                    hard_deadline: None,
                 };
                 let _ = api::update_item(&lid, &item_id, &req).await;
             });
@@ -127,8 +104,11 @@ pub fn create_item_actions(
                 quantity: None,
                 actual_quantity: None,
                 unit: None,
-                due_date: None,
-                due_time: None,
+                start_date: None,
+                start_time: None,
+                deadline: None,
+                deadline_time: None,
+                hard_deadline: None,
             };
             let _ = api::update_item(&lid, &item_id, &req).await;
         });
@@ -156,12 +136,96 @@ pub fn create_item_actions(
                 quantity: None,
                 actual_quantity: Some(new_actual),
                 unit: None,
-                due_date: None,
-                due_time: None,
+                start_date: None,
+                start_time: None,
+                deadline: None,
+                deadline_time: None,
+                hard_deadline: None,
             };
             let _ = api::update_item(&lid, &iid, &req).await;
         });
     });
+
+    let lid_date = list_id.clone();
+    let on_date_save = Callback::new(
+        move |(item_id, date_type, date_val, time_val): (
+            String,
+            String,
+            String,
+            Option<String>,
+        )| {
+            let date_opt = if date_val.is_empty() {
+                Some(None) // clear
+            } else {
+                Some(Some(date_val.clone()))
+            };
+            let time_opt = if date_val.is_empty() {
+                Some(None) // clear time too
+            } else {
+                time_val.clone().map(Some) // Some(Some("HH:MM")) or None (don't change)
+            };
+
+            // Optimistic update
+            items.update(|list| {
+                if let Some(item) = list.iter_mut().find(|i| i.id == item_id) {
+                    let d = if date_val.is_empty() {
+                        None
+                    } else {
+                        Some(date_val.clone())
+                    };
+                    match date_type.as_str() {
+                        "start" => {
+                            item.start_date = d;
+                            item.start_time = time_val.clone();
+                        }
+                        "deadline" => {
+                            item.deadline = d;
+                            item.deadline_time = time_val.clone();
+                        }
+                        "hard_deadline" => {
+                            item.hard_deadline = d;
+                        }
+                        _ => {}
+                    }
+                }
+            });
+
+            let lid = lid_date.clone();
+            let iid = item_id.clone();
+            let dt = date_type.clone();
+            leptos::task::spawn_local(async move {
+                let mut req = UpdateItemRequest {
+                    title: None,
+                    description: None,
+                    completed: None,
+                    position: None,
+                    quantity: None,
+                    actual_quantity: None,
+                    unit: None,
+                    start_date: None,
+                    start_time: None,
+                    deadline: None,
+                    deadline_time: None,
+                    hard_deadline: None,
+                };
+                match dt.as_str() {
+                    "start" => {
+                        req.start_date = date_opt;
+                        req.start_time = time_opt;
+                    }
+                    "deadline" => {
+                        req.deadline = date_opt;
+                        req.deadline_time = time_opt;
+                    }
+                    "hard_deadline" => {
+                        req.hard_deadline = date_opt;
+                    }
+                    _ => {}
+                }
+                let _ = api::update_item(&lid, &iid, &req).await;
+            });
+        },
+    );
 
     ItemActions {
         on_add,
@@ -169,5 +233,6 @@ pub fn create_item_actions(
         on_delete,
         on_description_save,
         on_quantity_change,
+        on_date_save,
     }
 }

--- a/crates/frontend/src/components/items/item_row.rs
+++ b/crates/frontend/src/components/items/item_row.rs
@@ -1,6 +1,9 @@
-use kartoteka_shared::{Item, Tag};
+use kartoteka_shared::Item;
+use kartoteka_shared::Tag;
 use leptos::prelude::*;
 
+use crate::components::common::date_utils::item_date_badges;
+use crate::components::items::date_editor::DateEditor;
 use crate::components::tags::tag_list::TagList;
 
 #[component]
@@ -16,11 +19,19 @@ pub fn ItemRow(
     #[prop(optional)] on_quantity_change: Option<Callback<(String, i32)>>,
     #[prop(default = vec![])] move_targets: Vec<(String, String)>,
     #[prop(optional)] on_move: Option<Callback<(String, String)>>,
+    /// (item_id, date_type, date_value, time_value)
+    #[prop(optional)]
+    on_date_save: Option<Callback<(String, String, String, Option<String>)>>,
+    /// Deadlines feature config for ghost chips
+    #[prop(default = serde_json::Value::Null)]
+    deadlines_config: serde_json::Value,
 ) -> impl IntoView {
     let id = item.id.clone();
     let id_toggle = id.clone();
     let id_delete = id.clone();
     let id_move = id.clone();
+    let id_for_editor = id.clone();
+    let id_for_desc = id.clone();
     let completed = item.completed;
 
     let row_class = if completed {
@@ -47,9 +58,39 @@ pub fn ItemRow(
 
     let has_tags = !item_tag_ids.is_empty() || on_tag_toggle.is_some();
 
+    // Date editing state
+    let editing_date = RwSignal::new(Option::<String>::None);
+    let date_badges = item_date_badges(&item, None);
+
+    // Ghost chips: date types enabled in config but not set on this item
+    let cfg_start = deadlines_config
+        .get("has_start_date")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let cfg_deadline = deadlines_config
+        .get("has_deadline")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let cfg_hard = deadlines_config
+        .get("has_hard_deadline")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    let ghost_start = cfg_start && item.start_date.is_none();
+    let ghost_deadline = cfg_deadline && item.deadline.is_none();
+    let ghost_hard = cfg_hard && item.hard_deadline.is_none();
+    let has_ghosts = ghost_start || ghost_deadline || ghost_hard;
+
+    // Store initial values for editor
+    let item_start_date = item.start_date.clone();
+    let item_start_time = item.start_time.clone();
+    let item_deadline = item.deadline.clone();
+    let item_deadline_time = item.deadline_time.clone();
+    let item_hard_deadline = item.hard_deadline.clone();
+
     view! {
         <div class="border-b border-base-300 py-1">
-            // Row 1: checkbox, expand, title, quantity, actions
+            // Row 1: checkbox, expand, title, date badges, quantity, actions
             <div class=row_class>
                 <input
                     type="checkbox"
@@ -63,9 +104,58 @@ pub fn ItemRow(
                     class="btn btn-ghost btn-xs btn-square"
                     on:click=move |_| expanded.update(|e| *e = !*e)
                 >
-                    {move || if expanded.get() { "▲" } else { "▼" }}
+                    {move || if expanded.get() { "\u{25B2}" } else { "\u{25BC}" }}
                 </button>
                 <span class=title_class>{item.title}</span>
+
+                // Date badges (clickable)
+                {
+                    if date_badges.is_empty() && !has_ghosts {
+                        view! {}.into_any()
+                    } else {
+                        view! {
+                            <div class="flex gap-1 flex-wrap shrink-0">
+                                {date_badges.into_iter().map(|b| {
+                                    let dt = b.date_type.to_string();
+                                    view! {
+                                        <button type="button" class=format!("{} cursor-pointer", b.css)
+                                            on:click=move |_| {
+                                                let current = editing_date.get();
+                                                if current.as_deref() == Some(dt.as_str()) {
+                                                    editing_date.set(None);
+                                                } else {
+                                                    editing_date.set(Some(dt.clone()));
+                                                }
+                                            }
+                                        >{b.label}</button>
+                                    }
+                                }).collect::<Vec<_>>()}
+                                // Ghost chips for missing date types
+                                {if ghost_start {
+                                    view! {
+                                        <button type="button" class="badge badge-ghost badge-sm opacity-40 cursor-pointer"
+                                            on:click=move |_| editing_date.set(Some("start".into()))
+                                        >"+\u{1F4C5}"</button>
+                                    }.into_any()
+                                } else { view! {}.into_any() }}
+                                {if ghost_deadline {
+                                    view! {
+                                        <button type="button" class="badge badge-ghost badge-sm opacity-40 cursor-pointer"
+                                            on:click=move |_| editing_date.set(Some("deadline".into()))
+                                        >"+\u{23F0}"</button>
+                                    }.into_any()
+                                } else { view! {}.into_any() }}
+                                {if ghost_hard {
+                                    view! {
+                                        <button type="button" class="badge badge-ghost badge-sm opacity-40 cursor-pointer"
+                                            on:click=move |_| editing_date.set(Some("hard_deadline".into()))
+                                        >"+\u{1F6A8}"</button>
+                                    }.into_any()
+                                } else { view! {}.into_any() }}
+                            </div>
+                        }.into_any()
+                    }
+                }
 
                 // Quantity stepper
                 {if show_stepper {
@@ -83,7 +173,7 @@ pub fn ItemRow(
                                         actual.set(new_val);
                                         if let Some(cb) = cb_dec { cb.run((id_dec.clone(), new_val)); }
                                     }
-                                >"−"</button>
+                                >"\u{2212}"</button>
                                 <span class="text-sm font-mono">
                                     {move || actual.get()} " / " {target_qty} " " {unit_str.clone()}
                                 </span>
@@ -110,9 +200,9 @@ pub fn ItemRow(
                     let move_open = RwSignal::new(false);
                     view! {
                         <div class="relative">
-                            <button type="button" class="btn btn-ghost btn-xs btn-square" title="Przenieś do..."
+                            <button type="button" class="btn btn-ghost btn-xs btn-square" title="Przenie\u{015B} do..."
                                 on:click=move |_| move_open.update(|v| *v = !*v)
-                            >"↗"</button>
+                            >"\u{2197}"</button>
                             <div
                                 class="absolute right-0 top-full mt-1 bg-base-200 border border-base-300 rounded-box min-w-44 max-h-60 overflow-y-auto z-50 p-2 shadow-lg"
                                 style:display=move || if move_open.get() { "block" } else { "none" }
@@ -140,10 +230,10 @@ pub fn ItemRow(
 
                 <button type="button" class="btn btn-ghost btn-xs btn-square opacity-60 hover:opacity-100"
                     on:click=move |_| on_delete.run(id_delete.clone())
-                >"✕"</button>
+                >"\u{2715}"</button>
             </div>
 
-            // Row 2: Tags (below title, indented)
+            // Row 2: Tags
             {if has_tags {
                 view! {
                     <div class="pl-14 pb-1">
@@ -158,10 +248,42 @@ pub fn ItemRow(
                 view! {}.into_any()
             }}
 
+            // Inline date editor (when a badge is clicked)
+            {move || {
+                let dt = editing_date.get();
+                if let (Some(dt), Some(on_save)) = (dt, on_date_save) {
+                    let id_for_save = id_for_editor.clone();
+                    let dt_for_save = dt.clone();
+                    let (border, init_date, init_time, has_time) = match dt.as_str() {
+                        "start" => ("border-info", item_start_date.clone(), item_start_time.clone(), true),
+                        "hard_deadline" => ("border-error", item_hard_deadline.clone(), None, false),
+                        _ => ("border-warning", item_deadline.clone(), item_deadline_time.clone(), true),
+                    };
+                    view! {
+                        <div class="pl-14 pb-2">
+                            <DateEditor
+                                border_color=border
+                                initial_date=init_date
+                                initial_time=init_time
+                                has_time=has_time
+                                on_change=Callback::new(move |(date, time): (String, Option<String>)| {
+                                    on_save.run((id_for_save.clone(), dt_for_save.clone(), date, time));
+                                })
+                            />
+                            <button type="button" class="btn btn-xs btn-ghost mt-1 opacity-50"
+                                on:click=move |_| editing_date.set(None)
+                            >"Zamknij"</button>
+                        </div>
+                    }.into_any()
+                } else {
+                    view! {}.into_any()
+                }
+            }}
+
             // Description (expandable)
             {move || {
                 if expanded.get() {
-                    let id_blur = id.clone();
+                    let id_blur = id_for_desc.clone();
                     view! {
                         <div class="pl-14 pb-2">
                             <textarea

--- a/crates/frontend/src/components/items/mod.rs
+++ b/crates/frontend/src/components/items/mod.rs
@@ -1,5 +1,6 @@
 pub mod add_input;
 pub mod add_item_input;
+pub mod date_editor;
 pub mod date_item_row;
 pub mod item_actions;
 pub mod item_row;

--- a/crates/frontend/src/components/lists/list_header.rs
+++ b/crates/frontend/src/components/lists/list_header.rs
@@ -1,4 +1,4 @@
-use kartoteka_shared::{FEATURE_DUE_DATE, FEATURE_QUANTITY, ListFeature};
+use kartoteka_shared::{FEATURE_DEADLINES, FEATURE_QUANTITY, ListFeature};
 use leptos::prelude::*;
 
 use crate::components::confirm_delete_modal::ConfirmDeleteModal;
@@ -15,11 +15,46 @@ pub fn ListHeader(
     #[prop(optional)] on_rename: Option<Callback<String>>,
     #[prop(default = vec![])] features: Vec<ListFeature>,
     #[prop(optional)] on_feature_toggle: Option<Callback<(String, bool)>>,
+    /// Called when deadlines sub-config changes: new full config JSON
+    #[prop(optional)]
+    on_deadlines_config_change: Option<Callback<serde_json::Value>>,
 ) -> impl IntoView {
     let show_delete = RwSignal::new(false);
     let show_settings = RwSignal::new(false);
     let has_quantity = features.iter().any(|f| f.name == FEATURE_QUANTITY);
-    let has_due_date = features.iter().any(|f| f.name == FEATURE_DUE_DATE);
+    let has_deadlines = features.iter().any(|f| f.name == FEATURE_DEADLINES);
+    let deadlines_config = features
+        .iter()
+        .find(|f| f.name == FEATURE_DEADLINES)
+        .map(|f| f.config.clone())
+        .unwrap_or(serde_json::json!({}));
+    let cfg_has_start = deadlines_config
+        .get("has_start_date")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let cfg_has_deadline = deadlines_config
+        .get("has_deadline")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true);
+    let cfg_has_hard = deadlines_config
+        .get("has_hard_deadline")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    let start_checked = RwSignal::new(cfg_has_start);
+    let deadline_checked = RwSignal::new(cfg_has_deadline);
+    let hard_checked = RwSignal::new(cfg_has_hard);
+
+    let fire_config_change = move || {
+        if let Some(cb) = on_deadlines_config_change {
+            let config = serde_json::json!({
+                "has_start_date": start_checked.get(),
+                "has_deadline": deadline_checked.get(),
+                "has_hard_deadline": hard_checked.get(),
+            });
+            cb.run(config);
+        }
+    };
 
     view! {
         <div class="flex items-center justify-between mb-4">
@@ -72,30 +107,78 @@ pub fn ListHeader(
         {move || {
             if show_settings.get() {
                 on_feature_toggle.map(|on_toggle| view! {
-                    <div class="bg-base-200 rounded-lg p-3 mb-4 flex items-center gap-4">
-                        <span class="text-sm font-semibold">"Funkcje:"</span>
-                        <label class="label cursor-pointer gap-2">
-                            <input
-                                type="checkbox"
-                                class="checkbox checkbox-sm"
-                                prop:checked=has_quantity
-                                on:change=move |ev| {
-                                    on_toggle.run((FEATURE_QUANTITY.to_string(), event_target_checked(&ev)));
-                                }
-                            />
-                            <span class="label-text">"Ilości"</span>
-                        </label>
-                        <label class="label cursor-pointer gap-2">
-                            <input
-                                type="checkbox"
-                                class="checkbox checkbox-sm"
-                                prop:checked=has_due_date
-                                on:change=move |ev| {
-                                    on_toggle.run((FEATURE_DUE_DATE.to_string(), event_target_checked(&ev)));
-                                }
-                            />
-                            <span class="label-text">"Terminy"</span>
-                        </label>
+                    <div class="bg-base-200 rounded-lg p-3 mb-4">
+                        <div class="flex items-center gap-4">
+                            <span class="text-sm font-semibold">"Funkcje:"</span>
+                            <label class="label cursor-pointer gap-2">
+                                <input
+                                    type="checkbox"
+                                    class="checkbox checkbox-sm"
+                                    prop:checked=has_quantity
+                                    on:change=move |ev| {
+                                        on_toggle.run((FEATURE_QUANTITY.to_string(), event_target_checked(&ev)));
+                                    }
+                                />
+                                <span class="label-text">"Ilo\u{015B}ci"</span>
+                            </label>
+                            <label class="label cursor-pointer gap-2">
+                                <input
+                                    type="checkbox"
+                                    class="checkbox checkbox-sm"
+                                    prop:checked=has_deadlines
+                                    on:change=move |ev| {
+                                        on_toggle.run((FEATURE_DEADLINES.to_string(), event_target_checked(&ev)));
+                                    }
+                                />
+                                <span class="label-text">"Terminy"</span>
+                            </label>
+                        </div>
+                        // Deadlines sub-config
+                        {if has_deadlines {
+                            view! {
+                                <div class="flex items-center gap-4 mt-2 ml-4 text-xs">
+                                    <span class="opacity-50">"Pola dat:"</span>
+                                    <label class="label cursor-pointer gap-1">
+                                        <input
+                                            type="checkbox"
+                                            class="checkbox checkbox-xs"
+                                            prop:checked=start_checked
+                                            on:change=move |ev| {
+                                                start_checked.set(event_target_checked(&ev));
+                                                fire_config_change();
+                                            }
+                                        />
+                                        <span class="label-text text-xs">"Start"</span>
+                                    </label>
+                                    <label class="label cursor-pointer gap-1">
+                                        <input
+                                            type="checkbox"
+                                            class="checkbox checkbox-xs"
+                                            prop:checked=deadline_checked
+                                            on:change=move |ev| {
+                                                deadline_checked.set(event_target_checked(&ev));
+                                                fire_config_change();
+                                            }
+                                        />
+                                        <span class="label-text text-xs">"Termin"</span>
+                                    </label>
+                                    <label class="label cursor-pointer gap-1">
+                                        <input
+                                            type="checkbox"
+                                            class="checkbox checkbox-xs"
+                                            prop:checked=hard_checked
+                                            on:change=move |ev| {
+                                                hard_checked.set(event_target_checked(&ev));
+                                                fire_config_change();
+                                            }
+                                        />
+                                        <span class="label-text text-xs">"Twardy termin"</span>
+                                    </label>
+                                </div>
+                            }.into_any()
+                        } else {
+                            view! {}.into_any()
+                        }}
                     </div>
                 })
             } else {

--- a/crates/frontend/src/components/lists/sublist_section.rs
+++ b/crates/frontend/src/components/lists/sublist_section.rs
@@ -10,7 +10,7 @@ use kartoteka_shared::{Item, ItemTagLink, List, Tag};
 pub fn SublistSection(
     sublist: List,
     #[prop(default = false)] has_quantity: bool,
-    #[prop(default = false)] has_due_date: bool,
+    #[prop(default = serde_json::Value::Null)] deadlines_config: serde_json::Value,
     #[prop(default = vec![])] all_tags: Vec<Tag>,
     #[prop(default = vec![])] item_tag_links: Vec<ItemTagLink>,
     on_tag_toggle: Callback<(String, String)>,
@@ -134,7 +134,7 @@ pub fn SublistSection(
                                     }
                                 }).collect::<Vec<_>>()}
                                 <div class="mt-2">
-                                    <AddItemInput on_submit=on_add has_quantity=has_quantity has_due_date=has_due_date />
+                                    <AddItemInput on_submit=on_add has_quantity=has_quantity deadlines_config=deadlines_config.clone() />
                                 </div>
                             </div>
                         }.into_any()

--- a/crates/frontend/src/pages/calendar/day.rs
+++ b/crates/frontend/src/pages/calendar/day.rs
@@ -35,7 +35,7 @@ pub fn CalendarDayPage() -> impl IntoView {
         let d = date();
         async move {
             set_loading.set(true);
-            match api::fetch_items_by_date(&d, false).await {
+            match api::fetch_items_by_date(&d, false, "all").await {
                 Ok(fetched) => items.set(fetched),
                 Err(e) => toast.push(format!("Błąd: {e}"), ToastKind::Error),
             }
@@ -164,6 +164,7 @@ pub fn CalendarDayPage() -> impl IntoView {
                                     {group_items.into_iter().map(|date_item| {
                                         let item_id = date_item.id.clone();
                                         let item_list_id = date_item.list_id.clone();
+                                        let date_type = date_item.date_type.clone();
                                         let item: Item = date_item.into();
 
                                         let item_tag_ids: Vec<String> = links.iter()
@@ -195,8 +196,11 @@ pub fn CalendarDayPage() -> impl IntoView {
                                                     quantity: None,
                                                     actual_quantity: None,
                                                     unit: None,
-                                                    due_date: None,
-                                                    due_time: None,
+                                                    start_date: None,
+                                                    start_time: None,
+                                                    deadline: None,
+                                                    deadline_time: None,
+                                                    hard_deadline: None,
                                                 };
                                                 let _ = api::update_item(&lid, &iid, &req).await;
                                             });
@@ -215,15 +219,55 @@ pub fn CalendarDayPage() -> impl IntoView {
                                             });
                                         });
 
-                                        view! {
-                                            <DateItemRow
-                                                item=item
-                                                on_toggle=on_toggle
-                                                on_delete=on_delete
-                                                all_tags=tags.clone()
-                                                item_tag_ids=item_tag_ids
-                                            />
-                                        }
+                                        // Date save
+                                        let ds_lid = item_list_id.clone();
+                                        let ds_iid = item_id.clone();
+                                        let on_date_save = Callback::new(move |(_iid, dt, date, time): (String, String, String, Option<String>)| {
+                                            let lid = ds_lid.clone();
+                                            let iid = ds_iid.clone();
+                                            let date_opt = if date.is_empty() { Some(None) } else { Some(Some(date)) };
+                                            let time_opt = if date_opt == Some(None) { Some(None) } else { time.map(Some) };
+                                            leptos::task::spawn_local(async move {
+                                                let mut req = UpdateItemRequest {
+                                                    title: None, description: None, completed: None, position: None,
+                                                    quantity: None, actual_quantity: None, unit: None,
+                                                    start_date: None, start_time: None,
+                                                    deadline: None, deadline_time: None, hard_deadline: None,
+                                                };
+                                                match dt.as_str() {
+                                                    "start" => { req.start_date = date_opt; req.start_time = time_opt; }
+                                                    "deadline" => { req.deadline = date_opt; req.deadline_time = time_opt; }
+                                                    "hard_deadline" => { req.hard_deadline = date_opt; }
+                                                    _ => {}
+                                                }
+                                                let _ = api::update_item(&lid, &iid, &req).await;
+                                            });
+                                        });
+
+                                        {if let Some(dt) = date_type {
+                                            view! {
+                                                <DateItemRow
+                                                    item=item
+                                                    on_toggle=on_toggle
+                                                    on_delete=on_delete
+                                                    all_tags=tags.clone()
+                                                    item_tag_ids=item_tag_ids
+                                                    date_type=dt
+                                                    on_date_save=on_date_save
+                                                />
+                                            }.into_any()
+                                        } else {
+                                            view! {
+                                                <DateItemRow
+                                                    item=item
+                                                    on_toggle=on_toggle
+                                                    on_delete=on_delete
+                                                    all_tags=tags.clone()
+                                                    item_tag_ids=item_tag_ids
+                                                    on_date_save=on_date_save
+                                                />
+                                            }.into_any()
+                                        }}
                                     }).collect_view()}
                                 </div>
                             }

--- a/crates/frontend/src/pages/calendar/mod.rs
+++ b/crates/frontend/src/pages/calendar/mod.rs
@@ -51,7 +51,7 @@ pub fn CalendarPage() -> impl IntoView {
                 ViewMode::Month => {
                     if let Some((y, m, _)) = parse_date(&date) {
                         let (from, to) = month_grid_range(y, m);
-                        match api::fetch_calendar_counts(&from, &to).await {
+                        match api::fetch_calendar_counts(&from, &to, "all").await {
                             Ok(counts) => month_counts.set(counts),
                             Err(e) => toast.push(format!("Błąd: {e}"), ToastKind::Error),
                         }
@@ -59,7 +59,7 @@ pub fn CalendarPage() -> impl IntoView {
                 }
                 ViewMode::Week => {
                     let (from, to) = week_range(&date);
-                    match api::fetch_calendar_full(&from, &to).await {
+                    match api::fetch_calendar_full(&from, &to, "all").await {
                         Ok(days) => week_data.set(days),
                         Err(e) => toast.push(format!("Błąd: {e}"), ToastKind::Error),
                     }

--- a/crates/frontend/src/pages/home.rs
+++ b/crates/frontend/src/pages/home.rs
@@ -1,5 +1,5 @@
 use kartoteka_shared::{
-    CreateListRequest, FEATURE_DUE_DATE, FEATURE_QUANTITY, List, ListFeature, ListTagLink,
+    CreateListRequest, FEATURE_DEADLINES, FEATURE_QUANTITY, List, ListFeature, ListTagLink,
     ListType, Tag,
 };
 use leptos::prelude::*;
@@ -23,7 +23,7 @@ pub fn HomePage() -> impl IntoView {
 
     let (new_list_type, set_new_list_type) = signal(ListType::Custom);
     let (feat_quantity, set_feat_quantity) = signal(false);
-    let (feat_due_date, set_feat_due_date) = signal(false);
+    let (feat_deadlines, set_feat_deadlines) = signal(false);
     let (refresh, set_refresh) = signal(0u32);
     let (active_tag_filter, set_active_tag_filter) = signal(Option::<String>::None);
 
@@ -104,7 +104,7 @@ pub fn HomePage() -> impl IntoView {
     let on_create = Callback::new(move |name: String| {
         let list_type = new_list_type.get();
         let fq = feat_quantity.get();
-        let fd = feat_due_date.get();
+        let fd = feat_deadlines.get();
         leptos::task::spawn_local(async move {
             let mut features = Vec::new();
             if fq {
@@ -115,8 +115,8 @@ pub fn HomePage() -> impl IntoView {
             }
             if fd {
                 features.push(ListFeature {
-                    name: FEATURE_DUE_DATE.into(),
-                    config: serde_json::json!({}),
+                    name: FEATURE_DEADLINES.into(),
+                    config: serde_json::json!({"has_start_date": false, "has_deadline": true, "has_hard_deadline": false}),
                 });
             }
             let req = CreateListRequest {
@@ -195,7 +195,7 @@ pub fn HomePage() -> impl IntoView {
                                         set_new_list_type.set(lt_for_click.clone());
                                         let defaults = lt_for_click.default_features();
                                         set_feat_quantity.set(defaults.iter().any(|f| f.name == FEATURE_QUANTITY));
-                                        set_feat_due_date.set(defaults.iter().any(|f| f.name == FEATURE_DUE_DATE));
+                                        set_feat_deadlines.set(defaults.iter().any(|f| f.name == FEATURE_DEADLINES));
                                     }
                                 >
                                     {icon} " " {label}
@@ -218,8 +218,8 @@ pub fn HomePage() -> impl IntoView {
                         <input
                             type="checkbox"
                             class="checkbox checkbox-sm"
-                            prop:checked=feat_due_date
-                            on:change=move |ev| set_feat_due_date.set(event_target_checked(&ev))
+                            prop:checked=feat_deadlines
+                            on:change=move |ev| set_feat_deadlines.set(event_target_checked(&ev))
                         />
                         <span class="label-text">"Terminy"</span>
                     </label>

--- a/crates/frontend/src/pages/list/date_view.rs
+++ b/crates/frontend/src/pages/list/date_view.rs
@@ -1,6 +1,6 @@
 use leptos::prelude::*;
 
-use crate::components::common::date_utils::{get_today, is_overdue, is_upcoming, sort_by_due_date};
+use crate::components::common::date_utils::{get_today, is_overdue, is_upcoming, sort_by_deadline};
 use crate::components::items::date_item_row::DateItemRow;
 use kartoteka_shared::{Item, ItemTagLink, Tag};
 
@@ -11,6 +11,7 @@ pub fn render_date_view(
     on_toggle: Callback<String>,
     on_delete: Callback<String>,
     on_tag_toggle: Callback<(String, String)>,
+    on_date_save: Callback<(String, String, String, Option<String>)>,
 ) -> impl IntoView {
     let today = get_today();
 
@@ -19,17 +20,17 @@ pub fn render_date_view(
         .filter(|i| is_overdue(i, &today))
         .cloned()
         .collect();
-    sort_by_due_date(&mut overdue);
+    sort_by_deadline(&mut overdue);
 
     let mut upcoming: Vec<Item> = all
         .iter()
         .filter(|i| is_upcoming(i, &today))
         .cloned()
         .collect();
-    sort_by_due_date(&mut upcoming);
+    sort_by_deadline(&mut upcoming);
 
     let mut done: Vec<Item> = all.iter().filter(|i| i.completed).cloned().collect();
-    sort_by_due_date(&mut done);
+    sort_by_deadline(&mut done);
 
     let render_section = |label: &str,
                           css: &str,
@@ -62,6 +63,7 @@ pub fn render_date_view(
                                 all_tags=tags_clone
                                 item_tag_ids=item_tags
                                 on_tag_toggle=item_tag_toggle
+                                on_date_save=on_date_save
                             />
                         }
                     }).collect::<Vec<_>>()}
@@ -72,8 +74,8 @@ pub fn render_date_view(
 
     view! {
         <div>
-            {render_section("Zaległe", "text-error", overdue, tags.clone(), links.clone())}
-            {render_section("Nadchodzące", "text-warning", upcoming, tags.clone(), links.clone())}
+            {render_section("Zaleg\u{0142}e", "text-error", overdue, tags.clone(), links.clone())}
+            {render_section("Nadchodz\u{0105}ce", "text-warning", upcoming, tags.clone(), links.clone())}
             {render_section("Zrobione", "text-base-content/40", done, tags, links)}
         </div>
     }

--- a/crates/frontend/src/pages/list/mod.rs
+++ b/crates/frontend/src/pages/list/mod.rs
@@ -15,7 +15,7 @@ use crate::components::lists::list_tag_bar::ListTagBar;
 use crate::components::lists::sublist_section::SublistSection;
 use crate::components::tags::tag_filter_bar::TagFilterBar;
 use kartoteka_shared::{
-    FEATURE_DUE_DATE, FEATURE_QUANTITY, Item, ItemTagLink, List, ListFeature, ListTagLink, Tag,
+    FEATURE_DEADLINES, FEATURE_QUANTITY, Item, ItemTagLink, List, ListFeature, ListTagLink, Tag,
     UpdateListRequest,
 };
 
@@ -75,6 +75,7 @@ pub fn ListPage() -> impl IntoView {
     let on_delete = actions.on_delete;
     let on_description_save = actions.on_description_save;
     let on_quantity_change = actions.on_quantity_change;
+    let on_date_save = actions.on_date_save;
 
     let on_tag_toggle = make_item_tag_toggle(item_tag_links);
     let lid_for_tag = list_id();
@@ -180,6 +181,15 @@ pub fn ListPage() -> impl IntoView {
         }
     };
 
+    /// Get deadlines feature config from list features, or Null if not enabled
+    fn get_deadlines_config(feats: &[ListFeature]) -> serde_json::Value {
+        feats
+            .iter()
+            .find(|f| f.name == FEATURE_DEADLINES)
+            .map(|f| f.config.clone())
+            .unwrap_or(serde_json::Value::Null)
+    }
+
     view! {
         <div class="container mx-auto max-w-2xl p-4">
             {move || view! {
@@ -197,9 +207,14 @@ pub fn ListPage() -> impl IntoView {
                         list_features.update(|feats| {
                             if enabled {
                                 if !feats.iter().any(|f| f.name == feature_name) {
+                                    let config = if feature_name == FEATURE_DEADLINES {
+                                        serde_json::json!({"has_start_date": false, "has_deadline": true, "has_hard_deadline": false})
+                                    } else {
+                                        serde_json::json!({})
+                                    };
                                     feats.push(ListFeature {
                                         name: feature_name.clone(),
-                                        config: serde_json::json!({}),
+                                        config,
                                     });
                                 }
                             } else {
@@ -207,12 +222,29 @@ pub fn ListPage() -> impl IntoView {
                             }
                         });
                         let fname = feature_name.clone();
+                        let config = if fname == FEATURE_DEADLINES {
+                            serde_json::json!({"has_start_date": false, "has_deadline": true, "has_hard_deadline": false})
+                        } else {
+                            serde_json::json!({})
+                        };
                         leptos::task::spawn_local(async move {
                             if enabled {
-                                let _ = api::add_feature(&lid, &fname, serde_json::json!({})).await;
+                                let _ = api::add_feature(&lid, &fname, config).await;
                             } else {
                                 let _ = api::remove_feature(&lid, &fname).await;
                             }
+                        });
+                    })
+                    on_deadlines_config_change=Callback::new(move |new_config: serde_json::Value| {
+                        let lid = list_id();
+                        // Optimistic update
+                        list_features.update(|feats| {
+                            if let Some(f) = feats.iter_mut().find(|f| f.name == FEATURE_DEADLINES) {
+                                f.config = new_config.clone();
+                            }
+                        });
+                        leptos::task::spawn_local(async move {
+                            let _ = api::add_feature(&lid, FEATURE_DEADLINES, new_config).await;
                         });
                     })
                     on_rename=Callback::new(move |new_name: String| {
@@ -265,7 +297,8 @@ pub fn ListPage() -> impl IntoView {
 
             {move || {
                 let feats = list_features.get();
-                view! { <AddItemInput on_submit=on_add has_quantity=feats.iter().any(|f| f.name == FEATURE_QUANTITY) has_due_date=feats.iter().any(|f| f.name == FEATURE_DUE_DATE) /> }
+                let deadlines_config = get_deadlines_config(&feats);
+                view! { <AddItemInput on_submit=on_add has_quantity=feats.iter().any(|f| f.name == FEATURE_QUANTITY) deadlines_config=deadlines_config /> }
             }}
 
             {move || {
@@ -277,7 +310,7 @@ pub fn ListPage() -> impl IntoView {
                 if loading.get() {
                     view! { <p>"Wczytywanie..."</p> }.into_any()
                 } else if let Some(e) = error.get() {
-                    view! { <p style="color: red;">{format!("Błąd: {e}")}</p> }.into_any()
+                    view! { <p style="color: red;">{format!("B\u{0142}\u{0105}d: {e}")}</p> }.into_any()
                 } else if items.read().is_empty() && sublists.read().is_empty() {
                     view! { <div class="text-center text-base-content/50 py-12">"Lista jest pusta"</div> }.into_any()
                 } else {
@@ -285,8 +318,8 @@ pub fn ListPage() -> impl IntoView {
                         <div>
                             {move || {
                                 let feats = list_features.get();
-                                if feats.iter().any(|f| f.name == FEATURE_DUE_DATE) {
-                                    render_date_view(filtered_items(), all_tags.get(), item_tag_links.get(), on_toggle, on_delete, on_tag_toggle).into_any()
+                                if feats.iter().any(|f| f.name == FEATURE_DEADLINES) {
+                                    render_date_view(filtered_items(), all_tags.get(), item_tag_links.get(), on_toggle, on_delete, on_tag_toggle, on_date_save).into_any()
                                 } else {
                                     render_normal_view(NormalViewProps {
                                         items: filtered_items(),
@@ -297,6 +330,8 @@ pub fn ListPage() -> impl IntoView {
                                         on_description_save, on_quantity_change,
                                         has_quantity: feats.iter().any(|f| f.name == FEATURE_QUANTITY),
                                         on_move: on_move_main,
+                                        on_date_save,
+                                        deadlines_config: get_deadlines_config(&feats),
                                     }).into_any()
                                 }
                             }}
@@ -315,7 +350,7 @@ pub fn ListPage() -> impl IntoView {
                                                 let lname = list_name.get();
                                                 let sl_id = sl.id.clone();
                                                 let mut mt: Vec<(String, String)> = vec![
-                                                    (lid, format!("{lname} (główna)"))
+                                                    (lid, format!("{lname} (g\u{0142}\u{00F3}wna)"))
                                                 ];
                                                 mt.extend(
                                                     subs.iter()
@@ -323,11 +358,12 @@ pub fn ListPage() -> impl IntoView {
                                                         .map(|s| (s.id.clone(), s.name.clone()))
                                                 );
                                                 let feats = list_features.get();
+                                                let deadlines_config = get_deadlines_config(&feats);
                                                 view! {
                                                     <SublistSection
                                                         sublist=sl.clone()
                                                         has_quantity=feats.iter().any(|f| f.name == FEATURE_QUANTITY)
-                                                        has_due_date=feats.iter().any(|f| f.name == FEATURE_DUE_DATE)
+                                                        deadlines_config=deadlines_config
                                                         all_tags=tags
                                                         item_tag_links=links
                                                         on_tag_toggle=on_tag_toggle

--- a/crates/frontend/src/pages/list/normal_view.rs
+++ b/crates/frontend/src/pages/list/normal_view.rs
@@ -15,6 +15,8 @@ pub struct NormalViewProps {
     pub on_quantity_change: Callback<(String, i32)>,
     pub has_quantity: bool,
     pub on_move: Callback<(String, String)>,
+    pub on_date_save: Callback<(String, String, String, Option<String>)>,
+    pub deadlines_config: serde_json::Value,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -31,6 +33,8 @@ pub fn render_normal_view(p: NormalViewProps) -> impl IntoView {
         on_quantity_change,
         has_quantity,
         on_move,
+        on_date_save,
+        deadlines_config,
     } = p;
     let move_targets: Vec<(String, String)> = sublists
         .iter()
@@ -50,6 +54,7 @@ pub fn render_normal_view(p: NormalViewProps) -> impl IntoView {
                     on_tag_toggle.run((item_id.clone(), tag_id));
                 });
                 let mt = move_targets.clone();
+                let dc = deadlines_config.clone();
                 view! {
                     <ItemRow
                         item=item.clone()
@@ -63,6 +68,8 @@ pub fn render_normal_view(p: NormalViewProps) -> impl IntoView {
                         on_quantity_change=on_quantity_change
                         move_targets=mt
                         on_move=on_move
+                        on_date_save=on_date_save
+                        deadlines_config=dc
                     />
                 }
             }).collect::<Vec<_>>()}

--- a/crates/frontend/src/pages/today.rs
+++ b/crates/frontend/src/pages/today.rs
@@ -5,7 +5,9 @@ use leptos_router::components::A;
 
 use crate::api;
 use crate::app::{ToastContext, ToastKind};
-use crate::components::common::date_utils::{format_polish_date, get_today_string};
+use crate::components::common::date_utils::{
+    format_polish_date, get_today_string, is_overdue_for_date_type,
+};
 use crate::components::filters::filter_chips::FilterChips;
 use crate::components::items::date_item_row::DateItemRow;
 use kartoteka_shared::*;
@@ -30,7 +32,7 @@ pub fn TodayPage() -> impl IntoView {
     let _resource = LocalResource::new(move || {
         let date = today_for_fetch.clone();
         async move {
-            match api::fetch_items_by_date(&date, true).await {
+            match api::fetch_items_by_date(&date, true, "all").await {
                 Ok(fetched) => items.set(fetched),
                 Err(e) => toast.push(format!("Błąd ładowania zadań: {e}"), ToastKind::Error),
             }
@@ -50,7 +52,7 @@ pub fn TodayPage() -> impl IntoView {
     view! {
         <div class="container mx-auto max-w-2xl p-4">
             <div class="flex items-center justify-between mb-4">
-                <h1 class="text-2xl font-bold">"Dziś"</h1>
+                <h1 class="text-2xl font-bold">"Dzi\u{015B}"</h1>
                 <span class="text-base-content/50">{format_polish_date(&today_display)}</span>
             </div>
 
@@ -67,7 +69,7 @@ pub fn TodayPage() -> impl IntoView {
                 if all_items.is_empty() {
                     return view! {
                         <p class="text-center text-base-content/50 py-12">
-                            "Brak zadań na dziś"
+                            "Brak zada\u{0144} na dzi\u{015B}"
                         </p>
                     }.into_any();
                 }
@@ -114,14 +116,17 @@ pub fn TodayPage() -> impl IntoView {
                     })
                     .collect();
 
-                // Split into overdue and today
+                // Split into overdue and today — check the relevant date field per date_type
                 let mut overdue_groups: BTreeMap<(String, String), Vec<DateItem>> = BTreeMap::new();
                 let mut today_groups: BTreeMap<(String, String), Vec<DateItem>> = BTreeMap::new();
 
                 for item in filtered {
-                    let is_overdue = item.due_date.as_ref()
-                        .map(|d| d < &today_str && !item.completed)
-                        .unwrap_or(false);
+                    let relevant_date = match item.date_type.as_deref() {
+                        Some("start") => item.start_date.as_deref(),
+                        Some("hard_deadline") => item.hard_deadline.as_deref(),
+                        _ => item.deadline.as_deref(),
+                    };
+                    let is_overdue = is_overdue_for_date_type(relevant_date, item.completed, &today_str);
                     let key = (item.list_id.clone(), item.list_name.clone());
                     if is_overdue {
                         overdue_groups.entry(key).or_default().push(item);
@@ -149,7 +154,7 @@ pub fn TodayPage() -> impl IntoView {
                                 view! {
                                     <div class="mb-6">
                                         <h3 class="text-xs text-error uppercase tracking-wider font-semibold mb-2">
-                                            "Zaległe"
+                                            "Zaleg\u{0142}e"
                                         </h3>
                                         {render_groups(overdue_groups, tags.clone(), links.clone(), items)}
                                     </div>
@@ -164,7 +169,7 @@ pub fn TodayPage() -> impl IntoView {
                                         {if has_overdue {
                                             view! {
                                                 <h3 class="text-xs text-base-content/50 uppercase tracking-wider font-semibold mb-2">
-                                                    "Dziś"
+                                                    "Dzi\u{015B}"
                                                 </h3>
                                             }.into_any()
                                         } else {
@@ -211,6 +216,7 @@ fn render_groups(
                     {group_items.into_iter().map(|date_item| {
                         let item_id = date_item.id.clone();
                         let item_list_id = date_item.list_id.clone();
+                        let date_type = date_item.date_type.clone();
                         let item: Item = date_item.into();
 
                         let item_tag_ids: Vec<String> = links.iter()
@@ -223,8 +229,9 @@ fn render_groups(
                         let on_toggle = Callback::new(move |_id: String| {
                             let lid = toggle_list_id.clone();
                             let iid = toggle_item_id.clone();
+                            // Toggle ALL occurrences with same id (multi-date items)
                             items_signal.update(|items| {
-                                if let Some(item) = items.iter_mut().find(|i| i.id == iid) {
+                                for item in items.iter_mut().filter(|i| i.id == iid) {
                                     item.completed = !item.completed;
                                 }
                             });
@@ -242,8 +249,11 @@ fn render_groups(
                                     quantity: None,
                                     actual_quantity: None,
                                     unit: None,
-                                    due_date: None,
-                                    due_time: None,
+                                    start_date: None,
+                                    start_time: None,
+                                    deadline: None,
+                                    deadline_time: None,
+                                    hard_deadline: None,
                                 };
                                 let _ = api::update_item(&lid, &iid, &req).await;
                             });
@@ -254,6 +264,7 @@ fn render_groups(
                         let on_delete = Callback::new(move |_id: String| {
                             let lid = delete_list_id.clone();
                             let iid = delete_item_id.clone();
+                            // Remove ALL occurrences
                             items_signal.update(|items| {
                                 items.retain(|i| i.id != iid);
                             });
@@ -262,15 +273,68 @@ fn render_groups(
                             });
                         });
 
-                        view! {
-                            <DateItemRow
-                                item=item
-                                on_toggle=on_toggle
-                                on_delete=on_delete
-                                all_tags=tags.clone()
-                                item_tag_ids=item_tag_ids
-                            />
-                        }
+                        // Date save callback
+                        let date_save_list_id = item_list_id.clone();
+                        let date_save_item_id = item_id.clone();
+                        let on_date_save = Callback::new(move |(iid, dt, date, time): (String, String, String, Option<String>)| {
+                            let lid = date_save_list_id.clone();
+                            let date_opt = if date.is_empty() { Some(None) } else { Some(Some(date)) };
+                            let time_opt = if date_opt == Some(None) { Some(None) } else { time.map(Some) };
+                            // Optimistic update on all occurrences
+                            items_signal.update(|items| {
+                                for item in items.iter_mut().filter(|i| i.id == iid) {
+                                    let d = date_opt.clone().flatten();
+                                    let t = time_opt.clone().flatten();
+                                    match dt.as_str() {
+                                        "start" => { item.start_date = d; item.start_time = t; }
+                                        "deadline" => { item.deadline = d; item.deadline_time = t; }
+                                        "hard_deadline" => { item.hard_deadline = d; }
+                                        _ => {}
+                                    }
+                                }
+                            });
+                            let iid2 = date_save_item_id.clone();
+                            leptos::task::spawn_local(async move {
+                                let mut req = UpdateItemRequest {
+                                    title: None, description: None, completed: None, position: None,
+                                    quantity: None, actual_quantity: None, unit: None,
+                                    start_date: None, start_time: None,
+                                    deadline: None, deadline_time: None, hard_deadline: None,
+                                };
+                                match dt.as_str() {
+                                    "start" => { req.start_date = date_opt; req.start_time = time_opt; }
+                                    "deadline" => { req.deadline = date_opt; req.deadline_time = time_opt; }
+                                    "hard_deadline" => { req.hard_deadline = date_opt; }
+                                    _ => {}
+                                }
+                                let _ = api::update_item(&lid, &iid2, &req).await;
+                            });
+                        });
+
+                        {if let Some(dt) = date_type {
+                            view! {
+                                <DateItemRow
+                                    item=item
+                                    on_toggle=on_toggle
+                                    on_delete=on_delete
+                                    all_tags=tags.clone()
+                                    item_tag_ids=item_tag_ids
+                                    date_type=dt
+                                    on_date_save=on_date_save
+                                />
+                            }.into_any()
+                        } else {
+                            view! {
+                                <DateItemRow
+                                    item=item
+                                    on_toggle=on_toggle
+                                    on_delete=on_delete
+                                    all_tags=tags.clone()
+                                    item_tag_ids=item_tag_ids
+                                    on_date_save=on_date_save
+                                />
+                            }.into_any()
+                        }}
                     }).collect_view()}
                 </div>
             }

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -13,7 +13,7 @@ fn bool_from_number<'de, D: Deserializer<'de>>(d: D) -> Result<bool, D::Error> {
 
 /// Known feature names
 pub const FEATURE_QUANTITY: &str = "quantity";
-pub const FEATURE_DUE_DATE: &str = "due_date";
+pub const FEATURE_DEADLINES: &str = "deadlines";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ListFeature {
@@ -50,10 +50,45 @@ impl ListType {
                 config: serde_json::json!({"unit_default": "szt"}),
             }],
             Self::Terminarz => vec![ListFeature {
-                name: FEATURE_DUE_DATE.into(),
-                config: serde_json::json!({}),
+                name: FEATURE_DEADLINES.into(),
+                config: serde_json::json!({"has_start_date": false, "has_deadline": true, "has_hard_deadline": false}),
             }],
             _ => vec![],
+        }
+    }
+}
+
+/// Date field types for cross-list queries
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum DateField {
+    StartDate,
+    Deadline,
+    HardDeadline,
+}
+
+impl DateField {
+    pub fn column_name(&self) -> &'static str {
+        match self {
+            Self::StartDate => "start_date",
+            Self::Deadline => "deadline",
+            Self::HardDeadline => "hard_deadline",
+        }
+    }
+
+    pub fn time_column_name(&self) -> Option<&'static str> {
+        match self {
+            Self::StartDate => Some("start_time"),
+            Self::Deadline => Some("deadline_time"),
+            Self::HardDeadline => None,
+        }
+    }
+
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::StartDate => "start",
+            Self::Deadline => "deadline",
+            Self::HardDeadline => "hard_deadline",
         }
     }
 }
@@ -93,8 +128,11 @@ pub struct Item {
     pub quantity: Option<i32>,
     pub actual_quantity: Option<i32>,
     pub unit: Option<String>,
-    pub due_date: Option<String>,
-    pub due_time: Option<String>,
+    pub start_date: Option<String>,
+    pub start_time: Option<String>,
+    pub deadline: Option<String>,
+    pub deadline_time: Option<String>,
+    pub hard_deadline: Option<String>,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -132,8 +170,11 @@ pub struct CreateItemRequest {
     pub description: Option<String>,
     pub quantity: Option<i32>,
     pub unit: Option<String>,
-    pub due_date: Option<String>,
-    pub due_time: Option<String>,
+    pub start_date: Option<String>,
+    pub start_time: Option<String>,
+    pub deadline: Option<String>,
+    pub deadline_time: Option<String>,
+    pub hard_deadline: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -145,8 +186,11 @@ pub struct UpdateItemRequest {
     pub quantity: Option<i32>,
     pub actual_quantity: Option<i32>,
     pub unit: Option<String>,
-    pub due_date: Option<String>,
-    pub due_time: Option<String>,
+    pub start_date: Option<Option<String>>,
+    pub start_time: Option<Option<String>>,
+    pub deadline: Option<Option<String>>,
+    pub deadline_time: Option<Option<String>>,
+    pub hard_deadline: Option<Option<String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -209,12 +253,17 @@ pub struct DateItem {
     pub quantity: Option<i32>,
     pub actual_quantity: Option<i32>,
     pub unit: Option<String>,
-    pub due_date: Option<String>,
-    pub due_time: Option<String>,
+    pub start_date: Option<String>,
+    pub start_time: Option<String>,
+    pub deadline: Option<String>,
+    pub deadline_time: Option<String>,
+    pub hard_deadline: Option<String>,
     pub created_at: String,
     pub updated_at: String,
     pub list_name: String,
     pub list_type: ListType,
+    #[serde(default)]
+    pub date_type: Option<String>,
 }
 
 // === Calendar types ===
@@ -254,8 +303,11 @@ impl From<DateItem> for Item {
             quantity: di.quantity,
             actual_quantity: di.actual_quantity,
             unit: di.unit,
-            due_date: di.due_date,
-            due_time: di.due_time,
+            start_date: di.start_date,
+            start_time: di.start_time,
+            deadline: di.deadline,
+            deadline_time: di.deadline_time,
+            hard_deadline: di.hard_deadline,
             created_at: di.created_at,
             updated_at: di.updated_at,
         }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -81,17 +81,18 @@ Z flat booleans na tabelę `list_features(list_id, feature_name, config TEXT/JSO
 
 ---
 
-## M4: Bogatsza semantyka czasu
+## ~~M4: Bogatsza semantyka czasu~~ ✅
 
 **Dostarcza:** Różne typy dat — start_date, deadline, hard_deadline. Buduje na feature slice system z M3.
 
-- Backend: nowe kolumny na items (`start_date`, `deadline`, `hard_deadline`)
-- Nowy feature slice `"deadlines"` z config `{"has_start_date": true, "has_deadline": true, "has_hard_deadline": false}` — włączany per lista przez M3 system
-- Cross-list query (M1) rozszerzony o nowe typy dat (`?date_field=deadline`)
-- Frontend: dynamiczne pola w formularzu itema (zależne od config feature slice), wizualne rozróżnienie per typ daty (kolor/ikona)
-- Kalendarz (M2) i "Dziś" (M1) rozumieją nowe typy dat
+- ✅ Backend: nowe kolumny na items (`start_date`, `start_time`, `deadline`, `deadline_time`, `hard_deadline`) — rename z `due_date`/`due_time`
+- ✅ Nowy feature slice `"deadlines"` z config `{"has_start_date": true, "has_deadline": true, "has_hard_deadline": false}` — włączany per lista przez M3 system, z sub-checkboxami w UI
+- ✅ Cross-list query (M1) rozszerzony o nowe typy dat (`?date_field=deadline|start_date|hard_deadline|all`), UNION ALL dla `all`, `COUNT(DISTINCT)` w calendar counts
+- ✅ Frontend: compact chip-based date input, inline date editor na istniejących itemach (klikalne badge), DateEditor shared component, quick dates + quick times
+- ✅ Kalendarz (M2) i "Dziś" (M1) rozumieją nowe typy dat z badge per date_type
+- ✅ `Option<Option<String>>` w `UpdateItemRequest` do clearing dat
 
-**Refaktor:** Ujednolicenie obsługi dat w shared (due_date + due_time jako raw stringi → spójny model dat).
+**Refaktor:** ✅ Ujednolicenie obsługi dat — `DateField` enum, `item_date_badges()` helper, `DateEditor` shared component. Rename `due_date`/`due_time` → `deadline`/`deadline_time` w całym codebase.
 
 ---
 

--- a/docs/superpowers/specs/2026-03-27-m4-richer-time-semantics-design.md
+++ b/docs/superpowers/specs/2026-03-27-m4-richer-time-semantics-design.md
@@ -1,0 +1,290 @@
+# M4: Bogatsza semantyka czasu — Design Spec
+
+## Context
+
+Kartoteka ma obecnie jedno pole daty na itemach (`due_date` + `due_time`), co wystarcza do prostego terminarza, ale nie pozwala na rozróżnienie między "kiedy zacząć", "kiedy chcę skończyć" i "absolutny termin". M4 wprowadza richer time model z trzema typami dat, budując na feature slice system z M3.
+
+## Decyzje projektowe
+
+1. **due_date → deadline** — rename istniejącego pola. Czysta semantyka bez duplikacji.
+2. **hard_deadline to osobna data** (nie boolean flag) — pozwala mieć soft deadline 10.04 i hard deadline 15.04 na tym samym itemie.
+3. **start_date + start_time** — spójne z deadline/deadline_time. "Zacznij o 9:00".
+4. **Multi-date display** — item pojawia się na kalendarzu/widoku Dziś na każdej swojej dacie z badge (start/deadline/hard).
+5. **Clearing dates** — `UpdateItemRequest` używa `Option<Option<String>>` dla pól dat (wzór z `UpdateTagRequest.parent_tag_id`). `None` = nie zmieniaj, `Some(None)` = wyczyść, `Some(Some(v))` = ustaw.
+
+## Model danych
+
+### Nowe kolumny na `items`
+
+| Kolumna | Typ | Opis |
+|---------|-----|------|
+| `start_date` | TEXT | Data startu (YYYY-MM-DD) |
+| `start_time` | TEXT | Godzina startu (HH:MM) |
+| `deadline` | TEXT | Soft deadline — rename z `due_date` |
+| `deadline_time` | TEXT | Godzina deadline — rename z `due_time` |
+| `hard_deadline` | TEXT | Absolutny/twardy termin (YYYY-MM-DD) |
+
+### Migracje
+
+Rozdzielone na dwa pliki dla atomowości:
+
+**`0008_richer_dates.sql`** — zmiany na tabeli `items`:
+```sql
+ALTER TABLE items ADD COLUMN start_date TEXT;
+ALTER TABLE items ADD COLUMN start_time TEXT;
+ALTER TABLE items ADD COLUMN hard_deadline TEXT;
+ALTER TABLE items RENAME COLUMN due_date TO deadline;
+ALTER TABLE items RENAME COLUMN due_time TO deadline_time;
+```
+
+**`0009_deadlines_feature.sql`** — migracja feature slice:
+```sql
+-- Migrate feature name and config
+UPDATE list_features SET feature_name = 'deadlines', config = '{"has_start_date": false, "has_deadline": true, "has_hard_deadline": false}'
+WHERE feature_name = 'due_date';
+
+-- Safety: remove any unknown feature names before recreating table
+DELETE FROM list_features WHERE feature_name NOT IN ('quantity', 'deadlines');
+
+-- Recreate list_features with updated CHECK constraint
+CREATE TABLE list_features_new (
+    list_id TEXT NOT NULL REFERENCES lists(id) ON DELETE CASCADE,
+    feature_name TEXT NOT NULL CHECK(feature_name IN ('quantity', 'deadlines')),
+    config TEXT NOT NULL DEFAULT '{}',
+    PRIMARY KEY (list_id, feature_name)
+);
+INSERT INTO list_features_new SELECT * FROM list_features;
+DROP TABLE list_features;
+ALTER TABLE list_features_new RENAME TO list_features;
+CREATE INDEX idx_list_features_list ON list_features(list_id);
+```
+
+## Feature slice: `"deadlines"`
+
+### Stała
+
+```rust
+pub const FEATURE_DEADLINES: &str = "deadlines";
+// Remove: pub const FEATURE_DUE_DATE: &str = "due_date";
+```
+
+### Config schema
+
+```json
+{
+  "has_start_date": true,
+  "has_deadline": true,
+  "has_hard_deadline": false
+}
+```
+
+### Default features per ListType
+
+Update `ListType::default_features()`:
+- `Terminarz` → `FEATURE_DEADLINES` with config `{"has_start_date": false, "has_deadline": true, "has_hard_deadline": false}`
+- Other types → unchanged
+
+## Shared structs changes
+
+### `crates/shared/src/lib.rs`
+
+**Item struct:**
+- `due_date: Option<String>` → `deadline: Option<String>`
+- `due_time: Option<String>` → `deadline_time: Option<String>`
+- Add: `start_date: Option<String>`
+- Add: `start_time: Option<String>`
+- Add: `hard_deadline: Option<String>`
+
+**DateItem struct:**
+- Same renames and additions as Item
+- Keep: `list_name`, `list_type`
+- Add: `date_type: Option<String>` — populated by API when querying with `date_field=all`, `None` when querying specific field
+
+**`From<DateItem> for Item` impl:**
+- Update field names: `due_date` → `deadline`, `due_time` → `deadline_time`
+- Forward new fields: `start_date`, `start_time`, `hard_deadline`
+- Drop `date_type`, `list_name`, `list_type` (not in Item)
+
+**CreateItemRequest:**
+- `due_date` → `deadline`, `due_time` → `deadline_time`
+- Add: `start_date`, `start_time`, `hard_deadline`
+
+**UpdateItemRequest:**
+- Rename: `due_date` → `deadline`, `due_time` → `deadline_time`
+- Add: `start_date`, `start_time`, `hard_deadline`
+- Change all date fields to `Option<Option<String>>` to support clearing (pattern from `UpdateTagRequest.parent_tag_id`)
+- `None` = don't change, `Some(None)` = clear to NULL, `Some(Some(v))` = set value
+
+### New: `DateField` enum
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum DateField {
+    StartDate,
+    Deadline,
+    HardDeadline,
+}
+
+impl DateField {
+    pub fn column_name(&self) -> &'static str {
+        match self {
+            Self::StartDate => "start_date",
+            Self::Deadline => "deadline",
+            Self::HardDeadline => "hard_deadline",
+        }
+    }
+
+    pub fn time_column_name(&self) -> Option<&'static str> {
+        match self {
+            Self::StartDate => Some("start_time"),
+            Self::Deadline => Some("deadline_time"),
+            Self::HardDeadline => None,
+        }
+    }
+
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::StartDate => "start",
+            Self::Deadline => "deadline",
+            Self::HardDeadline => "hard_deadline",
+        }
+    }
+}
+```
+
+## API changes
+
+### `crates/api/src/handlers/items.rs`
+
+#### `create` / `update`
+- Handle new fields: `start_date`, `start_time`, `hard_deadline`
+- Rename `due_date`/`due_time` → `deadline`/`deadline_time` in SQL
+- `update`: handle `Option<Option<String>>` for date fields — `None` = skip, `Some(None)` = SET NULL, `Some(Some(v))` = SET value
+
+#### `by_date` endpoint
+`GET /api/items/by-date?date=YYYY-MM-DD&date_field=deadline&include_overdue=true`
+
+- New param `date_field`: `deadline` (default), `start_date`, `hard_deadline`, `all`
+- When `date_field` is a single field: same logic as before, using that column
+- When `date_field=all`: UNION ALL query, adds `date_type` column
+- `include_overdue` applies to the selected `date_field` (for `all`, applies to each sub-query independently — only deadline has overdue semantics)
+
+#### `calendar` endpoint
+`GET /api/items/calendar?from=YYYY-MM-DD&to=YYYY-MM-DD&date_field=deadline&detail=counts`
+
+- New param `date_field`: same as `by_date`
+- When `date_field=all` with `detail=counts`: use `COUNT(DISTINCT i.id)` to avoid double-counting items that share dates across fields
+- When `date_field=all` with `detail=full`: UNION ALL with `date_type`, items may appear multiple times (intended for badge display)
+
+### SQL for `date_field=all` (by_date)
+
+Use explicit column list (not `SELECT *`) to match `DateItem` struct and avoid D1 column name collisions:
+
+```sql
+SELECT i.id, i.list_id, i.title, i.description, i.completed, i.position,
+       i.quantity, i.actual_quantity, i.unit,
+       i.start_date, i.start_time, i.deadline, i.deadline_time, i.hard_deadline,
+       i.created_at, i.updated_at,
+       l.name as list_name, l.list_type,
+       'start' as date_type
+FROM items i JOIN lists l ON l.id = i.list_id
+WHERE l.user_id = ?1 AND l.archived = 0 AND i.start_date = ?2
+
+UNION ALL
+
+SELECT i.id, i.list_id, i.title, i.description, i.completed, i.position,
+       i.quantity, i.actual_quantity, i.unit,
+       i.start_date, i.start_time, i.deadline, i.deadline_time, i.hard_deadline,
+       i.created_at, i.updated_at,
+       l.name as list_name, l.list_type,
+       'deadline' as date_type
+FROM items i JOIN lists l ON l.id = i.list_id
+WHERE l.user_id = ?1 AND l.archived = 0
+  AND (i.deadline = ?2 OR (i.deadline < ?2 AND i.completed = 0))
+
+UNION ALL
+
+SELECT i.id, i.list_id, i.title, i.description, i.completed, i.position,
+       i.quantity, i.actual_quantity, i.unit,
+       i.start_date, i.start_time, i.deadline, i.deadline_time, i.hard_deadline,
+       i.created_at, i.updated_at,
+       l.name as list_name, l.list_type,
+       'hard_deadline' as date_type
+FROM items i JOIN lists l ON l.id = i.list_id
+WHERE l.user_id = ?1 AND l.archived = 0 AND i.hard_deadline = ?2
+
+ORDER BY completed ASC, list_name ASC, deadline_time ASC, position ASC
+```
+
+### SQL for `date_field=all` (calendar counts)
+
+Use `COUNT(DISTINCT i.id)` to count unique items per day:
+
+```sql
+SELECT date, COUNT(DISTINCT id) as total, CAST(SUM(completed) AS INTEGER) / COUNT(*) as completed
+FROM (
+    SELECT i.id, i.start_date as date, i.completed FROM items i JOIN lists l ON l.id = i.list_id
+    WHERE l.user_id = ?1 AND l.archived = 0 AND i.start_date >= ?2 AND i.start_date <= ?3
+    UNION ALL
+    SELECT i.id, i.deadline as date, i.completed FROM items i JOIN lists l ON l.id = i.list_id
+    WHERE l.user_id = ?1 AND l.archived = 0 AND i.deadline >= ?2 AND i.deadline <= ?3
+    UNION ALL
+    SELECT i.id, i.hard_deadline as date, i.completed FROM items i JOIN lists l ON l.id = i.list_id
+    WHERE l.user_id = ?1 AND l.archived = 0 AND i.hard_deadline >= ?2 AND i.hard_deadline <= ?3
+)
+GROUP BY date ORDER BY date ASC
+```
+
+## Frontend changes
+
+### Multi-date display: duplicate items handling
+
+When `date_field=all`, the same item can appear 2-3 times (once per date type). Key decisions:
+
+1. **Optimistic toggle**: find ALL occurrences with same `id` in the items signal, toggle all at once
+2. **Overdue classification**: based on `date_type` field, not always `deadline`. Item appearing due to `start_date` checks `start_date` for overdue, not `deadline`.
+3. **DateItemRow**: accepts `date_type: Option<DateField>` prop to select which date to display in the date slot. When `date_type` is set, show that date field (not always `deadline`).
+
+### Components to modify
+
+| File | Change |
+|------|--------|
+| `components/items/add_item_input.rs` | Dynamic date fields based on `deadlines` feature config. Show start_date+start_time, deadline+deadline_time, hard_deadline based on config booleans. |
+| `components/items/item_row.rs` | Show date badges (color-coded): start=blue, deadline=amber, hard_deadline=red |
+| `components/items/date_item_row.rs` | Accept `date_type: Option<DateField>` prop. Display the date from the matching field. Add color-coded badge. Rename due_date → deadline. |
+| `components/common/date_utils.rs` | Rename `sort_by_due_date` → `sort_by_deadline`. Add `sort_by_date_field(items, field: DateField)`. Rename `is_overdue` refs from `due_date` → `deadline`. Add `is_overdue_for_field(item, field: DateField)`. |
+| `pages/today.rs` | Query with `date_field=all`. Update `render_groups` to handle `date_type`. Update toggle logic to find ALL items with same `id`. Overdue classification per `date_type`. Update inline `UpdateItemRequest` struct construction. |
+| `pages/calendar/month_grid.rs` | Use `date_field=all` for calendar counts. |
+| `pages/calendar/day.rs` | Use `date_field=all` for day detail. Show badges. Update inline `UpdateItemRequest` construction. |
+| `pages/list/date_view.rs` | Rename due_date → deadline. Update sort calls. |
+| `pages/list/normal_view.rs` | Update field names in item display. |
+| `api/items.rs` | Rename due_date→deadline in API calls, add new fields to request/response handling. |
+| `api/lists.rs` | Update feature name references (due_date → deadlines). |
+
+### Badge design
+
+- **Start** — blue outline badge, icon: play/calendar-start
+- **Deadline** — amber/yellow badge, icon: clock
+- **Hard deadline** — red badge, icon: alert-triangle
+
+### Feature config UI
+
+In list create/edit, when toggling `deadlines` feature:
+- Checkboxes for: Start date, Deadline, Hard deadline
+- At least one must be checked when feature is enabled
+
+## Verification
+
+1. `just check` — workspace compiles
+2. `just lint` — clippy + fmt pass
+3. `just dev` — local testing:
+   - Create list with `deadlines` feature (various configs)
+   - Add item with start_date, deadline, hard_deadline
+   - Verify Today page shows item on each date with correct badge
+   - Verify Calendar shows item on multiple dates with correct counts (no double-counting in counts view)
+   - Verify existing Terminarz lists still work (migrated due_date → deadline)
+   - Verify date clearing works (set a date, then remove it via update)
+   - Verify overdue classification works per date_type
+4. Test migration on dev D1 database (0008 then 0009 separately)
+5. `just ci` — full CI pipeline


### PR DESCRIPTION
## Summary

- **Richer date model**: rename `due_date`/`due_time` → `deadline`/`deadline_time`, add `start_date`/`start_time` and `hard_deadline` fields on items
- **Configurable deadlines feature slice**: `"deadlines"` with `has_start_date`, `has_deadline`, `has_hard_deadline` toggles per list (replaces flat `"due_date"` feature)
- **Inline date editing**: clickable date badges on items open inline DateEditor with quick dates (Dziś/Jutro/Pn), quick times (9:00/12:00/15:00/18:00), and manual stepper
- **Cross-list queries**: `date_field=all` UNION ALL support in by-date and calendar endpoints, `COUNT(DISTINCT)` for accurate calendar counts
- **Compact chip UI**: date types as collapsible chips in add item form, ghost chips for adding missing date types

## Test plan

- [ ] Run `just check` and `just lint` — compiles and passes clippy/fmt
- [ ] Apply migrations locally: `just migrate-local`
- [ ] Create Terminarz list — verify migrated `due_date` → `deadline` works
- [ ] Create list with all 3 date types enabled (Start + Deadline + Hard deadline)
- [ ] Add item with multiple dates, verify chips and badges display correctly
- [ ] Click date badge on existing item → inline editor opens, change date → saves
- [ ] Today page and Calendar show items on all their dates with badges
- [ ] Clear a date field via inline editor → date removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)