### PR TITLE
feat: containers (folders + projects) (M5)

### DIFF
--- a/crates/api/migrations/0010_containers.sql
+++ b/crates/api/migrations/0010_containers.sql
@@ -1,0 +1,26 @@
+-- M5: Containers (folders + projects) + pinning + recent tracking
+
+CREATE TABLE containers (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT,
+    status TEXT,  -- NULL=folder, 'active'/'done'/'paused'=project
+    parent_container_id TEXT REFERENCES containers(id) ON DELETE SET NULL,
+    position INTEGER NOT NULL DEFAULT 0,
+    pinned INTEGER NOT NULL DEFAULT 0,
+    last_opened_at TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX idx_containers_user_id ON containers(user_id);
+CREATE INDEX idx_containers_parent ON containers(parent_container_id);
+
+-- Add container_id to lists (nullable FK, orphan on delete)
+ALTER TABLE lists ADD COLUMN container_id TEXT REFERENCES containers(id) ON DELETE SET NULL;
+CREATE INDEX idx_lists_container_id ON lists(container_id);
+
+-- Pinning + recent tracking on lists
+ALTER TABLE lists ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE lists ADD COLUMN last_opened_at TEXT;

--- a/crates/api/src/handlers/containers.rs
+++ b/crates/api/src/handlers/containers.rs
@@ -1,0 +1,508 @@
+use kartoteka_shared::{
+    Container, ContainerDetail, CreateContainerRequest, List, MoveContainerRequest,
+    UpdateContainerRequest,
+};
+use wasm_bindgen::JsValue;
+use worker::*;
+
+const CONTAINER_SELECT: &str = "\
+    SELECT c.id, c.user_id, c.name, c.description, c.status, \
+    c.parent_container_id, c.position, c.pinned, c.last_opened_at, \
+    c.created_at, c.updated_at \
+    FROM containers c";
+
+pub async fn list_all(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
+    let user_id = ctx.data.clone();
+    let d1 = ctx.env.d1("DB")?;
+    let result = d1
+        .prepare(format!(
+            "{CONTAINER_SELECT} WHERE c.user_id = ?1 ORDER BY c.position ASC, c.created_at ASC"
+        ))
+        .bind(&[user_id.into()])?
+        .all()
+        .await?;
+    let containers = result.results::<Container>()?;
+    Response::from_json(&containers)
+}
+
+pub async fn create(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
+    let user_id = ctx.data.clone();
+    let body: CreateContainerRequest = req.json().await?;
+    let id = uuid::Uuid::new_v4().to_string();
+    let d1 = ctx.env.d1("DB")?;
+
+    // Validate: parent must not be a project (status != NULL)
+    if let Some(ref parent_id) = body.parent_container_id {
+        let parent = d1
+            .prepare("SELECT status FROM containers WHERE id = ?1 AND user_id = ?2")
+            .bind(&[parent_id.clone().into(), user_id.clone().into()])?
+            .first::<serde_json::Value>(None)
+            .await?;
+        match parent {
+            None => return Response::error("Parent container not found", 404),
+            Some(ref p) => {
+                if !p.get("status").map(|v| v.is_null()).unwrap_or(true) {
+                    return Response::error("Projects cannot contain sub-containers", 400);
+                }
+            }
+        }
+    }
+
+    let status_val: JsValue = match &body.status {
+        Some(s) => {
+            let s_str = serde_json::to_value(s)
+                .map_err(|e| Error::from(e.to_string()))?
+                .as_str()
+                .unwrap_or("active")
+                .to_string();
+            JsValue::from(s_str.as_str())
+        }
+        None => JsValue::NULL,
+    };
+
+    let parent_val: JsValue = match &body.parent_container_id {
+        Some(p) => JsValue::from(p.as_str()),
+        None => JsValue::NULL,
+    };
+
+    // Position: max + 1 among siblings
+    let max_pos = d1
+        .prepare(
+            "SELECT COALESCE(MAX(position), -1) as max_pos FROM containers WHERE user_id = ?1 AND parent_container_id IS ?2",
+        )
+        .bind(&[user_id.clone().into(), parent_val.clone()])?
+        .first::<serde_json::Value>(None)
+        .await?
+        .and_then(|v| v.get("max_pos")?.as_i64())
+        .unwrap_or(-1);
+    let position = (max_pos + 1) as i32;
+
+    d1.prepare(
+        "INSERT INTO containers (id, user_id, name, status, parent_container_id, position) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+    )
+    .bind(&[
+        id.clone().into(),
+        user_id.into(),
+        body.name.clone().into(),
+        status_val,
+        parent_val,
+        position.into(),
+    ])?
+    .run()
+    .await?;
+
+    let container = d1
+        .prepare(format!("{CONTAINER_SELECT} WHERE c.id = ?1"))
+        .bind(&[id.into()])?
+        .first::<Container>(None)
+        .await?
+        .ok_or_else(|| Error::from("Failed to create container"))?;
+
+    let mut resp = Response::from_json(&container)?;
+    resp = resp.with_status(201);
+    Ok(resp)
+}
+
+pub async fn get_one(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
+    let user_id = ctx.data.clone();
+    let id = ctx
+        .param("id")
+        .ok_or_else(|| Error::from("Missing id"))?
+        .to_string();
+    let d1 = ctx.env.d1("DB")?;
+
+    // Track last opened
+    let _ = d1
+        .prepare(
+            "UPDATE containers SET last_opened_at = datetime('now') WHERE id = ?1 AND user_id = ?2",
+        )
+        .bind(&[id.clone().into(), user_id.clone().into()])?
+        .run()
+        .await;
+
+    let container = d1
+        .prepare(format!(
+            "{CONTAINER_SELECT} WHERE c.id = ?1 AND c.user_id = ?2"
+        ))
+        .bind(&[id.clone().into(), user_id.into()])?
+        .first::<Container>(None)
+        .await?;
+
+    let container = match container {
+        Some(c) => c,
+        None => return Response::error("Not found", 404),
+    };
+
+    // Compute progress (item-level + list-level)
+    let item_progress = d1
+        .prepare(
+            "SELECT \
+             COALESCE(SUM(CASE WHEN i.completed = 1 THEN 1 ELSE 0 END), 0) as completed_items, \
+             COUNT(i.id) as total_items \
+             FROM items i JOIN lists l ON l.id = i.list_id \
+             WHERE l.container_id = ?1",
+        )
+        .bind(&[id.clone().into()])?
+        .first::<serde_json::Value>(None)
+        .await?
+        .unwrap_or_default();
+
+    let list_progress = d1
+        .prepare(
+            "SELECT COUNT(*) as total_lists, \
+             SUM(CASE WHEN NOT EXISTS (\
+               SELECT 1 FROM items i2 WHERE i2.list_id = l.id AND i2.completed = 0\
+             ) AND EXISTS (\
+               SELECT 1 FROM items i3 WHERE i3.list_id = l.id\
+             ) THEN 1 ELSE 0 END) as completed_lists \
+             FROM lists l WHERE l.container_id = ?1",
+        )
+        .bind(&[id.into()])?
+        .first::<serde_json::Value>(None)
+        .await?
+        .unwrap_or_default();
+
+    let completed_items = item_progress
+        .get("completed_items")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0) as u32;
+    let total_items = item_progress
+        .get("total_items")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0) as u32;
+    let completed_lists = list_progress
+        .get("completed_lists")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0) as u32;
+    let total_lists = list_progress
+        .get("total_lists")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0) as u32;
+
+    let detail = ContainerDetail {
+        container,
+        completed_items,
+        total_items,
+        completed_lists,
+        total_lists,
+    };
+
+    Response::from_json(&detail)
+}
+
+pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
+    let user_id = ctx.data.clone();
+    let id = ctx
+        .param("id")
+        .ok_or_else(|| Error::from("Missing id"))?
+        .to_string();
+    let body: UpdateContainerRequest = req.json().await?;
+    let d1 = ctx.env.d1("DB")?;
+
+    // Verify ownership
+    let existing = d1
+        .prepare("SELECT id FROM containers WHERE id = ?1 AND user_id = ?2")
+        .bind(&[id.clone().into(), user_id.into()])?
+        .first::<serde_json::Value>(None)
+        .await?;
+    if existing.is_none() {
+        return Response::error("Not found", 404);
+    }
+
+    if let Some(name) = &body.name {
+        d1.prepare("UPDATE containers SET name = ?1, updated_at = datetime('now') WHERE id = ?2")
+            .bind(&[name.clone().into(), id.clone().into()])?
+            .run()
+            .await?;
+    }
+
+    if let Some(description) = &body.description {
+        d1.prepare(
+            "UPDATE containers SET description = ?1, updated_at = datetime('now') WHERE id = ?2",
+        )
+        .bind(&[description.clone().into(), id.clone().into()])?
+        .run()
+        .await?;
+    }
+
+    if let Some(status_opt) = &body.status {
+        let status_val: JsValue = match status_opt {
+            Some(s) => {
+                let s_str = serde_json::to_value(s)
+                    .map_err(|e| Error::from(e.to_string()))?
+                    .as_str()
+                    .unwrap_or("active")
+                    .to_string();
+                JsValue::from(s_str.as_str())
+            }
+            None => JsValue::NULL,
+        };
+        d1.prepare("UPDATE containers SET status = ?1, updated_at = datetime('now') WHERE id = ?2")
+            .bind(&[status_val, id.clone().into()])?
+            .run()
+            .await?;
+    }
+
+    let container = d1
+        .prepare(format!("{CONTAINER_SELECT} WHERE c.id = ?1"))
+        .bind(&[id.into()])?
+        .first::<Container>(None)
+        .await?
+        .ok_or_else(|| Error::from("Not found"))?;
+
+    Response::from_json(&container)
+}
+
+pub async fn delete(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
+    let user_id = ctx.data.clone();
+    let id = ctx
+        .param("id")
+        .ok_or_else(|| Error::from("Missing id"))?
+        .to_string();
+    let d1 = ctx.env.d1("DB")?;
+
+    // Verify ownership
+    let check = d1
+        .prepare("SELECT id FROM containers WHERE id = ?1 AND user_id = ?2")
+        .bind(&[id.clone().into(), user_id.into()])?
+        .first::<serde_json::Value>(None)
+        .await?;
+    if check.is_none() {
+        return Response::error("Not found", 404);
+    }
+
+    d1.prepare("DELETE FROM containers WHERE id = ?1")
+        .bind(&[id.into()])?
+        .run()
+        .await?;
+
+    Ok(Response::empty()?.with_status(204))
+}
+
+pub async fn get_children(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
+    let user_id = ctx.data.clone();
+    let id = ctx
+        .param("id")
+        .ok_or_else(|| Error::from("Missing id"))?
+        .to_string();
+    let d1 = ctx.env.d1("DB")?;
+
+    // Verify ownership
+    let check = d1
+        .prepare("SELECT id FROM containers WHERE id = ?1 AND user_id = ?2")
+        .bind(&[id.clone().into(), user_id.clone().into()])?
+        .first::<serde_json::Value>(None)
+        .await?;
+    if check.is_none() {
+        return Response::error("Not found", 404);
+    }
+
+    // Get sub-containers
+    let sub_result = d1
+        .prepare(format!(
+            "{CONTAINER_SELECT} WHERE c.parent_container_id = ?1 ORDER BY c.position ASC"
+        ))
+        .bind(&[id.clone().into()])?
+        .all()
+        .await?;
+    let sub_containers = sub_result.results::<Container>()?;
+
+    // Get lists in this container
+    let list_select = super::lists::LIST_SELECT;
+    let list_result = d1
+        .prepare(format!(
+            "{list_select} WHERE l.container_id = ?1 AND l.parent_list_id IS NULL AND l.archived = 0 ORDER BY l.updated_at DESC"
+        ))
+        .bind(&[id.into()])?
+        .all()
+        .await?;
+    let lists = list_result.results::<List>()?;
+
+    let resp = serde_json::json!({
+        "containers": sub_containers,
+        "lists": lists,
+    });
+
+    Response::from_json(&resp)
+}
+
+pub async fn move_container(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
+    let user_id = ctx.data.clone();
+    let id = ctx
+        .param("id")
+        .ok_or_else(|| Error::from("Missing id"))?
+        .to_string();
+    let body: MoveContainerRequest = req.json().await?;
+    let d1 = ctx.env.d1("DB")?;
+
+    // Verify ownership
+    let check = d1
+        .prepare("SELECT id FROM containers WHERE id = ?1 AND user_id = ?2")
+        .bind(&[id.clone().into(), user_id.clone().into()])?
+        .first::<serde_json::Value>(None)
+        .await?;
+    if check.is_none() {
+        return Response::error("Not found", 404);
+    }
+
+    // Validate new parent is not a project
+    if let Some(ref parent_id) = body.parent_container_id {
+        if parent_id == &id {
+            return Response::error("Cannot move container into itself", 400);
+        }
+        let parent = d1
+            .prepare("SELECT status FROM containers WHERE id = ?1 AND user_id = ?2")
+            .bind(&[parent_id.clone().into(), user_id.into()])?
+            .first::<serde_json::Value>(None)
+            .await?;
+        match parent {
+            None => return Response::error("Parent container not found", 404),
+            Some(ref p) => {
+                if !p.get("status").map(|v| v.is_null()).unwrap_or(true) {
+                    return Response::error("Projects cannot contain sub-containers", 400);
+                }
+            }
+        }
+    }
+
+    let parent_val: JsValue = match &body.parent_container_id {
+        Some(p) => JsValue::from(p.as_str()),
+        None => JsValue::NULL,
+    };
+
+    d1.prepare(
+        "UPDATE containers SET parent_container_id = ?1, updated_at = datetime('now') WHERE id = ?2",
+    )
+    .bind(&[parent_val, id.clone().into()])?
+    .run()
+    .await?;
+
+    let container = d1
+        .prepare(format!("{CONTAINER_SELECT} WHERE c.id = ?1"))
+        .bind(&[id.into()])?
+        .first::<Container>(None)
+        .await?
+        .ok_or_else(|| Error::from("Not found"))?;
+
+    Response::from_json(&container)
+}
+
+pub async fn toggle_pin(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
+    let user_id = ctx.data.clone();
+    let id = ctx
+        .param("id")
+        .ok_or_else(|| Error::from("Missing id"))?
+        .to_string();
+    let d1 = ctx.env.d1("DB")?;
+
+    let row = d1
+        .prepare("SELECT pinned FROM containers WHERE id = ?1 AND user_id = ?2")
+        .bind(&[id.clone().into(), user_id.into()])?
+        .first::<serde_json::Value>(None)
+        .await?;
+
+    if row.is_none() {
+        return Response::error("Not found", 404);
+    }
+
+    let current = row
+        .as_ref()
+        .and_then(|r| r.get("pinned"))
+        .and_then(|v| v.as_f64())
+        .map(|f| f != 0.0)
+        .unwrap_or(false);
+
+    let new_val: i32 = if current { 0 } else { 1 };
+    d1.prepare("UPDATE containers SET pinned = ?1, updated_at = datetime('now') WHERE id = ?2")
+        .bind(&[new_val.into(), id.clone().into()])?
+        .run()
+        .await?;
+
+    let container = d1
+        .prepare(format!("{CONTAINER_SELECT} WHERE c.id = ?1"))
+        .bind(&[id.into()])?
+        .first::<Container>(None)
+        .await?
+        .ok_or_else(|| Error::from("Not found"))?;
+
+    Response::from_json(&container)
+}
+
+// === Home endpoint ===
+
+pub async fn home(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
+    let user_id = ctx.data.clone();
+    let d1 = ctx.env.d1("DB")?;
+    let list_select = super::lists::LIST_SELECT;
+
+    // Pinned lists
+    let pinned_lists_result = d1
+        .prepare(format!(
+            "{list_select} WHERE l.user_id = ?1 AND l.pinned = 1 AND l.archived = 0 AND l.parent_list_id IS NULL ORDER BY l.name ASC"
+        ))
+        .bind(&[user_id.clone().into()])?
+        .all()
+        .await?;
+    let pinned_lists = pinned_lists_result.results::<List>()?;
+
+    // Pinned containers
+    let pinned_containers_result = d1
+        .prepare(format!(
+            "{CONTAINER_SELECT} WHERE c.user_id = ?1 AND c.pinned = 1 ORDER BY c.name ASC"
+        ))
+        .bind(&[user_id.clone().into()])?
+        .all()
+        .await?;
+    let pinned_containers = pinned_containers_result.results::<Container>()?;
+
+    // Recent lists (not pinned, has last_opened_at, top 5)
+    let recent_lists_result = d1
+        .prepare(format!(
+            "{list_select} WHERE l.user_id = ?1 AND l.pinned = 0 AND l.last_opened_at IS NOT NULL AND l.archived = 0 AND l.parent_list_id IS NULL ORDER BY l.last_opened_at DESC LIMIT 5"
+        ))
+        .bind(&[user_id.clone().into()])?
+        .all()
+        .await?;
+    let recent_lists = recent_lists_result.results::<List>()?;
+
+    // Recent containers (not pinned, has last_opened_at, top 5)
+    let recent_containers_result = d1
+        .prepare(format!(
+            "{CONTAINER_SELECT} WHERE c.user_id = ?1 AND c.pinned = 0 AND c.last_opened_at IS NOT NULL ORDER BY c.last_opened_at DESC LIMIT 5"
+        ))
+        .bind(&[user_id.clone().into()])?
+        .all()
+        .await?;
+    let recent_containers = recent_containers_result.results::<Container>()?;
+
+    // Root containers (no parent)
+    let root_containers_result = d1
+        .prepare(format!(
+            "{CONTAINER_SELECT} WHERE c.user_id = ?1 AND c.parent_container_id IS NULL ORDER BY c.position ASC, c.created_at ASC"
+        ))
+        .bind(&[user_id.clone().into()])?
+        .all()
+        .await?;
+    let root_containers = root_containers_result.results::<Container>()?;
+
+    // Root lists (no container, no parent list, not archived)
+    let root_lists_result = d1
+        .prepare(format!(
+            "{list_select} WHERE l.user_id = ?1 AND l.container_id IS NULL AND l.parent_list_id IS NULL AND l.archived = 0 ORDER BY l.updated_at DESC"
+        ))
+        .bind(&[user_id.into()])?
+        .all()
+        .await?;
+    let root_lists = root_lists_result.results::<List>()?;
+
+    let resp = serde_json::json!({
+        "pinned_lists": pinned_lists,
+        "pinned_containers": pinned_containers,
+        "recent_lists": recent_lists,
+        "recent_containers": recent_containers,
+        "root_containers": root_containers,
+        "root_lists": root_lists,
+    });
+
+    Response::from_json(&resp)
+}

--- a/crates/api/src/handlers/lists.rs
+++ b/crates/api/src/handlers/lists.rs
@@ -1,9 +1,11 @@
 use kartoteka_shared::*;
+use wasm_bindgen::JsValue;
 use worker::*;
 
-const LIST_SELECT: &str = "\
+pub const LIST_SELECT: &str = "\
     SELECT l.id, l.user_id, l.name, l.description, l.list_type, \
-    l.parent_list_id, l.position, l.archived, l.created_at, l.updated_at, \
+    l.parent_list_id, l.position, l.archived, l.container_id, l.pinned, l.last_opened_at, \
+    l.created_at, l.updated_at, \
     COALESCE((SELECT json_group_array(json_object('name', lf.feature_name, 'config', json(lf.config))) \
     FROM list_features lf WHERE lf.list_id = l.id), '[]') as features \
     FROM lists l";
@@ -13,7 +15,7 @@ pub async fn list_all(_req: Request, ctx: RouteContext<String>) -> Result<Respon
     let d1 = ctx.env.d1("DB")?;
     let result = d1
         .prepare(format!(
-            "{LIST_SELECT} WHERE l.user_id = ?1 AND l.parent_list_id IS NULL AND l.archived = 0 ORDER BY l.updated_at DESC"
+            "{LIST_SELECT} WHERE l.user_id = ?1 AND l.parent_list_id IS NULL AND l.container_id IS NULL AND l.archived = 0 ORDER BY l.updated_at DESC"
         ))
         .bind(&[user_id.into()])?
         .all()
@@ -78,6 +80,14 @@ pub async fn get_one(_req: Request, ctx: RouteContext<String>) -> Result<Respons
         .ok_or_else(|| Error::from("Missing id"))?
         .to_string();
     let d1 = ctx.env.d1("DB")?;
+
+    // Track last opened
+    let _ = d1
+        .prepare("UPDATE lists SET last_opened_at = datetime('now') WHERE id = ?1 AND user_id = ?2")
+        .bind(&[id.clone().into(), user_id.clone().into()])?
+        .run()
+        .await;
+
     let list = d1
         .prepare(format!("{LIST_SELECT} WHERE l.id = ?1 AND l.user_id = ?2"))
         .bind(&[id.into(), user_id.into()])?
@@ -439,6 +449,100 @@ pub async fn remove_feature(_req: Request, ctx: RouteContext<String>) -> Result<
     let list = d1
         .prepare(format!("{LIST_SELECT} WHERE l.id = ?1"))
         .bind(&[list_id.into()])?
+        .first::<List>(None)
+        .await?
+        .ok_or_else(|| Error::from("Not found"))?;
+
+    Response::from_json(&list)
+}
+
+// === Container assignment ===
+
+pub async fn move_list(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
+    let user_id = ctx.data.clone();
+    let id = ctx
+        .param("id")
+        .ok_or_else(|| Error::from("Missing id"))?
+        .to_string();
+    let body: MoveListRequest = req.json().await?;
+    let d1 = ctx.env.d1("DB")?;
+
+    // Verify list ownership
+    let check = d1
+        .prepare("SELECT id FROM lists WHERE id = ?1 AND user_id = ?2")
+        .bind(&[id.clone().into(), user_id.clone().into()])?
+        .first::<serde_json::Value>(None)
+        .await?;
+    if check.is_none() {
+        return Response::error("Not found", 404);
+    }
+
+    // If target container specified, verify ownership
+    if let Some(ref cid) = body.container_id {
+        let ccheck = d1
+            .prepare("SELECT id FROM containers WHERE id = ?1 AND user_id = ?2")
+            .bind(&[cid.clone().into(), user_id.into()])?
+            .first::<serde_json::Value>(None)
+            .await?;
+        if ccheck.is_none() {
+            return Response::error("Container not found", 404);
+        }
+    }
+
+    let cid_val: JsValue = match &body.container_id {
+        Some(cid) => JsValue::from(cid.as_str()),
+        None => JsValue::NULL,
+    };
+
+    d1.prepare("UPDATE lists SET container_id = ?1, updated_at = datetime('now') WHERE id = ?2")
+        .bind(&[cid_val, id.clone().into()])?
+        .run()
+        .await?;
+
+    let list = d1
+        .prepare(format!("{LIST_SELECT} WHERE l.id = ?1"))
+        .bind(&[id.into()])?
+        .first::<List>(None)
+        .await?
+        .ok_or_else(|| Error::from("Not found"))?;
+
+    Response::from_json(&list)
+}
+
+pub async fn toggle_pin(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
+    let user_id = ctx.data.clone();
+    let id = ctx
+        .param("id")
+        .ok_or_else(|| Error::from("Missing id"))?
+        .to_string();
+    let d1 = ctx.env.d1("DB")?;
+
+    let row = d1
+        .prepare("SELECT pinned FROM lists WHERE id = ?1 AND user_id = ?2")
+        .bind(&[id.clone().into(), user_id.into()])?
+        .first::<serde_json::Value>(None)
+        .await?;
+
+    if row.is_none() {
+        return Response::error("Not found", 404);
+    }
+
+    let current = row
+        .as_ref()
+        .and_then(|r| r.get("pinned"))
+        .and_then(|v| v.as_f64())
+        .map(|f| f != 0.0)
+        .unwrap_or(false);
+
+    let new_val: i32 = if current { 0 } else { 1 };
+    d1.prepare("UPDATE lists SET pinned = ?1, updated_at = datetime('now') WHERE id = ?2")
+        .bind(&[new_val.into(), id.clone().into()])?
+        .run()
+        .await?;
+
+    let list = d1
+        .prepare(format!("{LIST_SELECT} WHERE l.id = ?1"))
+        .bind(&[id.into()])?
         .first::<List>(None)
         .await?
         .ok_or_else(|| Error::from("Not found"))?;

--- a/crates/api/src/handlers/mod.rs
+++ b/crates/api/src/handlers/mod.rs
@@ -1,3 +1,4 @@
+pub mod containers;
 pub mod items;
 pub mod lists;
 pub mod tags;

--- a/crates/api/src/helpers.rs
+++ b/crates/api/src/helpers.rs
@@ -15,6 +15,19 @@ pub async fn verify_list_belongs_to_user(
     Ok(check.is_some())
 }
 
+pub async fn verify_container_belongs_to_user(
+    d1: &D1Database,
+    container_id: &str,
+    user_id: &str,
+) -> Result<bool> {
+    let check = d1
+        .prepare("SELECT id FROM containers WHERE id = ?1 AND user_id = ?2")
+        .bind(&[container_id.into(), user_id.into()])?
+        .first::<serde_json::Value>(None)
+        .await?;
+    Ok(check.is_some())
+}
+
 pub async fn verify_item_belongs_to_user(
     d1: &D1Database,
     item_id: &str,

--- a/crates/api/src/router.rs
+++ b/crates/api/src/router.rs
@@ -1,7 +1,7 @@
 use worker::*;
 
 use crate::auth;
-use crate::handlers::{items, lists, tags};
+use crate::handlers::{containers, items, lists, tags};
 
 fn cors_headers() -> Headers {
     let headers = Headers::new();
@@ -46,6 +46,17 @@ pub async fn handle(req: Request, env: Env) -> Result<Response> {
 
     let router = Router::with_data(user_id);
     let response = router
+        // Home
+        .get_async("/api/home", containers::home)
+        // Containers
+        .get_async("/api/containers", containers::list_all)
+        .post_async("/api/containers", containers::create)
+        .get_async("/api/containers/:id", containers::get_one)
+        .put_async("/api/containers/:id", containers::update)
+        .delete_async("/api/containers/:id", containers::delete)
+        .get_async("/api/containers/:id/children", containers::get_children)
+        .patch_async("/api/containers/:id/move", containers::move_container)
+        .patch_async("/api/containers/:id/pin", containers::toggle_pin)
         // Lists
         .get_async("/api/lists", lists::list_all)
         .post_async("/api/lists", lists::create)
@@ -69,6 +80,9 @@ pub async fn handle(req: Request, env: Env) -> Result<Response> {
         // Cross-list queries
         .get_async("/api/items/by-date", items::by_date)
         .get_async("/api/items/calendar", items::calendar)
+        // List container + pin
+        .patch_async("/api/lists/:id/container", lists::move_list)
+        .patch_async("/api/lists/:id/pin", lists::toggle_pin)
         // Item move
         .patch_async("/api/items/:id/move", items::move_item)
         // Tags CRUD

--- a/crates/frontend/src/api/containers.rs
+++ b/crates/frontend/src/api/containers.rs
@@ -1,0 +1,83 @@
+use kartoteka_shared::*;
+
+pub async fn fetch_home() -> Result<serde_json::Value, String> {
+    super::get(&format!("{}/home", super::API_BASE))
+        .send()
+        .await
+        .map_err(|e| e.to_string())?
+        .json()
+        .await
+        .map_err(|e| e.to_string())
+}
+
+pub async fn fetch_containers() -> Result<Vec<Container>, String> {
+    super::get(&format!("{}/containers", super::API_BASE))
+        .send()
+        .await
+        .map_err(|e| e.to_string())?
+        .json()
+        .await
+        .map_err(|e| e.to_string())
+}
+
+pub async fn create_container(req: &CreateContainerRequest) -> Result<Container, String> {
+    super::post_json(&format!("{}/containers", super::API_BASE), req).await
+}
+
+pub async fn fetch_container(id: &str) -> Result<ContainerDetail, String> {
+    super::get(&format!("{}/containers/{id}", super::API_BASE))
+        .send()
+        .await
+        .map_err(|e| e.to_string())?
+        .json()
+        .await
+        .map_err(|e| e.to_string())
+}
+
+pub async fn update_container(id: &str, req: &UpdateContainerRequest) -> Result<Container, String> {
+    super::put_json(&format!("{}/containers/{id}", super::API_BASE), req).await
+}
+
+pub async fn delete_container(id: &str) -> Result<(), String> {
+    let resp = super::del(&format!("{}/containers/{id}", super::API_BASE))
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+    if resp.ok() {
+        Ok(())
+    } else {
+        Err(format!("Błąd serwera: {}", resp.status()))
+    }
+}
+
+pub async fn fetch_container_children(id: &str) -> Result<serde_json::Value, String> {
+    super::get(&format!("{}/containers/{id}/children", super::API_BASE))
+        .send()
+        .await
+        .map_err(|e| e.to_string())?
+        .json()
+        .await
+        .map_err(|e| e.to_string())
+}
+
+pub async fn toggle_container_pin(id: &str) -> Result<Container, String> {
+    super::patch_json(
+        &format!("{}/containers/{id}/pin", super::API_BASE),
+        &serde_json::json!({}),
+    )
+    .await
+}
+
+pub async fn move_list_to_container(
+    list_id: &str,
+    container_id: Option<&str>,
+) -> Result<List, String> {
+    let body = MoveListRequest {
+        container_id: container_id.map(|s| s.to_string()),
+    };
+    super::patch_json(
+        &format!("{}/lists/{list_id}/container", super::API_BASE),
+        &body,
+    )
+    .await
+}

--- a/crates/frontend/src/api/lists.rs
+++ b/crates/frontend/src/api/lists.rs
@@ -1,16 +1,6 @@
 use gloo_net::http::Request;
 use kartoteka_shared::*;
 
-pub async fn fetch_lists() -> Result<Vec<List>, String> {
-    super::get(&format!("{}/lists", super::API_BASE))
-        .send()
-        .await
-        .map_err(|e| e.to_string())?
-        .json()
-        .await
-        .map_err(|e| e.to_string())
-}
-
 pub async fn create_list(req: &CreateListRequest) -> Result<List, String> {
     super::post_json(&format!("{}/lists", super::API_BASE), req).await
 }

--- a/crates/frontend/src/api/mod.rs
+++ b/crates/frontend/src/api/mod.rs
@@ -1,7 +1,9 @@
+mod containers;
 mod items;
 mod lists;
 mod tags;
 
+pub use containers::*;
 pub use items::*;
 pub use lists::*;
 pub use tags::*;

--- a/crates/frontend/src/app.rs
+++ b/crates/frontend/src/app.rs
@@ -5,9 +5,9 @@ use leptos_router::path;
 use crate::components::nav::Nav;
 use crate::components::toast_container::ToastContainer;
 use crate::pages::{
-    calendar::CalendarPage, calendar::day::CalendarDayPage, home::HomePage, list::ListPage,
-    login::LoginPage, settings::SettingsPage, tags::TagsPage, tags::detail::TagDetailPage,
-    today::TodayPage,
+    calendar::CalendarPage, calendar::day::CalendarDayPage, container::ContainerPage,
+    home::HomePage, list::ListPage, login::LoginPage, settings::SettingsPage, tags::TagsPage,
+    tags::detail::TagDetailPage, today::TodayPage,
 };
 
 #[derive(Clone, Debug, PartialEq)]
@@ -81,6 +81,7 @@ pub fn App() -> impl IntoView {
                     <Route path=path!("/tags") view=TagsPage/>
                     <Route path=path!("/tags/:id") view=TagDetailPage/>
                     <Route path=path!("/lists/:id") view=ListPage/>
+                    <Route path=path!("/containers/:id") view=ContainerPage/>
                 </Routes>
             </main>
         </Router>

--- a/crates/frontend/src/components/common/breadcrumbs.rs
+++ b/crates/frontend/src/components/common/breadcrumbs.rs
@@ -1,0 +1,17 @@
+use leptos::prelude::*;
+
+#[component]
+pub fn Breadcrumbs(crumbs: Vec<(String, String)>) -> impl IntoView {
+    view! {
+        <div class="breadcrumbs text-sm mb-4">
+            <ul>
+                <li><a href="/">"Home"</a></li>
+                {crumbs.into_iter().map(|(label, href)| {
+                    view! {
+                        <li><a href=href>{label}</a></li>
+                    }
+                }).collect::<Vec<_>>()}
+            </ul>
+        </div>
+    }
+}

--- a/crates/frontend/src/components/common/mod.rs
+++ b/crates/frontend/src/components/common/mod.rs
@@ -1,3 +1,4 @@
+pub mod breadcrumbs;
 pub mod confirm_delete_modal;
 pub mod date_utils;
 pub mod editable_color;

--- a/crates/frontend/src/components/lists/container_card.rs
+++ b/crates/frontend/src/components/lists/container_card.rs
@@ -1,0 +1,136 @@
+use kartoteka_shared::{Container, ContainerStatus};
+use leptos::prelude::*;
+use leptos_router::hooks::use_navigate;
+
+pub fn container_icon(status: &Option<ContainerStatus>) -> &'static str {
+    match status {
+        None => "📁",
+        Some(ContainerStatus::Active) => "🚀",
+        Some(ContainerStatus::Done) => "✅",
+        Some(ContainerStatus::Paused) => "⏸️",
+    }
+}
+
+pub fn container_status_label(status: &ContainerStatus) -> &'static str {
+    match status {
+        ContainerStatus::Active => "aktywny",
+        ContainerStatus::Done => "ukończony",
+        ContainerStatus::Paused => "wstrzymany",
+    }
+}
+
+pub fn container_status_class(status: &ContainerStatus) -> &'static str {
+    match status {
+        ContainerStatus::Active => "badge badge-success badge-sm",
+        ContainerStatus::Done => "badge badge-neutral badge-sm",
+        ContainerStatus::Paused => "badge badge-warning badge-sm",
+    }
+}
+
+#[component]
+pub fn ContainerCard(
+    container: Container,
+    #[prop(optional)] completed_items: Option<u32>,
+    #[prop(optional)] total_items: Option<u32>,
+    #[prop(optional)] on_delete: Option<Callback<String>>,
+    #[prop(optional)] on_pin: Option<Callback<String>>,
+) -> impl IntoView {
+    let href = format!("/containers/{}", container.id);
+    let icon = container_icon(&container.status);
+    let is_project = container.status.is_some();
+    let is_pinned = container.pinned;
+
+    let navigate = use_navigate();
+    let href_clone = href.clone();
+
+    let container_id_delete = container.id.clone();
+    let container_id_pin = container.id.clone();
+
+    let status_badge = container.status.as_ref().map(|s| {
+        let label = container_status_label(s);
+        let cls = container_status_class(s);
+        view! { <span class=cls>{label}</span> }
+    });
+
+    let progress_bar = if is_project {
+        let total = total_items.unwrap_or(0);
+        let completed = completed_items.unwrap_or(0);
+        let pct = if total > 0 {
+            (completed as f32 / total as f32 * 100.0) as u32
+        } else {
+            0
+        };
+        view! {
+            <div class="mt-2">
+                <div class="flex justify-between text-xs text-base-content/60 mb-1">
+                    <span>{format!("{}/{} zadań", completed, total)}</span>
+                    <span>{format!("{}%", pct)}</span>
+                </div>
+                <progress class="progress progress-primary w-full" value=completed max=total></progress>
+            </div>
+        }.into_any()
+    } else {
+        view! {}.into_any()
+    };
+
+    view! {
+        <div
+            class="card bg-base-200 border border-base-300 cursor-pointer card-neon relative"
+            on:click=move |_| { navigate(&href_clone, Default::default()); }
+        >
+            // Pin button
+            {on_pin.map(|cb| {
+                let cid = container_id_pin.clone();
+                let pin_icon = if is_pinned { "📌" } else { "📍" };
+                view! {
+                    <button
+                        type="button"
+                        aria-label="Przypnij"
+                        class="btn btn-ghost btn-xs absolute top-2 right-8 opacity-40 hover:opacity-100"
+                        on:click=move |ev| {
+                            ev.stop_propagation();
+                            cb.run(cid.clone());
+                        }
+                    >
+                        {pin_icon}
+                    </button>
+                }
+            })}
+
+            // Delete button
+            {on_delete.map(|cb| {
+                let cid = container_id_delete.clone();
+                view! {
+                    <button
+                        type="button"
+                        aria-label="Usuń kontener"
+                        class="btn btn-ghost btn-xs absolute top-2 right-2 opacity-40 hover:opacity-100"
+                        on:click=move |ev| {
+                            ev.stop_propagation();
+                            cb.run(cid.clone());
+                        }
+                    >
+                        "\u{1F5D1}"
+                    </button>
+                }
+            })}
+
+            <div class="card-body p-4">
+                <div class="flex items-center gap-2">
+                    <span class="text-lg">{icon}</span>
+                    <h3 class="card-title text-base">{container.name.clone()}</h3>
+                    {status_badge}
+                    {if is_pinned {
+                        view! { <span class="text-xs opacity-50">"📌"</span> }.into_any()
+                    } else {
+                        view! {}.into_any()
+                    }}
+                </div>
+                {container.description.as_ref().map(|d| view! {
+                    <p class="text-sm text-base-content/60 mt-1">{d.clone()}</p>
+                })}
+                {progress_bar}
+            </div>
+        </div>
+    }
+}

--- a/crates/frontend/src/components/lists/create_entity_input.rs
+++ b/crates/frontend/src/components/lists/create_entity_input.rs
@@ -1,0 +1,181 @@
+use kartoteka_shared::{
+    ContainerStatus, CreateContainerRequest, CreateListRequest, FEATURE_DEADLINES,
+    FEATURE_QUANTITY, ListFeature, ListType,
+};
+use leptos::prelude::*;
+
+use crate::components::items::add_input::AddInput;
+use crate::components::list_card::{list_type_icon, list_type_label};
+
+#[derive(Clone, PartialEq)]
+pub enum EntityMode {
+    List,
+    Folder,
+    Project,
+}
+
+#[component]
+pub fn CreateEntityInput(
+    #[prop(optional)] parent_container_id: Option<String>,
+    /// Whether to show folder/project options (false for projects which can't nest containers)
+    #[prop(default = true)]
+    show_container_options: bool,
+    on_create_list: Callback<CreateListRequest>,
+    on_create_container: Callback<CreateContainerRequest>,
+) -> impl IntoView {
+    let (mode, set_mode) = signal(EntityMode::List);
+    let (new_list_type, set_new_list_type) = signal(ListType::Custom);
+    let (feat_quantity, set_feat_quantity) = signal(false);
+    let (feat_deadlines, set_feat_deadlines) = signal(false);
+
+    let parent_id = parent_container_id.clone();
+
+    let on_submit = Callback::new(move |name: String| {
+        let m = mode.get();
+        match m {
+            EntityMode::List => {
+                let fq = feat_quantity.get();
+                let fd = feat_deadlines.get();
+                let lt = new_list_type.get();
+                let mut features = Vec::new();
+                if fq {
+                    features.push(ListFeature {
+                        name: FEATURE_QUANTITY.into(),
+                        config: serde_json::json!({"unit_default": "szt"}),
+                    });
+                }
+                if fd {
+                    features.push(ListFeature {
+                        name: FEATURE_DEADLINES.into(),
+                        config: serde_json::json!({"has_start_date": false, "has_deadline": true, "has_hard_deadline": false}),
+                    });
+                }
+                on_create_list.run(CreateListRequest {
+                    name,
+                    list_type: lt,
+                    features: Some(features),
+                });
+            }
+            EntityMode::Folder => {
+                on_create_container.run(CreateContainerRequest {
+                    name,
+                    status: None,
+                    parent_container_id: parent_id.clone(),
+                });
+            }
+            EntityMode::Project => {
+                on_create_container.run(CreateContainerRequest {
+                    name,
+                    status: Some(ContainerStatus::Active),
+                    parent_container_id: parent_id.clone(),
+                });
+            }
+        }
+    });
+
+    view! {
+        <div class="mb-4">
+            // Mode tabs
+            <div class="tabs tabs-boxed mb-2 w-fit">
+                <button
+                    type="button"
+                    class=move || if mode.get() == EntityMode::List { "tab tab-active" } else { "tab" }
+                    on:click=move |_| set_mode.set(EntityMode::List)
+                >
+                    "📝 Lista"
+                </button>
+                {if show_container_options {
+                    view! {
+                        <>
+                            <button
+                                type="button"
+                                class=move || if mode.get() == EntityMode::Folder { "tab tab-active" } else { "tab" }
+                                on:click=move |_| set_mode.set(EntityMode::Folder)
+                            >
+                                "📁 Folder"
+                            </button>
+                            <button
+                                type="button"
+                                class=move || if mode.get() == EntityMode::Project { "tab tab-active" } else { "tab" }
+                                on:click=move |_| set_mode.set(EntityMode::Project)
+                            >
+                                "🚀 Projekt"
+                            </button>
+                        </>
+                    }.into_any()
+                } else {
+                    view! {}.into_any()
+                }}
+            </div>
+
+            // List options (only when mode=List)
+            {move || if mode.get() == EntityMode::List {
+                view! {
+                    <div>
+                        <div class="flex flex-wrap gap-2 mb-2">
+                            {[ListType::Checklist, ListType::Zakupy, ListType::Pakowanie, ListType::Terminarz, ListType::Custom]
+                                .into_iter()
+                                .map(|lt| {
+                                    let lt_class = lt.clone();
+                                    let lt_click = lt.clone();
+                                    let icon = list_type_icon(&lt);
+                                    let label = list_type_label(&lt);
+                                    view! {
+                                        <button
+                                            type="button"
+                                            class=move || if new_list_type.get() == lt_class { "btn btn-sm btn-primary" } else { "btn btn-sm btn-outline" }
+                                            on:click=move |_| {
+                                                set_new_list_type.set(lt_click.clone());
+                                                let defaults = lt_click.default_features();
+                                                set_feat_quantity.set(defaults.iter().any(|f| f.name == FEATURE_QUANTITY));
+                                                set_feat_deadlines.set(defaults.iter().any(|f| f.name == FEATURE_DEADLINES));
+                                            }
+                                        >
+                                            {icon} " " {label}
+                                        </button>
+                                    }
+                                })
+                                .collect::<Vec<_>>()}
+                        </div>
+                        <div class="flex items-center gap-4 mb-2">
+                            <label class="label cursor-pointer gap-2">
+                                <input
+                                    type="checkbox"
+                                    class="checkbox checkbox-sm"
+                                    prop:checked=feat_quantity
+                                    on:change=move |ev| set_feat_quantity.set(event_target_checked(&ev))
+                                />
+                                <span class="label-text">"Ilości"</span>
+                            </label>
+                            <label class="label cursor-pointer gap-2">
+                                <input
+                                    type="checkbox"
+                                    class="checkbox checkbox-sm"
+                                    prop:checked=feat_deadlines
+                                    on:change=move |ev| set_feat_deadlines.set(event_target_checked(&ev))
+                                />
+                                <span class="label-text">"Terminy"</span>
+                            </label>
+                        </div>
+                    </div>
+                }.into_any()
+            } else {
+                view! {}.into_any()
+            }}
+
+            // Input
+            <div class="flex gap-2">
+                {move || {
+                    let placeholder = match mode.get() {
+                        EntityMode::List => "Nazwa nowej listy...",
+                        EntityMode::Folder => "Nazwa nowego folderu...",
+                        EntityMode::Project => "Nazwa nowego projektu...",
+                    };
+                    view! {
+                        <AddInput placeholder=placeholder button_label="Dodaj" on_submit=on_submit />
+                    }
+                }}
+            </div>
+        </div>
+    }
+}

--- a/crates/frontend/src/components/lists/mod.rs
+++ b/crates/frontend/src/components/lists/mod.rs
@@ -1,4 +1,6 @@
 pub mod add_group_input;
+pub mod container_card;
+pub mod create_entity_input;
 pub mod list_card;
 pub mod list_header;
 pub mod list_tag_bar;

--- a/crates/frontend/src/components/mod.rs
+++ b/crates/frontend/src/components/mod.rs
@@ -18,4 +18,6 @@ pub use tags::tag_badge;
 pub use tags::tag_list;
 pub use tags::tag_tree;
 
+pub use lists::container_card;
+pub use lists::create_entity_input;
 pub use lists::list_card;

--- a/crates/frontend/src/pages/container.rs
+++ b/crates/frontend/src/pages/container.rs
@@ -1,0 +1,411 @@
+use kartoteka_shared::{
+    Container, ContainerDetail, ContainerStatus, CreateContainerRequest, CreateListRequest, List,
+    UpdateContainerRequest,
+};
+use leptos::prelude::*;
+use leptos_router::hooks::use_params_map;
+
+use crate::api;
+use crate::app::{ToastContext, ToastKind};
+use crate::components::common::breadcrumbs::Breadcrumbs;
+use crate::components::common::editable_description::EditableDescription;
+use crate::components::common::editable_title::EditableTitle;
+use crate::components::confirm_delete_modal::ConfirmDeleteModal;
+use crate::components::container_card::ContainerCard;
+use crate::components::create_entity_input::CreateEntityInput;
+use crate::components::list_card::ListCard;
+
+async fn build_breadcrumbs(
+    container_id: &str,
+    all_containers: &[Container],
+) -> Vec<(String, String)> {
+    let mut crumbs = Vec::new();
+    let mut current_id = Some(container_id.to_string());
+
+    // Walk up the parent chain (max depth guard: 10)
+    let mut chain = Vec::new();
+    let mut depth = 0;
+    while let Some(ref cid) = current_id.clone() {
+        if depth > 10 {
+            break;
+        }
+        if let Some(c) = all_containers.iter().find(|c| &c.id == cid) {
+            chain.push((c.name.clone(), format!("/containers/{}", c.id)));
+            current_id = c.parent_container_id.clone();
+        } else {
+            break;
+        }
+        depth += 1;
+    }
+    chain.reverse();
+    // Remove the last item (current page, will be shown as plain text by the page title)
+    if !chain.is_empty() {
+        chain.pop();
+    }
+    crumbs.extend(chain);
+    crumbs
+}
+
+#[component]
+pub fn ContainerPage() -> impl IntoView {
+    let params = use_params_map();
+    let container_id = move || params.read().get("id").unwrap_or_default();
+
+    let toast = use_context::<ToastContext>().expect("ToastContext missing");
+
+    let (refresh, set_refresh) = signal(0u32);
+    let detail = RwSignal::new(Option::<ContainerDetail>::None);
+    let sub_containers = RwSignal::new(Vec::<Container>::new());
+    let sub_lists = RwSignal::new(Vec::<List>::new());
+    let breadcrumbs = RwSignal::new(Vec::<(String, String)>::new());
+    let (loading, set_loading) = signal(true);
+    let pending_delete_list = RwSignal::new(Option::<(String, String)>::None);
+
+    let cid = container_id();
+    leptos::task::spawn_local({
+        let cid = cid.clone();
+        async move {
+            // Fetch container detail
+            if let Ok(det) = api::fetch_container(&cid).await {
+                detail.set(Some(det));
+            }
+
+            // Fetch children
+            if let Ok(children) = api::fetch_container_children(&cid).await {
+                if let Some(sc) = children
+                    .get("containers")
+                    .and_then(|v| serde_json::from_value::<Vec<Container>>(v.clone()).ok())
+                {
+                    sub_containers.set(sc);
+                }
+                if let Some(sl) = children
+                    .get("lists")
+                    .and_then(|v| serde_json::from_value::<Vec<List>>(v.clone()).ok())
+                {
+                    sub_lists.set(sl);
+                }
+            }
+
+            // Fetch all containers for breadcrumbs
+            if let Ok(all) = api::fetch_containers().await {
+                let crumbs = build_breadcrumbs(&cid, &all).await;
+                breadcrumbs.set(crumbs);
+            }
+
+            set_loading.set(false);
+        }
+    });
+
+    // Reload on refresh signal
+    let cid_refresh = cid.clone();
+    Effect::new(move |_| {
+        let r = refresh.get();
+        if r == 0 {
+            return;
+        } // Skip initial run
+        let cid = cid_refresh.clone();
+        leptos::task::spawn_local(async move {
+            if let Ok(det) = api::fetch_container(&cid).await {
+                detail.set(Some(det));
+            }
+            if let Ok(children) = api::fetch_container_children(&cid).await {
+                if let Some(sc) = children
+                    .get("containers")
+                    .and_then(|v| serde_json::from_value::<Vec<Container>>(v.clone()).ok())
+                {
+                    sub_containers.set(sc);
+                }
+                if let Some(sl) = children
+                    .get("lists")
+                    .and_then(|v| serde_json::from_value::<Vec<List>>(v.clone()).ok())
+                {
+                    sub_lists.set(sl);
+                }
+            }
+        });
+    });
+
+    let cid_create = cid.clone();
+    let is_project = move || {
+        detail
+            .get()
+            .map(|d| d.container.status.is_some())
+            .unwrap_or(false)
+    };
+
+    let on_create_list = Callback::new(move |req: CreateListRequest| {
+        let cid = cid_create.clone();
+        leptos::task::spawn_local(async move {
+            match api::create_list(&req).await {
+                Ok(mut list) => {
+                    // Move new list into this container
+                    let _ = api::move_list_to_container(&list.id, Some(&cid)).await;
+                    list.container_id = Some(cid);
+                    sub_lists.update(|ls| ls.push(list));
+                }
+                Err(e) => toast.push(e, ToastKind::Error),
+            }
+        });
+    });
+
+    let on_create_container = Callback::new(move |req: CreateContainerRequest| {
+        leptos::task::spawn_local(async move {
+            match api::create_container(&req).await {
+                Ok(c) => sub_containers.update(|cs| cs.push(c)),
+                Err(e) => toast.push(e, ToastKind::Error),
+            }
+        });
+    });
+
+    view! {
+        <div class="container mx-auto max-w-2xl p-4">
+            {move || {
+                let crumbs = breadcrumbs.get();
+                if !crumbs.is_empty() {
+                    view! { <Breadcrumbs crumbs=crumbs /> }.into_any()
+                } else {
+                    view! {}.into_any()
+                }
+            }}
+
+            {move || {
+                if loading.get() {
+                    return view! { <p>"Wczytywanie..."</p> }.into_any();
+                }
+
+                let det = detail.get();
+                let Some(det) = det else {
+                    return view! { <p class="text-error">"Nie znaleziono kontenera"</p> }.into_any();
+                };
+
+                let container = det.container.clone();
+                let cid = container.id.clone();
+                let cid_name = cid.clone();
+                let cid_desc = cid.clone();
+                let cid_status = cid.clone();
+                let is_proj = container.status.is_some();
+                let completed_items = det.completed_items;
+                let total_items = det.total_items;
+                let completed_lists = det.completed_lists;
+                let total_lists_count = det.total_lists;
+
+                view! {
+                    <div>
+                        // Header
+                        <div class="mb-4">
+                            <div class="flex items-center gap-2 mb-1">
+                                <span class="text-2xl">
+                                    {if is_proj { "🚀" } else { "📁" }}
+                                </span>
+                                <EditableTitle
+                                    value=container.name.clone()
+                                    on_save=Callback::new(move |name: String| {
+                                        let cid = cid_name.clone();
+                                        leptos::task::spawn_local(async move {
+                                            let req = UpdateContainerRequest {
+                                                name: Some(name),
+                                                description: None,
+                                                status: None,
+                                            };
+                                            match api::update_container(&cid, &req).await {
+                                                Ok(c) => detail.update(|d| {
+                                                    if let Some(det) = d {
+                                                        det.container.name = c.name;
+                                                    }
+                                                }),
+                                                Err(e) => toast.push(e, ToastKind::Error),
+                                            }
+                                        });
+                                    })
+                                />
+                            </div>
+
+                            <EditableDescription
+                                value=container.description.clone()
+                                on_save=Callback::new(move |desc: Option<String>| {
+                                    let cid = cid_desc.clone();
+                                    leptos::task::spawn_local(async move {
+                                        let req = UpdateContainerRequest {
+                                            name: None,
+                                            description: desc,
+                                            status: None,
+                                        };
+                                        let _ = api::update_container(&cid, &req).await;
+                                    });
+                                })
+                            />
+                        </div>
+
+                        // Project status + progress
+                        {if is_proj {
+                            let status_str = match &container.status {
+                                Some(ContainerStatus::Active) => "active",
+                                Some(ContainerStatus::Done) => "done",
+                                Some(ContainerStatus::Paused) => "paused",
+                                None => "active",
+                            };
+                            let pct = if total_items > 0 {
+                                (completed_items as f32 / total_items as f32 * 100.0) as u32
+                            } else { 0 };
+
+                            view! {
+                                <div class="mb-4 p-4 bg-base-200 rounded-lg">
+                                    // Status selector
+                                    <div class="flex items-center gap-2 mb-3">
+                                        <span class="text-sm font-medium">"Status:"</span>
+                                        <select
+                                            class="select select-sm select-bordered"
+                                            on:change=move |ev| {
+                                                let val = event_target_value(&ev);
+                                                let new_status = match val.as_str() {
+                                                    "active" => Some(ContainerStatus::Active),
+                                                    "done" => Some(ContainerStatus::Done),
+                                                    "paused" => Some(ContainerStatus::Paused),
+                                                    _ => None,
+                                                };
+                                                let cid = cid_status.clone();
+                                                leptos::task::spawn_local(async move {
+                                                    let req = UpdateContainerRequest {
+                                                        name: None,
+                                                        description: None,
+                                                        status: Some(new_status),
+                                                    };
+                                                    match api::update_container(&cid, &req).await {
+                                                        Ok(c) => detail.update(|d| {
+                                                            if let Some(det) = d {
+                                                                det.container.status = c.status;
+                                                            }
+                                                        }),
+                                                        Err(e) => toast.push(e, ToastKind::Error),
+                                                    }
+                                                });
+                                            }
+                                        >
+                                            <option value="active" selected=move || status_str == "active">"Aktywny"</option>
+                                            <option value="done" selected=move || status_str == "done">"Ukończony"</option>
+                                            <option value="paused" selected=move || status_str == "paused">"Wstrzymany"</option>
+                                        </select>
+                                    </div>
+
+                                    // Item-level progress
+                                    <div class="mb-2">
+                                        <div class="flex justify-between text-xs text-base-content/60 mb-1">
+                                            <span>"Zadania: " {completed_items} "/" {total_items}</span>
+                                            <span>{pct}"%"</span>
+                                        </div>
+                                        <progress class="progress progress-primary w-full" value=completed_items max=total_items.max(1)></progress>
+                                    </div>
+
+                                    // List-level progress
+                                    <div class="text-xs text-base-content/60">
+                                        "Listy ukończone: " {completed_lists} "/" {total_lists_count}
+                                    </div>
+                                </div>
+                            }.into_any()
+                        } else {
+                            view! {}.into_any()
+                        }}
+
+                        // Create entity input
+                        <CreateEntityInput
+                            parent_container_id=container.id.clone()
+                            show_container_options=!is_project()
+                            on_create_list=on_create_list
+                            on_create_container=on_create_container
+                        />
+
+                        // Sub-containers
+                        {move || {
+                            let scs = sub_containers.get();
+                            if scs.is_empty() {
+                                view! {}.into_any()
+                            } else {
+                                view! {
+                                    <div class="mb-4">
+                                        <h3 class="text-sm font-semibold text-base-content/60 mb-2 uppercase tracking-wide">"Kontenery"</h3>
+                                        <div class="flex flex-col gap-3">
+                                            {scs.into_iter().map(|c| {
+                                                let cid_del = c.id.clone();
+                                                view! {
+                                                    <ContainerCard
+                                                        container=c
+                                                        on_delete=Callback::new(move |_: String| {
+                                                            let cid = cid_del.clone();
+                                                            leptos::task::spawn_local(async move {
+                                                                match api::delete_container(&cid).await {
+                                                                    Ok(()) => {
+                                                                        sub_containers.update(|cs| cs.retain(|c| c.id != cid));
+                                                                        toast.push("Kontener usunięty".into(), ToastKind::Success);
+                                                                    }
+                                                                    Err(e) => toast.push(e, ToastKind::Error),
+                                                                }
+                                                            });
+                                                        })
+                                                    />
+                                                }
+                                            }).collect::<Vec<_>>()}
+                                        </div>
+                                    </div>
+                                }.into_any()
+                            }
+                        }}
+
+                        // Lists in container
+                        {move || {
+                            let lists = sub_lists.get();
+                            if lists.is_empty() {
+                                view! { <div class="text-center text-base-content/50 py-8">"Brak list w tym kontenerze."</div> }.into_any()
+                            } else {
+                                view! {
+                                    <div class="mb-4">
+                                        <h3 class="text-sm font-semibold text-base-content/60 mb-2 uppercase tracking-wide">"Listy"</h3>
+                                        <div class="flex flex-col gap-3">
+                                            {lists.into_iter().map(|list| {
+                                                let lid_del = list.id.clone();
+                                                let lname_del = list.name.clone();
+                                                view! {
+                                                    <ListCard
+                                                        list
+                                                        on_delete=Callback::new(move |_: String| {
+                                                            pending_delete_list.set(Some((lid_del.clone(), lname_del.clone())));
+                                                        })
+                                                    />
+                                                }
+                                            }).collect::<Vec<_>>()}
+                                        </div>
+                                    </div>
+                                }.into_any()
+                            }
+                        }}
+
+                        // Delete list modal
+                        {move || pending_delete_list.get().map(|(lid, lname)| {
+                            let lid_confirm = lid.clone();
+                            view! {
+                                <ConfirmDeleteModal
+                                    list_id=lid
+                                    list_name=lname
+                                    on_confirm=Callback::new(move |_| {
+                                        let lid = lid_confirm.clone();
+                                        leptos::task::spawn_local(async move {
+                                            sub_lists.update(|ls| ls.retain(|l| l.id != lid));
+                                            pending_delete_list.set(None);
+                                            match api::delete_list(&lid).await {
+                                                Ok(()) => toast.push("Lista usunięta".into(), ToastKind::Success),
+                                                Err(e) => {
+                                                    set_refresh.update(|n| *n += 1);
+                                                    toast.push(e, ToastKind::Error);
+                                                }
+                                            }
+                                        });
+                                    })
+                                    on_cancel=Callback::new(move |_| pending_delete_list.set(None))
+                                />
+                            }
+                        })}
+                    </div>
+                }.into_any()
+            }}
+        </div>
+    }
+}

--- a/crates/frontend/src/pages/container.rs
+++ b/crates/frontend/src/pages/container.rs
@@ -61,49 +61,18 @@ pub fn ContainerPage() -> impl IntoView {
     let (loading, set_loading) = signal(true);
     let pending_delete_list = RwSignal::new(Option::<(String, String)>::None);
 
-    let cid = container_id();
-    leptos::task::spawn_local({
-        let cid = cid.clone();
-        async move {
-            // Fetch container detail
-            if let Ok(det) = api::fetch_container(&cid).await {
-                detail.set(Some(det));
-            }
-
-            // Fetch children
-            if let Ok(children) = api::fetch_container_children(&cid).await {
-                if let Some(sc) = children
-                    .get("containers")
-                    .and_then(|v| serde_json::from_value::<Vec<Container>>(v.clone()).ok())
-                {
-                    sub_containers.set(sc);
-                }
-                if let Some(sl) = children
-                    .get("lists")
-                    .and_then(|v| serde_json::from_value::<Vec<List>>(v.clone()).ok())
-                {
-                    sub_lists.set(sl);
-                }
-            }
-
-            // Fetch all containers for breadcrumbs
-            if let Ok(all) = api::fetch_containers().await {
-                let crumbs = build_breadcrumbs(&cid, &all).await;
-                breadcrumbs.set(crumbs);
-            }
-
-            set_loading.set(false);
-        }
-    });
-
-    // Reload on refresh signal
-    let cid_refresh = cid.clone();
+    // Reactive effect: re-runs whenever container_id or refresh changes.
+    // This ensures navigating folder→folder (same route, different :id) re-fetches data.
     Effect::new(move |_| {
-        let r = refresh.get();
-        if r == 0 {
-            return;
-        } // Skip initial run
-        let cid = cid_refresh.clone();
+        let cid = container_id();
+        let _r = refresh.get(); // track refresh signal too
+
+        detail.set(None);
+        sub_containers.set(vec![]);
+        sub_lists.set(vec![]);
+        breadcrumbs.set(vec![]);
+        set_loading.set(true);
+
         leptos::task::spawn_local(async move {
             if let Ok(det) = api::fetch_container(&cid).await {
                 detail.set(Some(det));
@@ -122,10 +91,14 @@ pub fn ContainerPage() -> impl IntoView {
                     sub_lists.set(sl);
                 }
             }
+            if let Ok(all) = api::fetch_containers().await {
+                let crumbs = build_breadcrumbs(&cid, &all).await;
+                breadcrumbs.set(crumbs);
+            }
+            set_loading.set(false);
         });
     });
 
-    let cid_create = cid.clone();
     let is_project = move || {
         detail
             .get()
@@ -134,7 +107,7 @@ pub fn ContainerPage() -> impl IntoView {
     };
 
     let on_create_list = Callback::new(move |req: CreateListRequest| {
-        let cid = cid_create.clone();
+        let cid = container_id();
         leptos::task::spawn_local(async move {
             match api::create_list(&req).await {
                 Ok(mut list) => {

--- a/crates/frontend/src/pages/home.rs
+++ b/crates/frontend/src/pages/home.rs
@@ -1,18 +1,17 @@
 use kartoteka_shared::{
-    CreateListRequest, FEATURE_DEADLINES, FEATURE_QUANTITY, List, ListFeature, ListTagLink,
-    ListType, Tag,
+    Container, CreateContainerRequest, CreateListRequest, List, ListTagLink, Tag,
 };
 use leptos::prelude::*;
 
 use crate::api;
 use crate::app::{ToastContext, ToastKind};
-use crate::components::add_input::AddInput;
 use crate::components::confirm_delete_modal::ConfirmDeleteModal;
-use crate::components::list_card::{ListCard, list_type_icon, list_type_label};
+use crate::components::container_card::ContainerCard;
+use crate::components::create_entity_input::CreateEntityInput;
+use crate::components::list_card::{ListCard, list_type_icon};
 
 #[component]
 pub fn HomePage() -> impl IntoView {
-    // Redirect to login if no Hanko token
     if !api::is_logged_in() {
         if let Some(w) = web_sys::window() {
             let _ = w.location().set_href("/login");
@@ -21,25 +20,62 @@ pub fn HomePage() -> impl IntoView {
 
     let toast = use_context::<ToastContext>().expect("ToastContext missing");
 
-    let (new_list_type, set_new_list_type) = signal(ListType::Custom);
-    let (feat_quantity, set_feat_quantity) = signal(false);
-    let (feat_deadlines, set_feat_deadlines) = signal(false);
     let (refresh, set_refresh) = signal(0u32);
     let (active_tag_filter, set_active_tag_filter) = signal(Option::<String>::None);
-
-    // pending_delete: (list_id, list_name) — drives the modal
     let pending_delete = RwSignal::new(Option::<(String, String)>::None);
 
-    // Lists: fetched via LocalResource, kept in writable RwSignal for optimistic updates
-    let lists_res = LocalResource::new(move || {
+    // Home data: pinned + recent + root
+    let home_res = LocalResource::new(move || {
         let _ = refresh.get();
-        api::fetch_lists()
+        api::fetch_home()
     });
-    let lists_data = RwSignal::new(Vec::<List>::new());
+
+    let pinned_lists = RwSignal::new(Vec::<List>::new());
+    let pinned_containers = RwSignal::new(Vec::<Container>::new());
+    let recent_lists = RwSignal::new(Vec::<List>::new());
+    let recent_containers = RwSignal::new(Vec::<Container>::new());
+    let root_containers = RwSignal::new(Vec::<Container>::new());
+    let root_lists = RwSignal::new(Vec::<List>::new());
+
     Effect::new(move |_| {
-        if let Some(data) = lists_res.get() {
-            if let Ok(lists) = data.as_deref() {
-                lists_data.set(lists.to_vec());
+        if let Some(data) = home_res.get() {
+            if let Ok(v) = &*data {
+                if let Some(pl) = v
+                    .get("pinned_lists")
+                    .and_then(|x| serde_json::from_value::<Vec<List>>(x.clone()).ok())
+                {
+                    pinned_lists.set(pl);
+                }
+                if let Some(pc) = v
+                    .get("pinned_containers")
+                    .and_then(|x| serde_json::from_value::<Vec<Container>>(x.clone()).ok())
+                {
+                    pinned_containers.set(pc);
+                }
+                if let Some(rl) = v
+                    .get("recent_lists")
+                    .and_then(|x| serde_json::from_value::<Vec<List>>(x.clone()).ok())
+                {
+                    recent_lists.set(rl);
+                }
+                if let Some(rc) = v
+                    .get("recent_containers")
+                    .and_then(|x| serde_json::from_value::<Vec<Container>>(x.clone()).ok())
+                {
+                    recent_containers.set(rc);
+                }
+                if let Some(rcc) = v
+                    .get("root_containers")
+                    .and_then(|x| serde_json::from_value::<Vec<Container>>(x.clone()).ok())
+                {
+                    root_containers.set(rcc);
+                }
+                if let Some(rll) = v
+                    .get("root_lists")
+                    .and_then(|x| serde_json::from_value::<Vec<List>>(x.clone()).ok())
+                {
+                    root_lists.set(rll);
+                }
             }
         }
     });
@@ -63,7 +99,6 @@ pub fn HomePage() -> impl IntoView {
         let _ = refresh.get();
         api::fetch_list_tag_links()
     });
-
     let list_tag_links = RwSignal::new(Vec::<ListTagLink>::new());
     Effect::new(move |_| {
         if let Some(data) = links_res.get() {
@@ -81,10 +116,8 @@ pub fn HomePage() -> impl IntoView {
         if has_tag {
             list_tag_links
                 .update(|links| links.retain(|l| !(l.list_id == list_id && l.tag_id == tag_id)));
-            let lid = list_id.clone();
-            let tid = tag_id.clone();
             leptos::task::spawn_local(async move {
-                let _ = api::remove_tag_from_list(&lid, &tid).await;
+                let _ = api::remove_tag_from_list(&list_id, &tag_id).await;
             });
         } else {
             list_tag_links.update(|links| {
@@ -93,45 +126,33 @@ pub fn HomePage() -> impl IntoView {
                     tag_id: tag_id.clone(),
                 })
             });
-            let lid = list_id.clone();
-            let tid = tag_id.clone();
             leptos::task::spawn_local(async move {
-                let _ = api::assign_tag_to_list(&lid, &tid).await;
+                let _ = api::assign_tag_to_list(&list_id, &tag_id).await;
             });
         }
     });
 
-    let on_create = Callback::new(move |name: String| {
-        let list_type = new_list_type.get();
-        let fq = feat_quantity.get();
-        let fd = feat_deadlines.get();
+    let on_create_list = Callback::new(move |req: CreateListRequest| {
         leptos::task::spawn_local(async move {
-            let mut features = Vec::new();
-            if fq {
-                features.push(ListFeature {
-                    name: FEATURE_QUANTITY.into(),
-                    config: serde_json::json!({"unit_default": "szt"}),
-                });
+            match api::create_list(&req).await {
+                Ok(_) => set_refresh.update(|n| *n += 1),
+                Err(e) => toast.push(e, ToastKind::Error),
             }
-            if fd {
-                features.push(ListFeature {
-                    name: FEATURE_DEADLINES.into(),
-                    config: serde_json::json!({"has_start_date": false, "has_deadline": true, "has_hard_deadline": false}),
-                });
+        });
+    });
+
+    let on_create_container = Callback::new(move |req: CreateContainerRequest| {
+        leptos::task::spawn_local(async move {
+            match api::create_container(&req).await {
+                Ok(_) => set_refresh.update(|n| *n += 1),
+                Err(e) => toast.push(e, ToastKind::Error),
             }
-            let req = CreateListRequest {
-                name,
-                list_type,
-                features: Some(features),
-            };
-            let _ = api::create_list(&req).await;
-            set_refresh.update(|n| *n += 1);
         });
     });
 
     view! {
         <div class="container mx-auto max-w-2xl p-4">
-            <h2 class="text-2xl font-bold mb-4">"Twoje listy"</h2>
+            <h2 class="text-2xl font-bold mb-4">"Kartoteka"</h2>
 
             // Tag filter bar
             <Suspense fallback=|| view! {}>
@@ -171,65 +192,14 @@ pub fn HomePage() -> impl IntoView {
                 })}
             </Suspense>
 
-            // Create form — preset picker
-            <div class="mb-4">
-                <div class="flex flex-wrap gap-2 mb-2">
-                    {[ListType::Checklist, ListType::Zakupy, ListType::Pakowanie, ListType::Terminarz, ListType::Custom]
-                        .into_iter()
-                        .map(|lt| {
-                            let lt_for_class = lt.clone();
-                            let lt_for_click = lt.clone();
-                            let icon = list_type_icon(&lt);
-                            let label = list_type_label(&lt);
-                            view! {
-                                <button
-                                    type="button"
-                                    class=move || {
-                                        if new_list_type.get() == lt_for_class {
-                                            "btn btn-sm btn-primary"
-                                        } else {
-                                            "btn btn-sm btn-outline"
-                                        }
-                                    }
-                                    on:click=move |_| {
-                                        set_new_list_type.set(lt_for_click.clone());
-                                        let defaults = lt_for_click.default_features();
-                                        set_feat_quantity.set(defaults.iter().any(|f| f.name == FEATURE_QUANTITY));
-                                        set_feat_deadlines.set(defaults.iter().any(|f| f.name == FEATURE_DEADLINES));
-                                    }
-                                >
-                                    {icon} " " {label}
-                                </button>
-                            }
-                        })
-                        .collect::<Vec<_>>()}
-                </div>
-                <div class="flex items-center gap-4 mb-2">
-                    <label class="label cursor-pointer gap-2">
-                        <input
-                            type="checkbox"
-                            class="checkbox checkbox-sm"
-                            prop:checked=feat_quantity
-                            on:change=move |ev| set_feat_quantity.set(event_target_checked(&ev))
-                        />
-                        <span class="label-text">"Ilości"</span>
-                    </label>
-                    <label class="label cursor-pointer gap-2">
-                        <input
-                            type="checkbox"
-                            class="checkbox checkbox-sm"
-                            prop:checked=feat_deadlines
-                            on:change=move |ev| set_feat_deadlines.set(event_target_checked(&ev))
-                        />
-                        <span class="label-text">"Terminy"</span>
-                    </label>
-                </div>
-                <div class="flex gap-2">
-                    <AddInput placeholder="Nazwa nowej listy..." button_label="Dodaj" on_submit=on_create />
-                </div>
-            </div>
+            // Create form
+            <CreateEntityInput
+                show_container_options=true
+                on_create_list=on_create_list
+                on_create_container=on_create_container
+            />
 
-            // Delete confirmation modal (conditionally rendered)
+            // Delete confirmation modal
             {move || pending_delete.get().map(|(lid, lname)| {
                 let lid_confirm = lid.clone();
                 view! {
@@ -239,18 +209,18 @@ pub fn HomePage() -> impl IntoView {
                         on_confirm=Callback::new(move |_| {
                             let lid = lid_confirm.clone();
                             leptos::task::spawn_local(async move {
-                                // Optimistic: remove from local signal
-                                let removed_idx = lists_data.read().iter().position(|l| l.id == lid);
-                                let removed = lists_data.read().iter().find(|l| l.id == lid).cloned();
-                                lists_data.update(|ls| ls.retain(|l| l.id != lid));
+                                let removed_idx = root_lists.read().iter().position(|l| l.id == lid);
+                                let removed = root_lists.read().iter().find(|l| l.id == lid).cloned();
+                                root_lists.update(|ls| ls.retain(|l| l.id != lid));
+                                pinned_lists.update(|ls| ls.retain(|l| l.id != lid));
+                                recent_lists.update(|ls| ls.retain(|l| l.id != lid));
                                 pending_delete.set(None);
 
                                 match api::delete_list(&lid).await {
                                     Ok(()) => toast.push("Lista usunięta".into(), ToastKind::Success),
                                     Err(e) => {
-                                        // Rollback at original position
                                         if let (Some(list), Some(idx)) = (removed, removed_idx) {
-                                            lists_data.update(|ls| {
+                                            root_lists.update(|ls| {
                                                 let idx = idx.min(ls.len());
                                                 ls.insert(idx, list);
                                             });
@@ -265,8 +235,11 @@ pub fn HomePage() -> impl IntoView {
                 }
             })}
 
-            // Lists grid
             {move || {
+                if home_res.get().is_none() {
+                    return view! { <p>"Wczytywanie..."</p> }.into_any();
+                }
+
                 let tags_data = tags_res.get();
                 let all_tags: Vec<Tag> = tags_data
                     .as_ref()
@@ -276,58 +249,222 @@ pub fn HomePage() -> impl IntoView {
                 let all_links = list_tag_links.get();
                 let filter = active_tag_filter.get();
 
-                // Show loading while resource hasn't resolved yet
-                if lists_res.get().is_none() {
-                    return view! {
-                        <p>"Wczytywanie..."</p>
-                    }.into_any();
-                }
+                let pl = pinned_lists.get();
+                let pc = pinned_containers.get();
+                let rl = recent_lists.get();
+                let rc = recent_containers.get();
+                let rc_list = root_containers.get();
+                let rll = root_lists.get();
 
-                let all_lists = lists_data.get();
-                if all_lists.is_empty() {
-                    return view! {
-                        <div class="text-center text-base-content/50 py-12">"Brak list. Utwórz pierwszą!"</div>
-                    }.into_any();
-                }
-
-                let filtered_lists: Vec<List> = all_lists
-                    .iter()
-                    .filter(|l| match &filter {
-                        None => true,
-                        Some(tag_id) => all_links
-                            .iter()
-                            .any(|link| link.list_id == l.id && &link.tag_id == tag_id),
-                    })
-                    .cloned()
-                    .collect();
+                let filter_list = |list: &List| match &filter {
+                    None => true,
+                    Some(tag_id) => all_links
+                        .iter()
+                        .any(|link| link.list_id == list.id && &link.tag_id == tag_id),
+                };
 
                 view! {
-                    <div class="flex flex-col gap-3">
-                        {filtered_lists.into_iter().map(|list| {
-                            let list_id = list.id.clone();
-                            let list_name = list.name.clone();
-                            let list_tag_ids: Vec<String> = all_links
-                                .iter()
-                                .filter(|l| l.list_id == list.id)
-                                .map(|l| l.tag_id.clone())
-                                .collect();
-                            let tog = on_list_tag_toggle.clone();
-                            let tag_cb = Callback::new(move |tag_id: String| {
-                                tog.run((list_id.clone(), tag_id));
-                            });
-                            let lid = list.id.clone();
+                    <div>
+                        // === Pinned section ===
+                        {if !pl.is_empty() || !pc.is_empty() {
+                            let pl = pl.clone();
+                            let pc = pc.clone();
+                            let all_tags = all_tags.clone();
+                            let all_links = all_links.clone();
                             view! {
-                                <ListCard
-                                    list
-                                    all_tags=all_tags.clone()
-                                    list_tag_ids
-                                    on_tag_toggle=tag_cb
-                                    on_delete=Callback::new(move |_: String| {
-                                        pending_delete.set(Some((lid.clone(), list_name.clone())));
-                                    })
-                                />
+                                <div class="collapse collapse-arrow bg-base-200 mb-4">
+                                    <input type="checkbox" checked />
+                                    <div class="collapse-title font-semibold">"📌 Przypięte"</div>
+                                    <div class="collapse-content">
+                                        <div class="flex flex-col gap-3 pt-2">
+                                            {pc.into_iter().map(|c| {
+                                                let cid = c.id.clone();
+                                                view! {
+                                                    <ContainerCard
+                                                        container=c
+                                                        on_pin=Callback::new(move |_| {
+                                                            let cid = cid.clone();
+                                                            leptos::task::spawn_local(async move {
+                                                                let _ = api::toggle_container_pin(&cid).await;
+                                                                set_refresh.update(|n| *n += 1);
+                                                            });
+                                                        })
+                                                    />
+                                                }
+                                            }).collect::<Vec<_>>()}
+                                            {pl.into_iter().filter(|l| filter_list(l)).map(|list| {
+                                                let list_id = list.id.clone();
+                                                let list_name = list.name.clone();
+                                                let lid_del = list.id.clone();
+                                                let list_tag_ids: Vec<String> = all_links
+                                                    .iter()
+                                                    .filter(|l| l.list_id == list.id)
+                                                    .map(|l| l.tag_id.clone())
+                                                    .collect();
+                                                let tog = on_list_tag_toggle.clone();
+                                                let tag_cb = Callback::new(move |tag_id: String| tog.run((list_id.clone(), tag_id)));
+                                                view! {
+                                                    <ListCard
+                                                        list
+                                                        all_tags=all_tags.clone()
+                                                        list_tag_ids
+                                                        on_tag_toggle=tag_cb
+                                                        on_delete=Callback::new(move |_: String| {
+                                                            pending_delete.set(Some((lid_del.clone(), list_name.clone())));
+                                                        })
+                                                    />
+                                                }
+                                            }).collect::<Vec<_>>()}
+                                        </div>
+                                    </div>
+                                </div>
+                            }.into_any()
+                        } else {
+                            view! {}.into_any()
+                        }}
+
+                        // === Recent section ===
+                        {if !rl.is_empty() || !rc.is_empty() {
+                            let rl = rl.clone();
+                            let rc = rc.clone();
+                            let all_tags = all_tags.clone();
+                            let all_links = all_links.clone();
+                            view! {
+                                <div class="collapse collapse-arrow bg-base-200 mb-4">
+                                    <input type="checkbox" checked />
+                                    <div class="collapse-title font-semibold">"🕐 Ostatnio otwierane"</div>
+                                    <div class="collapse-content">
+                                        <div class="flex flex-col gap-3 pt-2">
+                                            {rc.into_iter().map(|c| {
+                                                view! {
+                                                    <ContainerCard container=c />
+                                                }
+                                            }).collect::<Vec<_>>()}
+                                            {rl.into_iter().filter(|l| filter_list(l)).map(|list| {
+                                                let list_id = list.id.clone();
+                                                let list_name = list.name.clone();
+                                                let lid_del = list.id.clone();
+                                                let list_tag_ids: Vec<String> = all_links
+                                                    .iter()
+                                                    .filter(|l| l.list_id == list.id)
+                                                    .map(|l| l.tag_id.clone())
+                                                    .collect();
+                                                let tog = on_list_tag_toggle.clone();
+                                                let tag_cb = Callback::new(move |tag_id: String| tog.run((list_id.clone(), tag_id)));
+                                                view! {
+                                                    <ListCard
+                                                        list
+                                                        all_tags=all_tags.clone()
+                                                        list_tag_ids
+                                                        on_tag_toggle=tag_cb
+                                                        on_delete=Callback::new(move |_: String| {
+                                                            pending_delete.set(Some((lid_del.clone(), list_name.clone())));
+                                                        })
+                                                    />
+                                                }
+                                            }).collect::<Vec<_>>()}
+                                        </div>
+                                    </div>
+                                </div>
+                            }.into_any()
+                        } else {
+                            view! {}.into_any()
+                        }}
+
+                        // === Root containers ===
+                        {if !rc_list.is_empty() {
+                            let rc_list = rc_list.clone();
+                            view! {
+                                <div class="mb-4">
+                                    <h3 class="text-sm font-semibold text-base-content/60 mb-2 uppercase tracking-wide">"Foldery i projekty"</h3>
+                                    <div class="flex flex-col gap-3">
+                                        {rc_list.into_iter().map(|c| {
+                                            let cid = c.id.clone();
+                                            let cid_del = c.id.clone();
+                                            view! {
+                                                <ContainerCard
+                                                    container=c
+                                                    on_delete=Callback::new(move |_: String| {
+                                                        let cid = cid_del.clone();
+                                                        leptos::task::spawn_local(async move {
+                                                            match api::delete_container(&cid).await {
+                                                                Ok(()) => {
+                                                                    root_containers.update(|cs| cs.retain(|c| c.id != cid));
+                                                                    toast.push("Kontener usunięty".into(), ToastKind::Success);
+                                                                }
+                                                                Err(e) => toast.push(e, ToastKind::Error),
+                                                            }
+                                                        });
+                                                    })
+                                                    on_pin=Callback::new(move |_| {
+                                                        let cid = cid.clone();
+                                                        leptos::task::spawn_local(async move {
+                                                            let _ = api::toggle_container_pin(&cid).await;
+                                                            set_refresh.update(|n| *n += 1);
+                                                        });
+                                                    })
+                                                />
+                                            }
+                                        }).collect::<Vec<_>>()}
+                                    </div>
+                                </div>
+                            }.into_any()
+                        } else {
+                            view! {}.into_any()
+                        }}
+
+                        // === Root lists ===
+                        {
+                            let filtered: Vec<List> = rll.iter()
+                                .filter(|l| filter_list(l))
+                                .cloned()
+                                .collect();
+
+                            if filtered.is_empty() && rc_list.is_empty() && pl.is_empty() && pc.is_empty() {
+                                view! {
+                                    <div class="text-center text-base-content/50 py-12">"Brak list i kontenerów. Utwórz pierwszy!"</div>
+                                }.into_any()
+                            } else if filtered.is_empty() {
+                                view! {}.into_any()
+                            } else {
+                                let all_tags = all_tags.clone();
+                                let all_links = all_links.clone();
+                                view! {
+                                    <div>
+                                        {if !rc_list.is_empty() {
+                                            view! {
+                                                <h3 class="text-sm font-semibold text-base-content/60 mb-2 uppercase tracking-wide">"Listy"</h3>
+                                            }.into_any()
+                                        } else { view! {}.into_any() }}
+                                        <div class="flex flex-col gap-3">
+                                            {filtered.into_iter().map(|list| {
+                                                let list_id = list.id.clone();
+                                                let list_name = list.name.clone();
+                                                let lid_del = list.id.clone();
+                                                let list_tag_ids: Vec<String> = all_links
+                                                    .iter()
+                                                    .filter(|l| l.list_id == list.id)
+                                                    .map(|l| l.tag_id.clone())
+                                                    .collect();
+                                                let tog = on_list_tag_toggle.clone();
+                                                let tag_cb = Callback::new(move |tag_id: String| tog.run((list_id.clone(), tag_id)));
+                                                view! {
+                                                    <ListCard
+                                                        list
+                                                        all_tags=all_tags.clone()
+                                                        list_tag_ids
+                                                        on_tag_toggle=tag_cb
+                                                        on_delete=Callback::new(move |_: String| {
+                                                            pending_delete.set(Some((lid_del.clone(), list_name.clone())));
+                                                        })
+                                                    />
+                                                }
+                                            }).collect::<Vec<_>>()}
+                                        </div>
+                                    </div>
+                                }.into_any()
                             }
-                        }).collect::<Vec<_>>()}
+                        }
                     </div>
                 }.into_any()
             }}

--- a/crates/frontend/src/pages/list/mod.rs
+++ b/crates/frontend/src/pages/list/mod.rs
@@ -6,6 +6,7 @@ use leptos_router::hooks::{use_navigate, use_params_map};
 
 use crate::api;
 use crate::app::{ToastContext, ToastKind};
+use crate::components::common::breadcrumbs::Breadcrumbs;
 use crate::components::common::editable_description::EditableDescription;
 use crate::components::items::add_item_input::AddItemInput;
 use crate::components::items::item_actions::create_item_actions;
@@ -33,6 +34,7 @@ pub fn ListPage() -> impl IntoView {
     let list_tag_links = RwSignal::new(Vec::<ListTagLink>::new());
     let (loading, set_loading) = signal(true);
     let (error, set_error) = signal(Option::<String>::None);
+    let breadcrumbs = RwSignal::new(Vec::<(String, String)>::new());
 
     let toast = use_context::<ToastContext>().expect("ToastContext missing");
     let navigate = use_navigate();
@@ -44,6 +46,28 @@ pub fn ListPage() -> impl IntoView {
     let lid = list_id();
     leptos::task::spawn_local(async move {
         if let Ok(list) = api::fetch_list(&lid).await {
+            // Build breadcrumbs if the list belongs to a container
+            if let Some(cid) = list.container_id.clone() {
+                if let Ok(all_containers) = api::fetch_containers().await {
+                    let mut chain = Vec::new();
+                    let mut current_id = Some(cid);
+                    let mut depth = 0;
+                    while let Some(ref id) = current_id.clone() {
+                        if depth > 10 {
+                            break;
+                        }
+                        if let Some(c) = all_containers.iter().find(|c| &c.id == id) {
+                            chain.push((c.name.clone(), format!("/containers/{}", c.id)));
+                            current_id = c.parent_container_id.clone();
+                        } else {
+                            break;
+                        }
+                        depth += 1;
+                    }
+                    chain.reverse();
+                    breadcrumbs.set(chain);
+                }
+            }
             list_name.set(list.name);
             list_description.set(list.description);
             list_features.set(list.features);
@@ -192,6 +216,15 @@ pub fn ListPage() -> impl IntoView {
 
     view! {
         <div class="container mx-auto max-w-2xl p-4">
+            {move || {
+                let crumbs = breadcrumbs.get();
+                if !crumbs.is_empty() {
+                    view! { <Breadcrumbs crumbs=crumbs /> }.into_any()
+                } else {
+                    view! {}.into_any()
+                }
+            }}
+
             {move || view! {
                 <ListHeader
                     list_name=list_name.get()

--- a/crates/frontend/src/pages/mod.rs
+++ b/crates/frontend/src/pages/mod.rs
@@ -1,4 +1,5 @@
 pub mod calendar;
+pub mod container;
 pub mod home;
 pub mod list;
 pub mod login;

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -9,6 +9,94 @@ fn bool_from_number<'de, D: Deserializer<'de>>(d: D) -> Result<bool, D::Error> {
     }
 }
 
+// === Container types ===
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum ContainerStatus {
+    Active,
+    Done,
+    Paused,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Container {
+    pub id: String,
+    pub user_id: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub status: Option<ContainerStatus>,
+    pub parent_container_id: Option<String>,
+    pub position: i32,
+    #[serde(deserialize_with = "bool_from_number")]
+    pub pinned: bool,
+    pub last_opened_at: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContainerDetail {
+    #[serde(flatten)]
+    pub container: Container,
+    #[serde(deserialize_with = "u32_from_number", default)]
+    pub completed_items: u32,
+    #[serde(deserialize_with = "u32_from_number", default)]
+    pub total_items: u32,
+    #[serde(deserialize_with = "u32_from_number", default)]
+    pub completed_lists: u32,
+    #[serde(deserialize_with = "u32_from_number", default)]
+    pub total_lists: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateContainerRequest {
+    pub name: String,
+    pub status: Option<ContainerStatus>,
+    pub parent_container_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateContainerRequest {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub status: Option<Option<ContainerStatus>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MoveListRequest {
+    pub container_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MoveContainerRequest {
+    pub parent_container_id: Option<String>,
+}
+
+/// Combined home data returned by GET /api/home
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HomeItem {
+    pub kind: String, // "list" or "container"
+    pub id: String,
+    pub name: String,
+    pub updated_at: String,
+    pub last_opened_at: Option<String>,
+    // list-specific
+    pub list_type: Option<String>,
+    // container-specific
+    pub status: Option<ContainerStatus>,
+    pub parent_container_id: Option<String>,
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HomeData {
+    pub pinned: Vec<HomeItem>,
+    pub recent: Vec<HomeItem>,
+    pub root_containers: Vec<Container>,
+    pub root_lists: Vec<List>,
+}
+
 // === Domain types ===
 
 /// Known feature names
@@ -106,6 +194,12 @@ pub struct List {
     pub archived: bool,
     #[serde(default, deserialize_with = "features_from_json")]
     pub features: Vec<ListFeature>,
+    #[serde(default)]
+    pub container_id: Option<String>,
+    #[serde(default, deserialize_with = "bool_from_number")]
+    pub pinned: bool,
+    #[serde(default)]
+    pub last_opened_at: Option<String>,
     pub created_at: String,
     pub updated_at: String,
 }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -96,16 +96,17 @@ Z flat booleans na tabelę `list_features(list_id, feature_name, config TEXT/JSO
 
 ---
 
-## M5: Containers (foldery + projekty)
+## ~~M5: Containers (foldery + projekty)~~ ✅
 
 **Dostarcza:** Foldery i projekty jako unified Container.
 
-- Backend: tabela `containers`, `container_id TEXT` na listach (nullable FK)
-- Progress na projektach: computed server-side — `GET /api/containers/:id` zwraca `completed_items / total_items` across all list w kontenerze (nie stored, obliczany przy każdym request)
-- Endpointy: CRUD containers, przenoszenie list między kontenerami
-- Frontend: home page jako drzewiasta struktura, tworzenie folderów/projektów, status projektu z progress barem, breadcrumbs nawigacja
+- ✅ Backend: tabela `containers` + `container_id`, `pinned`, `last_opened_at` na listach (nullable FKs)
+- ✅ Progress na projektach: computed server-side — item-level (`completed_items / total_items`) + list-level (`completed_lists / total_lists`)
+- ✅ Endpointy: CRUD containers, przenoszenie list między kontenerami, pin/unpin, `/api/home`
+- ✅ Frontend: home page z sekcjami Przypięte / Ostatnio otwierane / Kontenery / Listy, tworzenie folderów/projektów, status projektu z progress barem, breadcrumbs nawigacja
+- ✅ Nowa strona `/containers/:id` z edytowalną nazwą/opisem, progress barem dla projektów, click-through nawigacja
 
-**Refaktor:** Home page z flat → tree. Wydzielenie nawigacji/breadcrumbs.
+**Refaktor:** ✅ Home page z flat → click-through. ✅ Wydzielenie `CreateEntityInput` do reużywalnego komponentu. ✅ `Breadcrumbs` shared component. ✅ `ContainerCard` component.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds unified `Container` type — folder (`status=NULL`) or project (`status=active/done/paused`)
- Folders can nest folders and projects; projects hold only lists
- Pinning and recent-tracking for both containers and lists
- Home page redesigned with Pinned / Recently Opened / Root Containers / Root Lists sections
- New `/containers/:id` page with breadcrumbs, editable name/desc, progress bars for projects
- List page shows breadcrumbs when list belongs to a container

## Changes

**Backend:**
- Migration `0010_containers.sql`: `containers` table + `container_id`, `pinned`, `last_opened_at` on `lists`
- Full CRUD handler for containers with server-side progress computation
- `/api/home` endpoint consolidating pinned/recent/root data
- Move list to container (`PATCH /api/lists/:id/container`) + pin endpoints

**Frontend:**
- `ContainerCard` — folder/project card with status badge, progress bar, pin/delete
- `Breadcrumbs` — shared component showing parent chain from Home
- `CreateEntityInput` — refactored from home.rs, supports List/Folder/Project modes
- Reactive container page (fixes folder→folder navigation)

## Test plan

- [ ] Create folder at root → visible on home page
- [ ] Navigate into folder → container page with breadcrumbs
- [ ] Create project inside folder → visible in container, shows status selector + progress
- [ ] Add lists to project → progress bar updates
- [ ] Move list to container via API
- [ ] Delete container → lists return to root
- [ ] Breadcrumbs on list page when list belongs to a container
- [ ] Folder→folder navigation re-fetches correctly
- [ ] Pin/unpin container and list → visible in Pinned section

🤖 Generated with [Claude Code](https://claude.com/claude-code)