### PR TITLE
feat: unify user settings + MCP feature validation

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: '/code-review:code-review https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           show_full_output: true
           claude_args: |
             --max-turns 15

--- a/crates/api/migrations/0012_unify_user_settings.sql
+++ b/crates/api/migrations/0012_unify_user_settings.sql
@@ -1,0 +1,14 @@
+CREATE TABLE user_settings (
+    user_id TEXT NOT NULL,
+    key TEXT NOT NULL,
+    value TEXT NOT NULL,
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (user_id, key)
+);
+
+-- Migrate locale data from old table
+INSERT INTO user_settings (user_id, key, value, updated_at)
+SELECT user_id, 'locale', '"' || locale || '"', updated_at
+FROM user_preferences;
+
+DROP TABLE user_preferences;

--- a/crates/api/src/handlers/items.rs
+++ b/crates/api/src/handlers/items.rs
@@ -166,16 +166,24 @@ fn check_item_features(
     has_quantity_field: bool,
 ) -> worker::Result<Option<Response>> {
     if has_date_field && !feature_names.iter().any(|f| f == FEATURE_DEADLINES) {
-        return Ok(Some(Response::error(
-            r#"{"error":"feature_required","feature":"deadlines","message":"This list does not have the 'deadlines' feature enabled. Enable it in list settings or retry without date fields."}"#,
-            422,
-        )?));
+        return Ok(Some(
+            Response::from_json(&serde_json::json!({
+                "error": "feature_required",
+                "feature": "deadlines",
+                "message": "This list does not have the 'deadlines' feature enabled. Enable it in list settings or retry without date fields."
+            }))
+            .map(|r| r.with_status(422))?,
+        ));
     }
     if has_quantity_field && !feature_names.iter().any(|f| f == FEATURE_QUANTITY) {
-        return Ok(Some(Response::error(
-            r#"{"error":"feature_required","feature":"quantity","message":"This list does not have the 'quantity' feature enabled. Enable it in list settings or retry without quantity fields."}"#,
-            422,
-        )?));
+        return Ok(Some(
+            Response::from_json(&serde_json::json!({
+                "error": "feature_required",
+                "feature": "quantity",
+                "message": "This list does not have the 'quantity' feature enabled. Enable it in list settings or retry without quantity fields."
+            }))
+            .map(|r| r.with_status(422))?,
+        ));
     }
     Ok(None)
 }

--- a/crates/api/src/handlers/items.rs
+++ b/crates/api/src/handlers/items.rs
@@ -69,6 +69,29 @@ pub async fn create(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
         .unwrap_or(-1);
     let position = (max_pos + 1) as i32;
 
+    let feature_rows = d1
+        .prepare("SELECT feature_name FROM list_features WHERE list_id = ?1")
+        .bind(&[list_id.clone().into()])?
+        .all()
+        .await?
+        .results::<serde_json::Value>()?;
+    let feature_names: Vec<String> = feature_rows
+        .iter()
+        .filter_map(|r| r.get("feature_name")?.as_str().map(String::from))
+        .collect();
+
+    let has_date_field = body.start_date.is_some()
+        || body.deadline.is_some()
+        || body.hard_deadline.is_some()
+        || body.start_time.is_some()
+        || body.deadline_time.is_some();
+    let has_quantity_field = body.quantity.is_some() || body.unit.is_some();
+
+    if let Some(err_resp) = check_item_features(&feature_names, has_date_field, has_quantity_field)?
+    {
+        return Ok(err_resp);
+    }
+
     let opt_str = |v: &Option<String>| -> JsValue {
         match v {
             Some(s) => JsValue::from(s.as_str()),
@@ -137,6 +160,26 @@ fn update_nullable_str(outer: &Option<Option<String>>) -> Option<JsValue> {
     }
 }
 
+fn check_item_features(
+    feature_names: &[String],
+    has_date_field: bool,
+    has_quantity_field: bool,
+) -> worker::Result<Option<Response>> {
+    if has_date_field && !feature_names.iter().any(|f| f == FEATURE_DEADLINES) {
+        return Ok(Some(Response::error(
+            r#"{"error":"feature_required","feature":"deadlines","message":"This list does not have the 'deadlines' feature enabled. Enable it in list settings or retry without date fields."}"#,
+            422,
+        )?));
+    }
+    if has_quantity_field && !feature_names.iter().any(|f| f == FEATURE_QUANTITY) {
+        return Ok(Some(Response::error(
+            r#"{"error":"feature_required","feature":"quantity","message":"This list does not have the 'quantity' feature enabled. Enable it in list settings or retry without quantity fields."}"#,
+            422,
+        )?));
+    }
+    Ok(None)
+}
+
 pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let id = ctx
@@ -149,7 +192,7 @@ pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
     // Verify item belongs to user (via list ownership)
     let item_check = d1
         .prepare(
-            "SELECT items.id FROM items \
+            "SELECT items.id, items.list_id FROM items \
              JOIN lists ON lists.id = items.list_id \
              WHERE items.id = ?1 AND lists.user_id = ?2",
         )
@@ -158,6 +201,35 @@ pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
         .await?;
     if item_check.is_none() {
         return json_error("item_not_found", 404);
+    }
+
+    let list_id_for_features = item_check
+        .as_ref()
+        .and_then(|v| v.get("list_id")?.as_str().map(String::from))
+        .ok_or_else(|| Error::from("Missing list_id on item"))?;
+
+    let feature_rows = d1
+        .prepare("SELECT feature_name FROM list_features WHERE list_id = ?1")
+        .bind(&[list_id_for_features.into()])?
+        .all()
+        .await?
+        .results::<serde_json::Value>()?;
+    let feature_names: Vec<String> = feature_rows
+        .iter()
+        .filter_map(|r| r.get("feature_name")?.as_str().map(String::from))
+        .collect();
+
+    let has_date_field = matches!(&body.start_date, Some(Some(_)))
+        || matches!(&body.deadline, Some(Some(_)))
+        || matches!(&body.hard_deadline, Some(Some(_)))
+        || matches!(&body.start_time, Some(Some(_)))
+        || matches!(&body.deadline_time, Some(Some(_)));
+    let has_quantity_field =
+        body.quantity.is_some() || body.actual_quantity.is_some() || body.unit.is_some();
+
+    if let Some(err_resp) = check_item_features(&feature_names, has_date_field, has_quantity_field)?
+    {
+        return Ok(err_resp);
     }
 
     if let Some(title) = &body.title {

--- a/crates/api/src/handlers/mod.rs
+++ b/crates/api/src/handlers/mod.rs
@@ -2,4 +2,5 @@ pub mod containers;
 pub mod items;
 pub mod lists;
 pub mod preferences;
+pub mod settings;
 pub mod tags;

--- a/crates/api/src/handlers/preferences.rs
+++ b/crates/api/src/handlers/preferences.rs
@@ -17,13 +17,16 @@ pub async fn get_preferences(_req: Request, ctx: RouteContext<String>) -> Result
 
     let db = ctx.env.d1("DB")?;
     let result = db
-        .prepare("SELECT locale FROM user_preferences WHERE user_id = ?1")
+        .prepare("SELECT value FROM user_settings WHERE user_id = ?1 AND key = 'locale'")
         .bind(&[user_id.into()])?
         .first::<serde_json::Value>(None)
         .await?;
 
     let locale = result
-        .and_then(|row| row.get("locale").and_then(|v| v.as_str()).map(String::from))
+        .and_then(|row| {
+            let raw = row.get("value")?.as_str().map(String::from)?;
+            serde_json::from_str::<String>(&raw).ok()
+        })
         .unwrap_or_else(|| "en".to_string());
 
     Response::from_json(&PreferencesResponse { locale })
@@ -38,13 +41,14 @@ pub async fn put_preferences(mut req: Request, ctx: RouteContext<String>) -> Res
         return json_error("invalid_locale", 400);
     }
 
+    let value_json = serde_json::to_string(&body.locale).unwrap_or_default();
+
     let db = ctx.env.d1("DB")?;
     db.prepare(
-        "INSERT INTO user_preferences (user_id, locale, updated_at) \
-         VALUES (?1, ?2, datetime('now')) \
-         ON CONFLICT(user_id) DO UPDATE SET locale = ?2, updated_at = datetime('now')",
+        "INSERT OR REPLACE INTO user_settings (user_id, key, value, updated_at) \
+         VALUES (?1, 'locale', ?2, datetime('now'))",
     )
-    .bind(&[user_id.into(), body.locale.into()])?
+    .bind(&[user_id.into(), value_json.into()])?
     .run()
     .await?;
 

--- a/crates/api/src/handlers/settings.rs
+++ b/crates/api/src/handlers/settings.rs
@@ -1,0 +1,65 @@
+use kartoteka_shared::*;
+use std::collections::HashMap;
+use worker::*;
+
+pub async fn list_all(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
+    let user_id = ctx.data.clone();
+    let d1 = ctx.env.d1("DB")?;
+
+    let rows = d1
+        .prepare("SELECT key, value FROM user_settings WHERE user_id = ?1")
+        .bind(&[user_id.into()])?
+        .all()
+        .await?
+        .results::<serde_json::Value>()?;
+
+    let mut map: HashMap<String, serde_json::Value> = HashMap::new();
+    for row in rows {
+        if let (Some(key), Some(raw_value)) = (
+            row.get("key").and_then(|v| v.as_str()).map(String::from),
+            row.get("value").and_then(|v| v.as_str()),
+        ) {
+            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(raw_value) {
+                map.insert(key, parsed);
+            }
+        }
+    }
+    Response::from_json(&map)
+}
+
+pub async fn upsert(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
+    let user_id = ctx.data.clone();
+    let key = ctx
+        .param("key")
+        .ok_or_else(|| Error::from("Missing key"))?
+        .to_string();
+    let body: UpsertSettingRequest = req.json().await?;
+    let d1 = ctx.env.d1("DB")?;
+
+    let value_str = body.value.to_string();
+    d1.prepare(
+        "INSERT OR REPLACE INTO user_settings (user_id, key, value, updated_at) \
+         VALUES (?1, ?2, ?3, datetime('now'))",
+    )
+    .bind(&[user_id.into(), key.into(), value_str.into()])?
+    .run()
+    .await?;
+
+    Ok(Response::empty()?.with_status(204))
+}
+
+pub async fn delete(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
+    let user_id = ctx.data.clone();
+    let key = ctx
+        .param("key")
+        .ok_or_else(|| Error::from("Missing key"))?
+        .to_string();
+    let d1 = ctx.env.d1("DB")?;
+
+    d1.prepare("DELETE FROM user_settings WHERE user_id = ?1 AND key = ?2")
+        .bind(&[user_id.into(), key.into()])?
+        .run()
+        .await?;
+
+    Ok(Response::empty()?.with_status(204))
+}

--- a/crates/api/src/router.rs
+++ b/crates/api/src/router.rs
@@ -1,7 +1,7 @@
 use worker::*;
 
 use crate::auth;
-use crate::handlers::{containers, items, lists, preferences, tags};
+use crate::handlers::{containers, items, lists, preferences, settings, tags};
 
 pub async fn handle(req: Request, env: Env) -> Result<Response> {
     let path = req.path();
@@ -59,6 +59,10 @@ pub async fn handle(req: Request, env: Env) -> Result<Response> {
         // Preferences
         .get_async("/api/preferences", preferences::get_preferences)
         .put_async("/api/preferences", preferences::put_preferences)
+        // Settings
+        .get_async("/api/settings", settings::list_all)
+        .put_async("/api/settings/:key", settings::upsert)
+        .delete_async("/api/settings/:key", settings::delete)
         // Tags CRUD
         .get_async("/api/tags", tags::list_all)
         .post_async("/api/tags", tags::create)

--- a/crates/frontend/src/api/mod.rs
+++ b/crates/frontend/src/api/mod.rs
@@ -2,11 +2,13 @@ mod containers;
 mod items;
 mod lists;
 pub mod preferences;
+mod settings;
 mod tags;
 
 pub use containers::*;
 pub use items::*;
 pub use lists::*;
+pub use settings::*;
 pub use tags::*;
 
 use gloo_net::http::{Headers, Request};

--- a/crates/frontend/src/api/settings.rs
+++ b/crates/frontend/src/api/settings.rs
@@ -9,8 +9,8 @@ pub async fn fetch_settings() -> Result<serde_json::Value, String> {
 }
 
 pub async fn upsert_setting(key: &str, value: serde_json::Value) -> Result<(), String> {
-    let json = serde_json::to_string(&serde_json::json!({ "value": value }))
-        .map_err(|e| e.to_string())?;
+    let json =
+        serde_json::to_string(&serde_json::json!({ "value": value })).map_err(|e| e.to_string())?;
     let resp = gloo_net::http::Request::put(&format!("{}/settings/{key}", super::API_BASE))
         .headers(super::auth_headers())
         .credentials(web_sys::RequestCredentials::Include)

--- a/crates/frontend/src/api/settings.rs
+++ b/crates/frontend/src/api/settings.rs
@@ -1,0 +1,26 @@
+pub async fn fetch_settings() -> Result<serde_json::Value, String> {
+    super::get(&format!("{}/settings", super::API_BASE))
+        .send()
+        .await
+        .map_err(|e| e.to_string())?
+        .json()
+        .await
+        .map_err(|e| e.to_string())
+}
+
+pub async fn upsert_setting(key: &str, value: serde_json::Value) -> Result<(), String> {
+    let json = serde_json::to_string(&serde_json::json!({ "value": value }))
+        .map_err(|e| e.to_string())?;
+    let resp = gloo_net::http::Request::put(&format!("{}/settings/{key}", super::API_BASE))
+        .headers(super::auth_headers())
+        .credentials(web_sys::RequestCredentials::Include)
+        .body(json)
+        .map_err(|e| e.to_string())?
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+    if resp.status() >= 400 {
+        return Err(format!("HTTP {}", resp.status()));
+    }
+    Ok(())
+}

--- a/crates/frontend/src/pages/settings.rs
+++ b/crates/frontend/src/pages/settings.rs
@@ -4,6 +4,7 @@ use wasm_bindgen_futures::spawn_local;
 
 use crate::api;
 use crate::api::preferences::put_preferences;
+use kartoteka_shared::SETTING_MCP_AUTO_ENABLE_FEATURES;
 
 #[component]
 pub fn McpRedirect() -> impl IntoView {
@@ -18,6 +19,18 @@ pub fn McpRedirect() -> impl IntoView {
 pub fn SettingsPage() -> impl IntoView {
     let mcp_url = format!("{}/mcp", api::auth_base());
     let copied = RwSignal::new(false);
+    let auto_enable = RwSignal::new(false);
+
+    // Load settings on mount
+    leptos::task::spawn_local(async move {
+        if let Ok(settings) = api::fetch_settings().await {
+            let val = settings
+                .get(SETTING_MCP_AUTO_ENABLE_FEATURES)
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            auto_enable.set(val);
+        }
+    });
 
     let mcp_url_copy = mcp_url.clone();
     let on_copy = move |_| {
@@ -85,6 +98,37 @@ pub fn SettingsPage() -> impl IntoView {
                             <option value="pl" selected=move || current_lang() == "pl">"Polski"</option>
                         </select>
                     </div>
+                </div>
+            </div>
+
+            <div class="card bg-base-200 border border-base-300 mb-4">
+                <div class="card-body">
+                    <h3 class="card-title text-lg">"Zachowanie AI"</h3>
+                    <label class="label cursor-pointer justify-start gap-4">
+                        <input
+                            type="checkbox"
+                            class="toggle toggle-sm"
+                            prop:checked=auto_enable
+                            on:change=move |ev| {
+                                let checked = event_target_checked(&ev);
+                                auto_enable.set(checked);
+                                leptos::task::spawn_local(async move {
+                                    let _ = api::upsert_setting(
+                                        SETTING_MCP_AUTO_ENABLE_FEATURES,
+                                        serde_json::Value::Bool(checked),
+                                    ).await;
+                                });
+                            }
+                        />
+                        <div>
+                            <div class="label-text font-medium">
+                                "Automatycznie włączaj funkcje list"
+                            </div>
+                            <div class="label-text text-xs text-base-content/60">
+                                "Gdy AI potrzebuje terminu lub ilości na liście bez tych funkcji, włączy je bez pytania."
+                            </div>
+                        </div>
+                    </label>
                 </div>
             </div>
 

--- a/crates/frontend/src/pages/settings.rs
+++ b/crates/frontend/src/pages/settings.rs
@@ -103,7 +103,7 @@ pub fn SettingsPage() -> impl IntoView {
 
             <div class="card bg-base-200 border border-base-300 mb-4">
                 <div class="card-body">
-                    <h3 class="card-title text-lg">"Zachowanie AI"</h3>
+                    <h3 class="card-title text-lg">{move_tr!("settings-ai-section-title")}</h3>
                     <label class="label cursor-pointer justify-start gap-4">
                         <input
                             type="checkbox"
@@ -122,10 +122,10 @@ pub fn SettingsPage() -> impl IntoView {
                         />
                         <div>
                             <div class="label-text font-medium">
-                                "Automatycznie włączaj funkcje list"
+                                {move_tr!("settings-ai-auto-enable-label")}
                             </div>
                             <div class="label-text text-xs text-base-content/60">
-                                "Gdy AI potrzebuje terminu lub ilości na liście bez tych funkcji, włączy je bez pytania."
+                                {move_tr!("settings-ai-auto-enable-description")}
                             </div>
                         </div>
                     </label>

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -103,6 +103,19 @@ pub struct HomeData {
 pub const FEATURE_QUANTITY: &str = "quantity";
 pub const FEATURE_DEADLINES: &str = "deadlines";
 
+pub const SETTING_MCP_AUTO_ENABLE_FEATURES: &str = "mcp_auto_enable_features";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserSetting {
+    pub key: String,
+    pub value: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpsertSettingRequest {
+    pub value: serde_json::Value,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ListFeature {
     pub name: String,

--- a/gateway/src/mcp/api.ts
+++ b/gateway/src/mcp/api.ts
@@ -71,27 +71,3 @@ export async function fetchUserLocale(userId: string, env: Env): Promise<string>
     return "en";
   }
 }
-
-export async function ensureFeatures(
-  api: ApiContext,
-  listId: string,
-  fields: Record<string, unknown>
-): Promise<void> {
-  const hasDateField =
-    fields.start_date !== undefined ||
-    fields.deadline !== undefined ||
-    fields.hard_deadline !== undefined ||
-    fields.start_time !== undefined ||
-    fields.deadline_time !== undefined;
-  const hasQuantity =
-    fields.quantity !== undefined ||
-    fields.actual_quantity !== undefined ||
-    fields.unit !== undefined;
-
-  if (hasDateField) {
-    await apiCall(api, "POST", `/api/lists/${listId}/features/deadlines`, { config: {} });
-  }
-  if (hasQuantity) {
-    await apiCall(api, "POST", `/api/lists/${listId}/features/quantity`, { config: {} });
-  }
-}

--- a/gateway/src/mcp/tools/items.ts
+++ b/gateway/src/mcp/tools/items.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ApiContext } from "../api";
-import { callTool, ensureFeatures } from "../api";
+import { callTool, apiCall, errorResult, jsonResult } from "../api";
 import { tr } from "../i18n";
 
 export function registerItemTools(server: McpServer, api: ApiContext, locale: string): void {
@@ -27,8 +27,9 @@ export function registerItemTools(server: McpServer, api: ApiContext, locale: st
       hard_deadline: z.string().optional().describe("Hard deadline YYYY-MM-DD"),
     },
   }, async ({ list_id, ...fields }) => {
-    await ensureFeatures(api, list_id, fields);
-    return callTool(api, "POST", `/api/lists/${list_id}/items`, fields);
+    return withAutoEnable(api, list_id, fields, (f) =>
+      apiCall(api, "POST", `/api/lists/${list_id}/items`, f)
+    );
   });
 
   server.registerTool("update_item", {
@@ -49,8 +50,9 @@ export function registerItemTools(server: McpServer, api: ApiContext, locale: st
       hard_deadline: z.string().nullable().optional().describe("Hard deadline YYYY-MM-DD (null to clear)"),
     },
   }, async ({ list_id, item_id, ...fields }) => {
-    await ensureFeatures(api, list_id, fields);
-    return callTool(api, "PUT", `/api/lists/${list_id}/items/${item_id}`, fields);
+    return withAutoEnable(api, list_id, fields, (f) =>
+      apiCall(api, "PUT", `/api/lists/${list_id}/items/${item_id}`, f)
+    );
   });
 
   server.registerTool("toggle_item", {
@@ -71,4 +73,56 @@ export function registerItemTools(server: McpServer, api: ApiContext, locale: st
     },
   }, ({ item_id, target_list_id }) =>
     callTool(api, "PATCH", `/api/items/${item_id}/move`, { list_id: target_list_id }));
+
+  async function withAutoEnable(
+    api: ApiContext,
+    listId: string,
+    fields: Record<string, unknown>,
+    apiFn: (f: Record<string, unknown>) => Promise<Response>
+  ): Promise<{ content: { type: "text"; text: string }[]; isError?: boolean }> {
+    const res = await apiFn(fields);
+    if (!res.ok) {
+      if (res.status === 422) {
+        let body: { error?: string; feature?: string; message?: string } = {};
+        try { body = await res.json(); } catch { /* ignore */ }
+
+        if (body.error === "feature_required" && body.feature) {
+          let autoEnable = false;
+          try {
+            const settings = await apiCall(api, "GET", "/api/settings").then(r => r.json()) as Record<string, unknown>;
+            autoEnable = settings["mcp_auto_enable_features"] === true;
+          } catch { /* default false */ }
+
+          if (autoEnable) {
+            const config = body.feature === "deadlines"
+              ? { has_start_date: false, has_deadline: true, has_hard_deadline: false }
+              : {};
+            const enableRes = await apiCall(api, "POST", `/api/lists/${listId}/features/${body.feature}`, { config });
+            if (!enableRes.ok) {
+              return errorResult(`Failed to auto-enable feature '${body.feature}': ${await enableRes.text()}`);
+            }
+            const retry = await apiFn(fields);
+            if (!retry.ok) {
+              return errorResult(`API error ${retry.status}: ${await retry.text()}`);
+            }
+            try {
+              return jsonResult(await retry.json());
+            } catch {
+              return errorResult("Failed to parse API response after auto-enabling feature.");
+            }
+          }
+
+          return errorResult(
+            `${body.message ?? "Feature not enabled."} Options: (1) use enable_list_feature tool to enable it, (2) retry without the field.`
+          );
+        }
+      }
+      return errorResult(`API error ${res.status}: ${await res.text()}`);
+    }
+    try {
+      return jsonResult(await res.json());
+    } catch {
+      return errorResult("Failed to parse API response.");
+    }
+  }
 }

--- a/gateway/src/mcp/tools/lists.ts
+++ b/gateway/src/mcp/tools/lists.ts
@@ -41,7 +41,7 @@ export function registerListTools(server: McpServer, api: ApiContext, locale: st
     callTool(api, "PATCH", `/api/lists/${list_id}/container`, { container_id }));
 
   server.registerTool("enable_list_feature", {
-    description: "Enable a feature on a list. For 'deadlines', optionally configure which date fields are available. For 'quantity', optionally set a default unit. Call only after confirming with the user (unless mcp_auto_enable_features is set).",
+    description: tr("tool-enable-list-feature", locale),
     inputSchema: {
       list_id: z.string().describe("The list ID"),
       feature: z.enum(["quantity", "deadlines"]).describe("Feature to enable"),
@@ -64,7 +64,7 @@ export function registerListTools(server: McpServer, api: ApiContext, locale: st
   });
 
   server.registerTool("disable_list_feature", {
-    description: "Disable a feature on a list. Item data (quantities, dates) is preserved — data is hidden in UI but not deleted.",
+    description: tr("tool-disable-list-feature", locale),
     inputSchema: {
       list_id: z.string().describe("The list ID"),
       feature: z.enum(["quantity", "deadlines"]).describe("Feature to disable"),

--- a/gateway/src/mcp/tools/lists.ts
+++ b/gateway/src/mcp/tools/lists.ts
@@ -39,4 +39,36 @@ export function registerListTools(server: McpServer, api: ApiContext, locale: st
     },
   }, ({ list_id, container_id }) =>
     callTool(api, "PATCH", `/api/lists/${list_id}/container`, { container_id }));
+
+  server.registerTool("enable_list_feature", {
+    description: "Enable a feature on a list. For 'deadlines', optionally configure which date fields are available. For 'quantity', optionally set a default unit. Call only after confirming with the user (unless mcp_auto_enable_features is set).",
+    inputSchema: {
+      list_id: z.string().describe("The list ID"),
+      feature: z.enum(["quantity", "deadlines"]).describe("Feature to enable"),
+      has_start_date: z.boolean().optional().describe("Show start date field (default false)"),
+      has_deadline: z.boolean().optional().describe("Show deadline field (default true)"),
+      has_hard_deadline: z.boolean().optional().describe("Show hard deadline field (default false)"),
+      unit_default: z.string().optional().describe("Default unit label, e.g. 'szt', 'kg'"),
+    },
+  }, async ({ list_id, feature, has_start_date, has_deadline, has_hard_deadline, unit_default }) => {
+    const config = feature === "deadlines"
+      ? {
+          has_start_date: has_start_date ?? false,
+          has_deadline: has_deadline ?? true,
+          has_hard_deadline: has_hard_deadline ?? false,
+        }
+      : unit_default
+        ? { unit_default }
+        : {};
+    return callTool(api, "POST", `/api/lists/${list_id}/features/${feature}`, { config });
+  });
+
+  server.registerTool("disable_list_feature", {
+    description: "Disable a feature on a list. Item data (quantities, dates) is preserved — data is hidden in UI but not deleted.",
+    inputSchema: {
+      list_id: z.string().describe("The list ID"),
+      feature: z.enum(["quantity", "deadlines"]).describe("Feature to disable"),
+    },
+  }, ({ list_id, feature }) =>
+    callTool(api, "DELETE", `/api/lists/${list_id}/features/${feature}`));
 }

--- a/locales/en/mcp.ftl
+++ b/locales/en/mcp.ftl
@@ -28,3 +28,7 @@ tool-get-tagged-items = Get all items tagged with a specific tag
 # Calendar
 tool-get-calendar = Get items with dates in a date range
 tool-get-today = Get all items for today, including overdue
+
+# List features
+tool-enable-list-feature = Enable a feature on a list. For 'deadlines', optionally configure which date fields are available. For 'quantity', optionally set a default unit. Call only after confirming with the user (unless mcp_auto_enable_features is set).
+tool-disable-list-feature = Disable a feature on a list. Item data (quantities, dates) is preserved — data is hidden in UI but not deleted.

--- a/locales/en/settings.ftl
+++ b/locales/en/settings.ftl
@@ -6,3 +6,6 @@ settings-mcp-copied = Copied!
 settings-account-section = Account settings
 settings-language-label = Language
 settings-language-section-title = Language
+settings-ai-section-title = AI behavior
+settings-ai-auto-enable-label = Automatically enable list features
+settings-ai-auto-enable-description = When AI needs deadlines or quantities on a list without those features, it will enable them without asking.

--- a/locales/pl/mcp.ftl
+++ b/locales/pl/mcp.ftl
@@ -28,3 +28,7 @@ tool-get-tagged-items = Pobierz wszystkie elementy z konkretnym tagiem
 # Kalendarz
 tool-get-calendar = Pobierz elementy z datami w zakresie dat
 tool-get-today = Pobierz wszystkie elementy na dziś, w tym zaległe
+
+# Funkcje list
+tool-enable-list-feature = Włącz funkcję na liście. Dla 'deadlines' opcjonalnie skonfiguruj dostępne pola dat. Dla 'quantity' opcjonalnie ustaw domyślną jednostkę. Wywołaj tylko po potwierdzeniu przez użytkownika (chyba że ustawienie mcp_auto_enable_features jest włączone).
+tool-disable-list-feature = Wyłącz funkcję na liście. Dane elementów (ilości, daty) są zachowane — ukryte w UI, ale nie usunięte.

--- a/locales/pl/settings.ftl
+++ b/locales/pl/settings.ftl
@@ -6,3 +6,6 @@ settings-mcp-copied = Skopiowano!
 settings-account-section = Ustawienia konta
 settings-language-label = Język
 settings-language-section-title = Język
+settings-ai-section-title = Zachowanie AI
+settings-ai-auto-enable-label = Automatycznie włączaj funkcje list
+settings-ai-auto-enable-description = Gdy AI potrzebuje terminu lub ilości na liście bez tych funkcji, włączy je bez pytania.


### PR DESCRIPTION
## Summary

Replaces the old PR #33 (had merge conflicts with i18n branch).

- Unifies `user_preferences` table into generic `user_settings(user_id, key, value)` key-value store (migration 0012 migrates locale data and drops old table)
- `/api/preferences` endpoints now read/write from `user_settings` internally — no frontend i18n regression
- Adds generic `/api/settings` CRUD (GET all, PUT :key, DELETE :key)
- API returns 422 `feature_required` when creating/updating items with feature-gated fields (dates, quantities) on lists without the feature enabled
- MCP: removes silent `ensureFeatures`, adds `enable_list_feature` / `disable_list_feature` tools, `withAutoEnable` pattern (checks `mcp_auto_enable_features` user setting)
- Frontend settings page gets "Zachowanie AI" toggle for `mcp_auto_enable_features`

## Supersedes

Closes #33

## Test plan

- [ ] Language selector still works (reads/writes locale through unified table)
- [ ] `GET /api/settings` returns `{"locale": "en"}` for existing users
- [ ] `PUT /api/settings/mcp_auto_enable_features` with `{"value": true}` → 204
- [ ] Add item with `deadline` to list without deadlines → 422
- [ ] Enable deadlines, retry → 201
- [ ] MCP with `mcp_auto_enable_features=true` → auto-enables and succeeds
- [ ] Settings page toggle persists across refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)