### PR TITLE
feat: item detail page with auto-save (#38)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        continue-on-error: true
+
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,6 @@ jobs:
             {
               "permissions": {
                 "allow": ["Read", "Glob", "Grep", "Bash"],
-                "deny": ["Edit", "Write", "WebFetch", "WebSearch"]
+                "deny": ["Edit", "WebFetch", "WebSearch"]
               }
             }

--- a/crates/api/migrations/0012_unify_user_settings.sql
+++ b/crates/api/migrations/0012_unify_user_settings.sql
@@ -1,4 +1,4 @@
-CREATE TABLE user_settings (
+CREATE TABLE IF NOT EXISTS user_settings (
     user_id TEXT NOT NULL,
     key TEXT NOT NULL,
     value TEXT NOT NULL,
@@ -6,9 +6,10 @@ CREATE TABLE user_settings (
     PRIMARY KEY (user_id, key)
 );
 
--- Migrate locale data from old table
-INSERT INTO user_settings (user_id, key, value, updated_at)
+-- Migrate locale data from old table (if it exists and hasn't been migrated yet)
+INSERT OR IGNORE INTO user_settings (user_id, key, value, updated_at)
 SELECT user_id, 'locale', '"' || locale || '"', updated_at
-FROM user_preferences;
+FROM user_preferences
+WHERE EXISTS (SELECT 1 FROM sqlite_master WHERE type='table' AND name='user_preferences');
 
-DROP TABLE user_preferences;
+DROP TABLE IF EXISTS user_preferences;

--- a/crates/api/src/handlers/items.rs
+++ b/crates/api/src/handlers/items.rs
@@ -32,6 +32,7 @@ pub async fn list_all(_req: Request, ctx: RouteContext<String>) -> Result<Respon
 
 pub async fn get_one(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
+    let list_id = require_param(&ctx, "list_id")?;
     let id = require_param(&ctx, "id")?;
     let d1 = ctx.env.d1("DB")?;
 
@@ -39,14 +40,40 @@ pub async fn get_one(_req: Request, ctx: RouteContext<String>) -> Result<Respons
         return json_error("item_not_found", 404);
     }
 
-    let query = format!("SELECT {} FROM items WHERE id = ?1", ITEM_COLS);
+    let query = format!(
+        "SELECT {} FROM items WHERE id = ?1 AND list_id = ?2",
+        ITEM_COLS
+    );
     let item = d1
         .prepare(&query)
-        .bind(&[id.into()])?
+        .bind(&[id.into(), list_id.clone().into()])?
         .first::<Item>(None)
         .await?
         .ok_or_else(|| Error::from("Not found"))?;
-    Response::from_json(&item)
+
+    // Fetch list name + features for the combined response (saves a round-trip from the client)
+    #[derive(serde::Deserialize)]
+    struct ListRow {
+        name: String,
+        features: Option<String>,
+    }
+    let list_row = d1
+        .prepare("SELECT name, (SELECT COALESCE(json_group_array(json_object('name', lf.feature_name, 'config', json(lf.config))), '[]') FROM list_features lf WHERE lf.list_id = ?1) as features FROM lists WHERE id = ?1")
+        .bind(&[list_id.into()])?
+        .first::<ListRow>(None)
+        .await?
+        .ok_or_else(|| Error::from("List not found"))?;
+    let list_features: Vec<ListFeature> = list_row
+        .features
+        .as_deref()
+        .and_then(|s| serde_json::from_str(s).ok())
+        .unwrap_or_default();
+
+    Response::from_json(&ItemDetailResponse {
+        item,
+        list_name: list_row.name,
+        list_features,
+    })
 }
 
 pub async fn create(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
@@ -200,7 +227,10 @@ pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
     }
 
     if let Some(description) = &body.description {
-        let desc_val: JsValue = description.as_str().into();
+        let desc_val: JsValue = match description {
+            Some(s) => s.clone().into(),
+            None => JsValue::NULL,
+        };
         d1.prepare("UPDATE items SET description = ?1, updated_at = datetime('now') WHERE id = ?2")
             .bind(&[desc_val, id.clone().into()])?
             .run()

--- a/crates/api/src/handlers/items.rs
+++ b/crates/api/src/handlers/items.rs
@@ -227,9 +227,11 @@ pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
     }
 
     if let Some(description) = &body.description {
-        let desc_val: JsValue = match description {
-            Some(s) => s.clone().into(),
-            None => JsValue::NULL,
+        // Empty string is the sentinel for "clear description" (set NULL in DB).
+        let desc_val: JsValue = if description.is_empty() {
+            JsValue::NULL
+        } else {
+            description.clone().into()
         };
         d1.prepare("UPDATE items SET description = ?1, updated_at = datetime('now') WHERE id = ?2")
             .bind(&[desc_val, id.clone().into()])?

--- a/crates/api/src/handlers/items.rs
+++ b/crates/api/src/handlers/items.rs
@@ -30,6 +30,25 @@ pub async fn list_all(_req: Request, ctx: RouteContext<String>) -> Result<Respon
     Response::from_json(&items)
 }
 
+pub async fn get_one(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
+    let user_id = ctx.data.clone();
+    let id = require_param(&ctx, "id")?;
+    let d1 = ctx.env.d1("DB")?;
+
+    if !check_item_ownership(&d1, &id, &user_id).await? {
+        return json_error("item_not_found", 404);
+    }
+
+    let query = format!("SELECT {} FROM items WHERE id = ?1", ITEM_COLS);
+    let item = d1
+        .prepare(&query)
+        .bind(&[id.into()])?
+        .first::<Item>(None)
+        .await?
+        .ok_or_else(|| Error::from("Not found"))?;
+    Response::from_json(&item)
+}
+
 pub async fn create(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let list_id = require_param(&ctx, "list_id")?;

--- a/crates/api/src/router.rs
+++ b/crates/api/src/router.rs
@@ -46,6 +46,7 @@ pub async fn handle(req: Request, env: Env) -> Result<Response> {
         // Items
         .get_async("/api/lists/:list_id/items", items::list_all)
         .post_async("/api/lists/:list_id/items", items::create)
+        .get_async("/api/lists/:list_id/items/:id", items::get_one)
         .put_async("/api/lists/:list_id/items/:id", items::update)
         .delete_async("/api/lists/:list_id/items/:id", items::delete)
         // Cross-list queries

--- a/crates/frontend/src/api/items.rs
+++ b/crates/frontend/src/api/items.rs
@@ -10,6 +10,19 @@ pub async fn fetch_items(list_id: &str) -> Result<Vec<Item>, String> {
         .map_err(|e| e.to_string())
 }
 
+pub async fn fetch_item(list_id: &str, item_id: &str) -> Result<Item, String> {
+    super::get(&format!(
+        "{}/lists/{list_id}/items/{item_id}",
+        super::API_BASE
+    ))
+    .send()
+    .await
+    .map_err(|e| e.to_string())?
+    .json()
+    .await
+    .map_err(|e| e.to_string())
+}
+
 pub async fn create_item(list_id: &str, req: &CreateItemRequest) -> Result<Item, String> {
     super::post_json(&format!("{}/lists/{list_id}/items", super::API_BASE), req).await
 }

--- a/crates/frontend/src/api/items.rs
+++ b/crates/frontend/src/api/items.rs
@@ -10,7 +10,7 @@ pub async fn fetch_items(list_id: &str) -> Result<Vec<Item>, String> {
         .map_err(|e| e.to_string())
 }
 
-pub async fn fetch_item(list_id: &str, item_id: &str) -> Result<Item, String> {
+pub async fn fetch_item_detail(list_id: &str, item_id: &str) -> Result<ItemDetailResponse, String> {
     super::get(&format!(
         "{}/lists/{list_id}/items/{item_id}",
         super::API_BASE

--- a/crates/frontend/src/app.rs
+++ b/crates/frontend/src/app.rs
@@ -8,9 +8,9 @@ use crate::components::sync_locale::SyncLocale;
 use crate::components::toast_container::ToastContainer;
 use crate::pages::{
     calendar::CalendarPage, calendar::day::CalendarDayPage, container::ContainerPage,
-    home::HomePage, list::ListPage, login::LoginPage, oauth_consent::OAuthConsentPage,
-    settings::McpRedirect, settings::SettingsPage, signup::SignupPage, tags::TagsPage,
-    tags::detail::TagDetailPage, today::TodayPage,
+    home::HomePage, item_detail::ItemDetailPage, list::ListPage, login::LoginPage,
+    oauth_consent::OAuthConsentPage, settings::McpRedirect, settings::SettingsPage,
+    signup::SignupPage, tags::TagsPage, tags::detail::TagDetailPage, today::TodayPage,
 };
 
 #[derive(Clone, Debug, PartialEq)]
@@ -102,6 +102,7 @@ pub fn App() -> impl IntoView {
                         <Route path=path!("/calendar/:date") view=CalendarDayPage/>
                         <Route path=path!("/tags") view=TagsPage/>
                         <Route path=path!("/tags/:id") view=TagDetailPage/>
+                        <Route path=path!("/lists/:list_id/items/:id") view=ItemDetailPage/>
                         <Route path=path!("/lists/:id") view=ListPage/>
                         <Route path=path!("/containers/:id") view=ContainerPage/>
                     </Routes>

--- a/crates/frontend/src/components/common/inline_confirm_button.rs
+++ b/crates/frontend/src/components/common/inline_confirm_button.rs
@@ -1,0 +1,48 @@
+use leptos::prelude::*;
+
+/// Inline button that requires a second click to confirm.
+/// First click shows confirm_label for `timeout_ms`, then reverts.
+/// Distinct from `ConfirmDeleteModal` which is a modal dialog.
+#[component]
+pub fn InlineConfirmButton(
+    /// Callback when confirmed (second click)
+    on_confirm: Callback<()>,
+    /// Label shown normally
+    #[prop(default = "\u{2715}".to_string())]
+    label: String,
+    /// Label shown during confirm state
+    #[prop(default = "Na pewno?".to_string())]
+    confirm_label: String,
+    /// CSS class for normal state
+    #[prop(default = "btn btn-ghost btn-sm btn-square opacity-60 hover:opacity-100".to_string())]
+    class: String,
+    /// CSS class for confirm state
+    #[prop(default = "btn btn-error btn-sm".to_string())]
+    confirm_class: String,
+    /// Timeout in ms before reverting to normal state
+    #[prop(default = 2500)]
+    timeout_ms: u32,
+) -> impl IntoView {
+    let confirming = RwSignal::new(false);
+
+    view! {
+        <button
+            type="button"
+            class=move || if confirming.get() { confirm_class.clone() } else { class.clone() }
+            on:click=move |_| {
+                if confirming.get() {
+                    on_confirm.run(());
+                    confirming.set(false);
+                } else {
+                    confirming.set(true);
+                    set_timeout(
+                        move || confirming.set(false),
+                        std::time::Duration::from_millis(timeout_ms.into()),
+                    );
+                }
+            }
+        >
+            {move || if confirming.get() { confirm_label.clone() } else { label.clone() }}
+        </button>
+    }
+}

--- a/crates/frontend/src/components/common/mod.rs
+++ b/crates/frontend/src/components/common/mod.rs
@@ -1,10 +1,10 @@
 pub mod breadcrumbs;
-pub mod inline_confirm_button;
 pub mod confirm_delete_modal;
 pub mod date_utils;
 pub mod editable_color;
 pub mod editable_description;
 pub mod editable_title;
 pub mod error_display;
+pub mod inline_confirm_button;
 pub mod loading;
 pub mod toast_container;

--- a/crates/frontend/src/components/common/mod.rs
+++ b/crates/frontend/src/components/common/mod.rs
@@ -1,4 +1,5 @@
 pub mod breadcrumbs;
+pub mod inline_confirm_button;
 pub mod confirm_delete_modal;
 pub mod date_utils;
 pub mod editable_color;

--- a/crates/frontend/src/components/items/date_badge_chips.rs
+++ b/crates/frontend/src/components/items/date_badge_chips.rs
@@ -1,0 +1,63 @@
+use crate::components::common::date_utils::DateBadge;
+use leptos::prelude::*;
+
+/// Renders clickable date badge chips that toggle an editing_date signal.
+/// Used by ItemRow and DateItemRow.
+#[component]
+pub fn DateBadgeChips(
+    badges: Vec<DateBadge>,
+    editing_date: RwSignal<Option<String>>,
+    /// Show ghost chips for unset date types
+    #[prop(default = false)]
+    ghost_start: bool,
+    #[prop(default = false)]
+    ghost_deadline: bool,
+    #[prop(default = false)]
+    ghost_hard: bool,
+) -> impl IntoView {
+    let has_ghosts = ghost_start || ghost_deadline || ghost_hard;
+    if badges.is_empty() && !has_ghosts {
+        return view! {}.into_any();
+    }
+
+    view! {
+        <div class="flex gap-1 flex-wrap shrink-0">
+            {badges.into_iter().map(|b| {
+                let dt = b.date_type.to_string();
+                view! {
+                    <button type="button" class=format!("{} cursor-pointer", b.css)
+                        on:click=move |_| {
+                            let current = editing_date.get();
+                            if current.as_deref() == Some(dt.as_str()) {
+                                editing_date.set(None);
+                            } else {
+                                editing_date.set(Some(dt.clone()));
+                            }
+                        }
+                    >{b.label}</button>
+                }
+            }).collect::<Vec<_>>()}
+            {if ghost_start {
+                view! {
+                    <button type="button" class="badge badge-ghost badge-sm opacity-40 cursor-pointer"
+                        on:click=move |_| editing_date.set(Some("start".into()))
+                    >"+\u{1F4C5}"</button>
+                }.into_any()
+            } else { view! {}.into_any() }}
+            {if ghost_deadline {
+                view! {
+                    <button type="button" class="badge badge-ghost badge-sm opacity-40 cursor-pointer"
+                        on:click=move |_| editing_date.set(Some("deadline".into()))
+                    >"+\u{23F0}"</button>
+                }.into_any()
+            } else { view! {}.into_any() }}
+            {if ghost_hard {
+                view! {
+                    <button type="button" class="badge badge-ghost badge-sm opacity-40 cursor-pointer"
+                        on:click=move |_| editing_date.set(Some("hard_deadline".into()))
+                    >"+\u{1F6A8}"</button>
+                }.into_any()
+            } else { view! {}.into_any() }}
+        </div>
+    }.into_any()
+}

--- a/crates/frontend/src/components/items/date_badge_chips.rs
+++ b/crates/frontend/src/components/items/date_badge_chips.rs
@@ -1,4 +1,5 @@
 use crate::components::common::date_utils::DateBadge;
+use kartoteka_shared::{DATE_TYPE_DEADLINE, DATE_TYPE_HARD_DEADLINE, DATE_TYPE_START};
 use leptos::prelude::*;
 
 /// Renders clickable date badge chips that toggle an editing_date signal.
@@ -38,21 +39,21 @@ pub fn DateBadgeChips(
             {if ghost_start {
                 view! {
                     <button type="button" class="badge badge-ghost badge-sm opacity-40 cursor-pointer"
-                        on:click=move |_| editing_date.set(Some("start".into()))
+                        on:click=move |_| editing_date.set(Some(DATE_TYPE_START.into()))
                     >"+\u{1F4C5}"</button>
                 }.into_any()
             } else { view! {}.into_any() }}
             {if ghost_deadline {
                 view! {
                     <button type="button" class="badge badge-ghost badge-sm opacity-40 cursor-pointer"
-                        on:click=move |_| editing_date.set(Some("deadline".into()))
+                        on:click=move |_| editing_date.set(Some(DATE_TYPE_DEADLINE.into()))
                     >"+\u{23F0}"</button>
                 }.into_any()
             } else { view! {}.into_any() }}
             {if ghost_hard {
                 view! {
                     <button type="button" class="badge badge-ghost badge-sm opacity-40 cursor-pointer"
-                        on:click=move |_| editing_date.set(Some("hard_deadline".into()))
+                        on:click=move |_| editing_date.set(Some(DATE_TYPE_HARD_DEADLINE.into()))
                     >"+\u{1F6A8}"</button>
                 }.into_any()
             } else { view! {}.into_any() }}

--- a/crates/frontend/src/components/items/date_badge_chips.rs
+++ b/crates/frontend/src/components/items/date_badge_chips.rs
@@ -10,10 +10,8 @@ pub fn DateBadgeChips(
     /// Show ghost chips for unset date types
     #[prop(default = false)]
     ghost_start: bool,
-    #[prop(default = false)]
-    ghost_deadline: bool,
-    #[prop(default = false)]
-    ghost_hard: bool,
+    #[prop(default = false)] ghost_deadline: bool,
+    #[prop(default = false)] ghost_hard: bool,
 ) -> impl IntoView {
     let has_ghosts = ghost_start || ghost_deadline || ghost_hard;
     if badges.is_empty() && !has_ghosts {

--- a/crates/frontend/src/components/items/date_item_row.rs
+++ b/crates/frontend/src/components/items/date_item_row.rs
@@ -5,6 +5,7 @@ use crate::components::common::date_utils::{
     format_date_short, get_today_string, is_overdue, item_date_badges, relative_date,
 };
 use crate::components::common::inline_confirm_button::InlineConfirmButton;
+use crate::components::items::date_badge_chips::DateBadgeChips;
 use crate::components::items::inline_date_editor_section::InlineDateEditorSection;
 use crate::components::tags::tag_list::TagList;
 
@@ -141,25 +142,7 @@ pub fn DateItemRow(
                             selected_tag_ids=item_tag_ids.clone()
                             on_toggle=on_tag_toggle
                         />
-                        {secondary_badges.into_iter().map(|b| {
-                            if on_date_save.is_some() {
-                                let dt = b.date_type.to_string();
-                                view! {
-                                    <button type="button" class=format!("{} cursor-pointer", b.css)
-                                        on:click=move |_| {
-                                            let current = editing_date.get();
-                                            if current.as_deref() == Some(dt.as_str()) {
-                                                editing_date.set(None);
-                                            } else {
-                                                editing_date.set(Some(dt.clone()));
-                                            }
-                                        }
-                                    >{b.label}</button>
-                                }.into_any()
-                            } else {
-                                view! { <span class=b.css>{b.label}</span> }.into_any()
-                            }
-                        }).collect::<Vec<_>>()}
+                        <DateBadgeChips badges=secondary_badges editing_date=editing_date />
                     </div>
                 }.into_any()
             } else {

--- a/crates/frontend/src/components/items/date_item_row.rs
+++ b/crates/frontend/src/components/items/date_item_row.rs
@@ -4,6 +4,7 @@ use leptos::prelude::*;
 use crate::components::common::date_utils::{
     format_date_short, get_today_string, is_overdue, item_date_badges, relative_date,
 };
+use crate::components::common::inline_confirm_button::InlineConfirmButton;
 use crate::components::items::date_editor::DateEditor;
 use crate::components::tags::tag_list::TagList;
 
@@ -134,26 +135,7 @@ pub fn DateItemRow(
                     }.into_any()
                 }}
 
-                {
-                    let confirming = RwSignal::new(false);
-                    view! {
-                        <button
-                            type="button"
-                            class=move || if confirming.get() { "btn btn-error btn-sm" } else { "btn btn-ghost btn-sm btn-square opacity-60 hover:opacity-100" }
-                            on:click=move |_| {
-                                if confirming.get() {
-                                    on_delete.run(id_delete.clone());
-                                    confirming.set(false);
-                                } else {
-                                    confirming.set(true);
-                                    set_timeout(move || confirming.set(false), std::time::Duration::from_millis(2500));
-                                }
-                            }
-                        >
-                            {move || if confirming.get() { "Na pewno?" } else { "\u{2715}" }}
-                        </button>
-                    }
-                }
+                <InlineConfirmButton on_confirm=Callback::new(move |()| on_delete.run(id_delete.clone())) />
             </div>
 
             // Row 2: tags + secondary date badges (clickable)

--- a/crates/frontend/src/components/items/date_item_row.rs
+++ b/crates/frontend/src/components/items/date_item_row.rs
@@ -5,7 +5,7 @@ use crate::components::common::date_utils::{
     format_date_short, get_today_string, is_overdue, item_date_badges, relative_date,
 };
 use crate::components::common::inline_confirm_button::InlineConfirmButton;
-use crate::components::items::date_editor::DateEditor;
+use crate::components::items::inline_date_editor_section::InlineDateEditorSection;
 use crate::components::tags::tag_list::TagList;
 
 #[component]
@@ -21,6 +21,7 @@ pub fn DateItemRow(
     #[prop(optional)]
     on_date_save: Option<Callback<(String, String, String, Option<String>)>>,
 ) -> impl IntoView {
+    let item_for_editor = item.clone();
     let id_toggle = item.id.clone();
     let id_delete = item.id.clone();
     let id_for_editor = item.id.clone();
@@ -73,13 +74,6 @@ pub fn DateItemRow(
 
     // Date editing state
     let editing_date = RwSignal::new(Option::<String>::None);
-
-    // Store initial values for editor
-    let item_start_date = item.start_date.clone();
-    let item_start_time = item.start_time.clone();
-    let item_deadline = item.deadline.clone();
-    let item_deadline_time = item.deadline_time.clone();
-    let item_hard_deadline = item.hard_deadline.clone();
 
     // Primary date is clickable if on_date_save is available
     let primary_dt_str = primary_dt.to_string();
@@ -176,28 +170,15 @@ pub fn DateItemRow(
             {move || {
                 let dt = editing_date.get();
                 if let (Some(dt), Some(on_save)) = (dt, on_date_save) {
-                    let id_for_save = id_for_editor.clone();
-                    let dt_for_save = dt.clone();
-                    let (border, init_date, init_time, has_time) = match dt.as_str() {
-                        "start" => ("border-info", item_start_date.clone(), item_start_time.clone(), true),
-                        "hard_deadline" => ("border-error", item_hard_deadline.clone(), None, false),
-                        _ => ("border-warning", item_deadline.clone(), item_deadline_time.clone(), true),
-                    };
                     view! {
-                        <div class="pl-10 pb-2">
-                            <DateEditor
-                                border_color=border
-                                initial_date=init_date
-                                initial_time=init_time
-                                has_time=has_time
-                                on_change=Callback::new(move |(date, time): (String, Option<String>)| {
-                                    on_save.run((id_for_save.clone(), dt_for_save.clone(), date, time));
-                                })
-                            />
-                            <button type="button" class="btn btn-xs btn-ghost mt-1 opacity-50"
-                                on:click=move |_| editing_date.set(None)
-                            >"Zamknij"</button>
-                        </div>
+                        <InlineDateEditorSection
+                            date_type=dt
+                            item=item_for_editor.clone()
+                            item_id=id_for_editor.clone()
+                            on_save=on_save
+                            on_close=Callback::new(move |()| editing_date.set(None))
+                            wrapper_class="pl-10 pb-2".to_string()
+                        />
                     }.into_any()
                 } else {
                     view! {}.into_any()

--- a/crates/frontend/src/components/items/inline_date_editor_section.rs
+++ b/crates/frontend/src/components/items/inline_date_editor_section.rs
@@ -1,4 +1,4 @@
-use kartoteka_shared::Item;
+use kartoteka_shared::{DATE_TYPE_HARD_DEADLINE, DATE_TYPE_START, Item};
 use leptos::prelude::*;
 
 use super::date_editor::DateEditor;
@@ -22,13 +22,15 @@ pub fn InlineDateEditorSection(
     wrapper_class: String,
 ) -> impl IntoView {
     let (border, init_date, init_time, has_time) = match date_type.as_str() {
-        "start" => (
+        x if x == DATE_TYPE_START => (
             "border-info",
             item.start_date.clone(),
             item.start_time.clone(),
             true,
         ),
-        "hard_deadline" => ("border-error", item.hard_deadline.clone(), None, false),
+        x if x == DATE_TYPE_HARD_DEADLINE => {
+            ("border-error", item.hard_deadline.clone(), None, false)
+        }
         _ => (
             "border-warning",
             item.deadline.clone(),

--- a/crates/frontend/src/components/items/inline_date_editor_section.rs
+++ b/crates/frontend/src/components/items/inline_date_editor_section.rs
@@ -1,0 +1,59 @@
+use kartoteka_shared::Item;
+use leptos::prelude::*;
+
+use super::date_editor::DateEditor;
+
+/// Inline date editor section: resolves date_type to border color + initial values,
+/// renders DateEditor + close button. Used by ItemRow, DateItemRow.
+#[component]
+pub fn InlineDateEditorSection(
+    /// Which date type is being edited: "start", "deadline", or "hard_deadline"
+    date_type: String,
+    /// The item being edited (for initial date/time values)
+    item: Item,
+    /// Item ID for the save callback
+    item_id: String,
+    /// Called with (item_id, date_type, date_value, time_value)
+    on_save: Callback<(String, String, String, Option<String>)>,
+    /// Called when the close button is clicked
+    on_close: Callback<()>,
+    /// CSS class for the wrapper div
+    #[prop(default = "pl-14 pb-2".to_string())]
+    wrapper_class: String,
+) -> impl IntoView {
+    let (border, init_date, init_time, has_time) = match date_type.as_str() {
+        "start" => (
+            "border-info",
+            item.start_date.clone(),
+            item.start_time.clone(),
+            true,
+        ),
+        "hard_deadline" => ("border-error", item.hard_deadline.clone(), None, false),
+        _ => (
+            "border-warning",
+            item.deadline.clone(),
+            item.deadline_time.clone(),
+            true,
+        ),
+    };
+
+    let id_for_save = item_id;
+    let dt_for_save = date_type;
+
+    view! {
+        <div class=wrapper_class>
+            <DateEditor
+                border_color=border
+                initial_date=init_date
+                initial_time=init_time
+                has_time=has_time
+                on_change=Callback::new(move |(date, time): (String, Option<String>)| {
+                    on_save.run((id_for_save.clone(), dt_for_save.clone(), date, time));
+                })
+            />
+            <button type="button" class="btn btn-xs btn-ghost mt-1 opacity-50"
+                on:click=move |_| on_close.run(())
+            >"Zamknij"</button>
+        </div>
+    }
+}

--- a/crates/frontend/src/components/items/item_actions.rs
+++ b/crates/frontend/src/components/items/item_actions.rs
@@ -98,11 +98,7 @@ pub fn create_item_actions(
         leptos::task::spawn_local(async move {
             let req = UpdateItemRequest {
                 title: None,
-                description: Some(if new_desc.is_empty() {
-                    None
-                } else {
-                    Some(new_desc)
-                }),
+                description: Some(new_desc), // empty string = clear (sentinel)
                 completed: None,
                 position: None,
                 quantity: None,

--- a/crates/frontend/src/components/items/item_actions.rs
+++ b/crates/frontend/src/components/items/item_actions.rs
@@ -98,7 +98,11 @@ pub fn create_item_actions(
         leptos::task::spawn_local(async move {
             let req = UpdateItemRequest {
                 title: None,
-                description: Some(new_desc),
+                description: Some(if new_desc.is_empty() {
+                    None
+                } else {
+                    Some(new_desc)
+                }),
                 completed: None,
                 position: None,
                 quantity: None,

--- a/crates/frontend/src/components/items/item_row.rs
+++ b/crates/frontend/src/components/items/item_row.rs
@@ -31,6 +31,8 @@ pub fn ItemRow(
 ) -> impl IntoView {
     let item_for_editor = item.clone();
     let id = item.id.clone();
+    let item_list_id = item.list_id.clone();
+    let item_title = item.title.clone();
     let id_toggle = id.clone();
     let id_delete = id.clone();
     let id_move = id.clone();
@@ -101,7 +103,9 @@ pub fn ItemRow(
                 >
                     {move || if expanded.get() { "\u{25B2}" } else { "\u{25BC}" }}
                 </button>
-                <span class=title_class>{item.title}</span>
+                <a href=format!("/lists/{}/items/{}", item_list_id, id) class=format!("{title_class} hover:text-primary transition-colors no-underline")>
+                    {item_title.clone()}
+                </a>
 
                 // Date badges (clickable)
                 <DateBadgeChips

--- a/crates/frontend/src/components/items/item_row.rs
+++ b/crates/frontend/src/components/items/item_row.rs
@@ -3,6 +3,7 @@ use kartoteka_shared::Tag;
 use leptos::prelude::*;
 
 use crate::components::common::date_utils::item_date_badges;
+use crate::components::items::date_badge_chips::DateBadgeChips;
 use crate::components::items::inline_date_editor_section::InlineDateEditorSection;
 use crate::components::tags::tag_list::TagList;
 
@@ -80,7 +81,6 @@ pub fn ItemRow(
     let ghost_start = cfg_start && item.start_date.is_none();
     let ghost_deadline = cfg_deadline && item.deadline.is_none();
     let ghost_hard = cfg_hard && item.hard_deadline.is_none();
-    let has_ghosts = ghost_start || ghost_deadline || ghost_hard;
 
     view! {
         <div class="border-b border-base-300 py-1">
@@ -103,53 +103,13 @@ pub fn ItemRow(
                 <span class=title_class>{item.title}</span>
 
                 // Date badges (clickable)
-                {
-                    if date_badges.is_empty() && !has_ghosts {
-                        view! {}.into_any()
-                    } else {
-                        view! {
-                            <div class="flex gap-1 flex-wrap shrink-0">
-                                {date_badges.into_iter().map(|b| {
-                                    let dt = b.date_type.to_string();
-                                    view! {
-                                        <button type="button" class=format!("{} cursor-pointer", b.css)
-                                            on:click=move |_| {
-                                                let current = editing_date.get();
-                                                if current.as_deref() == Some(dt.as_str()) {
-                                                    editing_date.set(None);
-                                                } else {
-                                                    editing_date.set(Some(dt.clone()));
-                                                }
-                                            }
-                                        >{b.label}</button>
-                                    }
-                                }).collect::<Vec<_>>()}
-                                // Ghost chips for missing date types
-                                {if ghost_start {
-                                    view! {
-                                        <button type="button" class="badge badge-ghost badge-sm opacity-40 cursor-pointer"
-                                            on:click=move |_| editing_date.set(Some("start".into()))
-                                        >"+\u{1F4C5}"</button>
-                                    }.into_any()
-                                } else { view! {}.into_any() }}
-                                {if ghost_deadline {
-                                    view! {
-                                        <button type="button" class="badge badge-ghost badge-sm opacity-40 cursor-pointer"
-                                            on:click=move |_| editing_date.set(Some("deadline".into()))
-                                        >"+\u{23F0}"</button>
-                                    }.into_any()
-                                } else { view! {}.into_any() }}
-                                {if ghost_hard {
-                                    view! {
-                                        <button type="button" class="badge badge-ghost badge-sm opacity-40 cursor-pointer"
-                                            on:click=move |_| editing_date.set(Some("hard_deadline".into()))
-                                        >"+\u{1F6A8}"</button>
-                                    }.into_any()
-                                } else { view! {}.into_any() }}
-                            </div>
-                        }.into_any()
-                    }
-                }
+                <DateBadgeChips
+                    badges=date_badges
+                    editing_date=editing_date
+                    ghost_start=ghost_start
+                    ghost_deadline=ghost_deadline
+                    ghost_hard=ghost_hard
+                />
 
                 // Quantity stepper
                 {if show_stepper {

--- a/crates/frontend/src/components/items/item_row.rs
+++ b/crates/frontend/src/components/items/item_row.rs
@@ -5,6 +5,7 @@ use leptos::prelude::*;
 use crate::components::common::date_utils::item_date_badges;
 use crate::components::items::date_badge_chips::DateBadgeChips;
 use crate::components::items::inline_date_editor_section::InlineDateEditorSection;
+use crate::components::items::quantity_stepper::QuantityStepper;
 use crate::components::tags::tag_list::TagList;
 
 #[component]
@@ -54,7 +55,6 @@ pub fn ItemRow(
     // Quantity stepper state
     let show_stepper = has_quantity && item.quantity.is_some();
     let target_qty = item.quantity.unwrap_or(0);
-    let actual = RwSignal::new(item.actual_quantity.unwrap_or(0));
     let unit_label = item.unit.clone().unwrap_or_default();
     let id_for_stepper = id.clone();
 
@@ -113,37 +113,18 @@ pub fn ItemRow(
 
                 // Quantity stepper
                 {if show_stepper {
-                    let id_dec = id_for_stepper.clone();
-                    let id_inc = id_for_stepper.clone();
-                    let cb_dec = on_quantity_change;
-                    let cb_inc = on_quantity_change;
-                    let unit_str = unit_label.clone();
+                    let id_for_stepper_clone = id_for_stepper.clone();
                     view! {
-                        <div class="flex flex-col items-center gap-0.5">
-                            <div class="flex items-center gap-1">
-                                <button type="button" class="btn btn-xs btn-circle btn-ghost"
-                                    on:click=move |_| {
-                                        let new_val = (actual.get() - 1).max(0);
-                                        actual.set(new_val);
-                                        if let Some(cb) = cb_dec { cb.run((id_dec.clone(), new_val)); }
-                                    }
-                                >"\u{2212}"</button>
-                                <span class="text-sm font-mono">
-                                    {move || actual.get()} " / " {target_qty} " " {unit_str.clone()}
-                                </span>
-                                <button type="button" class="btn btn-xs btn-circle btn-ghost"
-                                    on:click=move |_| {
-                                        let new_val = actual.get() + 1;
-                                        actual.set(new_val);
-                                        if let Some(cb) = cb_inc { cb.run((id_inc.clone(), new_val)); }
-                                    }
-                                >"+"</button>
-                            </div>
-                            <progress class="progress progress-primary w-20 h-1"
-                                value=move || actual.get().to_string()
-                                max=target_qty.to_string()
-                            />
-                        </div>
+                        <QuantityStepper
+                            target=target_qty
+                            initial_actual=item.actual_quantity.unwrap_or(0)
+                            on_change=Callback::new(move |new_val: i32| {
+                                if let Some(cb) = on_quantity_change {
+                                    cb.run((id_for_stepper_clone.clone(), new_val));
+                                }
+                            })
+                            unit=unit_label.clone()
+                        />
                     }.into_any()
                 } else {
                     view! {}.into_any()

--- a/crates/frontend/src/components/items/item_row.rs
+++ b/crates/frontend/src/components/items/item_row.rs
@@ -3,7 +3,7 @@ use kartoteka_shared::Tag;
 use leptos::prelude::*;
 
 use crate::components::common::date_utils::item_date_badges;
-use crate::components::items::date_editor::DateEditor;
+use crate::components::items::inline_date_editor_section::InlineDateEditorSection;
 use crate::components::tags::tag_list::TagList;
 
 #[component]
@@ -26,6 +26,7 @@ pub fn ItemRow(
     #[prop(default = serde_json::Value::Null)]
     deadlines_config: serde_json::Value,
 ) -> impl IntoView {
+    let item_for_editor = item.clone();
     let id = item.id.clone();
     let id_toggle = id.clone();
     let id_delete = id.clone();
@@ -80,13 +81,6 @@ pub fn ItemRow(
     let ghost_deadline = cfg_deadline && item.deadline.is_none();
     let ghost_hard = cfg_hard && item.hard_deadline.is_none();
     let has_ghosts = ghost_start || ghost_deadline || ghost_hard;
-
-    // Store initial values for editor
-    let item_start_date = item.start_date.clone();
-    let item_start_time = item.start_time.clone();
-    let item_deadline = item.deadline.clone();
-    let item_deadline_time = item.deadline_time.clone();
-    let item_hard_deadline = item.hard_deadline.clone();
 
     view! {
         <div class="border-b border-base-300 py-1">
@@ -252,28 +246,14 @@ pub fn ItemRow(
             {move || {
                 let dt = editing_date.get();
                 if let (Some(dt), Some(on_save)) = (dt, on_date_save) {
-                    let id_for_save = id_for_editor.clone();
-                    let dt_for_save = dt.clone();
-                    let (border, init_date, init_time, has_time) = match dt.as_str() {
-                        "start" => ("border-info", item_start_date.clone(), item_start_time.clone(), true),
-                        "hard_deadline" => ("border-error", item_hard_deadline.clone(), None, false),
-                        _ => ("border-warning", item_deadline.clone(), item_deadline_time.clone(), true),
-                    };
                     view! {
-                        <div class="pl-14 pb-2">
-                            <DateEditor
-                                border_color=border
-                                initial_date=init_date
-                                initial_time=init_time
-                                has_time=has_time
-                                on_change=Callback::new(move |(date, time): (String, Option<String>)| {
-                                    on_save.run((id_for_save.clone(), dt_for_save.clone(), date, time));
-                                })
-                            />
-                            <button type="button" class="btn btn-xs btn-ghost mt-1 opacity-50"
-                                on:click=move |_| editing_date.set(None)
-                            >"Zamknij"</button>
-                        </div>
+                        <InlineDateEditorSection
+                            date_type=dt
+                            item=item_for_editor.clone()
+                            item_id=id_for_editor.clone()
+                            on_save=on_save
+                            on_close=Callback::new(move |()| editing_date.set(None))
+                        />
                     }.into_any()
                 } else {
                     view! {}.into_any()

--- a/crates/frontend/src/components/items/item_row.rs
+++ b/crates/frontend/src/components/items/item_row.rs
@@ -3,6 +3,7 @@ use kartoteka_shared::Tag;
 use leptos::prelude::*;
 
 use crate::components::common::date_utils::item_date_badges;
+use crate::components::common::editable_description::EditableDescription;
 use crate::components::items::date_badge_chips::DateBadgeChips;
 use crate::components::items::inline_date_editor_section::InlineDateEditorSection;
 use crate::components::items::quantity_stepper::QuantityStepper;
@@ -204,20 +205,18 @@ pub fn ItemRow(
             // Description (expandable)
             {move || {
                 if expanded.get() {
-                    let id_blur = id_for_desc.clone();
+                    let id_desc = id_for_desc.clone();
                     view! {
                         <div class="pl-14 pb-2">
-                            <textarea
-                                class="textarea textarea-bordered w-full text-sm resize-none"
-                                rows="3"
-                                placeholder="Dodaj opis..."
-                                prop:value=move || description_text.get()
-                                on:input=move |ev| description_text.set(event_target_value(&ev))
-                                on:blur=move |_| {
+                            <EditableDescription
+                                value=Some(description_text.get())
+                                on_save=Callback::new(move |new_val: Option<String>| {
+                                    let text = new_val.clone().unwrap_or_default();
+                                    description_text.set(text);
                                     if let Some(cb) = on_description_save {
-                                        cb.run((id_blur.clone(), description_text.get()));
+                                        cb.run((id_desc.clone(), new_val.unwrap_or_default()));
                                     }
-                                }
+                                })
                             />
                         </div>
                     }.into_any()

--- a/crates/frontend/src/components/items/mod.rs
+++ b/crates/frontend/src/components/items/mod.rs
@@ -6,3 +6,4 @@ pub mod date_item_row;
 pub mod inline_date_editor_section;
 pub mod item_actions;
 pub mod item_row;
+pub mod quantity_stepper;

--- a/crates/frontend/src/components/items/mod.rs
+++ b/crates/frontend/src/components/items/mod.rs
@@ -2,5 +2,6 @@ pub mod add_input;
 pub mod add_item_input;
 pub mod date_editor;
 pub mod date_item_row;
+pub mod inline_date_editor_section;
 pub mod item_actions;
 pub mod item_row;

--- a/crates/frontend/src/components/items/mod.rs
+++ b/crates/frontend/src/components/items/mod.rs
@@ -1,5 +1,6 @@
 pub mod add_input;
 pub mod add_item_input;
+pub mod date_badge_chips;
 pub mod date_editor;
 pub mod date_item_row;
 pub mod inline_date_editor_section;

--- a/crates/frontend/src/components/items/quantity_stepper.rs
+++ b/crates/frontend/src/components/items/quantity_stepper.rs
@@ -1,0 +1,41 @@
+use leptos::prelude::*;
+
+/// Quantity stepper: -/+ buttons, actual/target display, progress bar.
+/// Used by ItemRow and ItemDetailPage.
+#[component]
+pub fn QuantityStepper(
+    target: i32,
+    initial_actual: i32,
+    unit: String,
+    on_change: Callback<i32>,
+) -> impl IntoView {
+    let actual = RwSignal::new(initial_actual);
+
+    view! {
+        <div class="flex flex-col items-center gap-0.5">
+            <div class="flex items-center gap-1">
+                <button type="button" class="btn btn-xs btn-circle btn-ghost"
+                    on:click=move |_| {
+                        let new_val = (actual.get() - 1).max(0);
+                        actual.set(new_val);
+                        on_change.run(new_val);
+                    }
+                >"\u{2212}"</button>
+                <span class="text-sm font-mono">
+                    {move || actual.get()} " / " {target} " " {unit.clone()}
+                </span>
+                <button type="button" class="btn btn-xs btn-circle btn-ghost"
+                    on:click=move |_| {
+                        let new_val = actual.get() + 1;
+                        actual.set(new_val);
+                        on_change.run(new_val);
+                    }
+                >"+"</button>
+            </div>
+            <progress class="progress progress-primary w-20 h-1"
+                value=move || actual.get().to_string()
+                max=target.to_string()
+            />
+        </div>
+    }
+}

--- a/crates/frontend/src/pages/item_detail.rs
+++ b/crates/frontend/src/pages/item_detail.rs
@@ -1,4 +1,4 @@
-use crate::api::{delete_item, fetch_item, fetch_list, update_item};
+use crate::api::{delete_item, fetch_item_detail, update_item};
 use crate::app::{ToastContext, ToastKind};
 use crate::components::common::editable_description::EditableDescription;
 use crate::components::common::editable_title::EditableTitle;
@@ -29,30 +29,24 @@ pub fn ItemDetailPage() -> impl IntoView {
     let list_id = move || params.with(|p| p.get("list_id").unwrap_or_default().to_string());
     let item_id = move || params.with(|p| p.get("id").unwrap_or_default().to_string());
 
-    // Fetch item
-    let item_resource = LocalResource::new(move || {
+    // Single call returns item + list context
+    let detail_resource = LocalResource::new(move || {
         let lid = list_id();
         let iid = item_id();
-        async move { fetch_item(&lid, &iid).await }
-    });
-
-    // Fetch list (for name in breadcrumbs + features)
-    let list_resource = LocalResource::new(move || {
-        let lid = list_id();
-        async move { fetch_list(&lid).await }
+        async move { fetch_item_detail(&lid, &iid).await }
     });
 
     view! {
         <Suspense fallback=move || view! { <LoadingSpinner /> }>
             {move || {
-                let item_result = item_resource.get().map(|r| (*r).clone());
-                let list_result = list_resource.get().map(|r| (*r).clone());
+                let result = detail_resource.get().map(|r| (*r).clone());
 
-                match (item_result, list_result) {
-                    (Some(Ok(item)), Some(Ok(list))) => {
-                        let lid = list.id.clone();
-                        let list_name = list.name.clone();
-                        let features = list.features.clone();
+                match result {
+                    Some(Ok(detail)) => {
+                        let item = detail.item;
+                        let lid = list_id();
+                        let list_name = detail.list_name;
+                        let features = detail.list_features;
 
                         // Deadlines config
                         let deadlines_config = features
@@ -62,17 +56,21 @@ pub fn ItemDetailPage() -> impl IntoView {
                             .unwrap_or(serde_json::Value::Null);
                         let has_quantity = features.iter().any(|f| f.name == FEATURE_QUANTITY);
 
-                        let cfg_start = deadlines_config.get("has_start_date")
-                            .and_then(|v| v.as_bool()).unwrap_or(false);
-                        let cfg_deadline = deadlines_config.get("has_deadline")
-                            .and_then(|v| v.as_bool()).unwrap_or(false);
-                        let cfg_hard = deadlines_config.get("has_hard_deadline")
-                            .and_then(|v| v.as_bool()).unwrap_or(false);
+                        let cfg_start = deadlines_config
+                            .get("has_start_date")
+                            .and_then(|v| v.as_bool())
+                            .unwrap_or(false);
+                        let cfg_deadline = deadlines_config
+                            .get("has_deadline")
+                            .and_then(|v| v.as_bool())
+                            .unwrap_or(false);
+                        let cfg_hard = deadlines_config
+                            .get("has_hard_deadline")
+                            .and_then(|v| v.as_bool())
+                            .unwrap_or(false);
 
                         // Breadcrumbs (list name as link, item title as plain text)
-                        let crumbs = vec![
-                            (list_name, format!("/lists/{lid}")),
-                        ];
+                        let crumbs = vec![(list_name, format!("/lists/{lid}"))];
                         let item_title_for_crumb = item.title.clone();
 
                         // Completed toggle
@@ -89,9 +87,12 @@ pub fn ItemDetailPage() -> impl IntoView {
                             <div class="breadcrumbs text-sm mb-4">
                                 <ul>
                                     <li><a href="/">"Home"</a></li>
-                                    {crumbs.into_iter().map(|(label, href)| {
-                                        view! { <li><a href=href>{label}</a></li> }
-                                    }).collect::<Vec<_>>()}
+                                    {crumbs
+                                        .into_iter()
+                                        .map(|(label, href)| {
+                                            view! { <li><a href=href>{label}</a></li> }
+                                        })
+                                        .collect::<Vec<_>>()}
                                     <li>{item_title_for_crumb}</li>
                                 </ul>
                             </div>
@@ -105,31 +106,46 @@ pub fn ItemDetailPage() -> impl IntoView {
                                     on:change=move |_| {
                                         let new_val = !completed.get();
                                         completed.set(new_val);
-                                        spawn_save(list_id(), item_id(), toast.clone(), UpdateItemRequest {
-                                            completed: Some(new_val),
-                                            ..Default::default()
-                                        });
+                                        spawn_save(
+                                            list_id(),
+                                            item_id(),
+                                            toast.clone(),
+                                            UpdateItemRequest {
+                                                completed: Some(new_val),
+                                                ..Default::default()
+                                            },
+                                        );
                                     }
                                 />
                                 <EditableTitle
                                     value=item.title.clone()
                                     on_save=Callback::new(move |new_title: String| {
-                                        spawn_save(list_id(), item_id(), toast.clone(), UpdateItemRequest {
-                                            title: Some(new_title),
-                                            ..Default::default()
-                                        });
+                                        spawn_save(
+                                            list_id(),
+                                            item_id(),
+                                            toast.clone(),
+                                            UpdateItemRequest {
+                                                title: Some(new_title),
+                                                ..Default::default()
+                                            },
+                                        );
                                     })
                                 />
                             </div>
 
-                            // Description
+                            // Description (None from EditableDescription means "clear")
                             <EditableDescription
                                 value=item.description.clone()
                                 on_save=Callback::new(move |new_desc: Option<String>| {
-                                    spawn_save(list_id(), item_id(), toast.clone(), UpdateItemRequest {
-                                        description: new_desc,
-                                        ..Default::default()
-                                    });
+                                    spawn_save(
+                                        list_id(),
+                                        item_id(),
+                                        toast.clone(),
+                                        UpdateItemRequest {
+                                            description: Some(new_desc),
+                                            ..Default::default()
+                                        },
+                                    );
                                 })
                             />
 
@@ -137,28 +153,40 @@ pub fn ItemDetailPage() -> impl IntoView {
                             {if cfg_start {
                                 view! {
                                     <div class="mb-4">
-                                        <label class="label text-sm font-medium">"Data rozpoczęcia"</label>
+                                        <label class="label text-sm font-medium">
+                                            "Data rozpoczęcia"
+                                        </label>
                                         <DateEditor
                                             border_color="border-info"
                                             initial_date=item.start_date.clone()
                                             initial_time=item.start_time.clone()
                                             has_time=true
-                                            on_change=Callback::new(move |(date, time): (String, Option<String>)| {
-                                                let (d, t) = if date.is_empty() {
-                                                    (Some(None), Some(None))
-                                                } else {
-                                                    (Some(Some(date)), time.map(Some))
-                                                };
-                                                spawn_save(list_id(), item_id(), toast.clone(), UpdateItemRequest {
-                                                    start_date: d,
-                                                    start_time: t,
-                                                    ..Default::default()
-                                                });
-                                            })
+                                            on_change=Callback::new(
+                                                move |(date, time): (String, Option<String>)| {
+                                                    let (d, t) = if date.is_empty() {
+                                                        (Some(None), Some(None))
+                                                    } else {
+                                                        (Some(Some(date)), time.map(Some))
+                                                    };
+                                                    spawn_save(
+                                                        list_id(),
+                                                        item_id(),
+                                                        toast.clone(),
+                                                        UpdateItemRequest {
+                                                            start_date: d,
+                                                            start_time: t,
+                                                            ..Default::default()
+                                                        },
+                                                    );
+                                                },
+                                            )
                                         />
                                     </div>
-                                }.into_any()
-                            } else { view! {}.into_any() }}
+                                }
+                                    .into_any()
+                            } else {
+                                view! {}.into_any()
+                            }}
 
                             {if cfg_deadline {
                                 view! {
@@ -169,22 +197,32 @@ pub fn ItemDetailPage() -> impl IntoView {
                                             initial_date=item.deadline.clone()
                                             initial_time=item.deadline_time.clone()
                                             has_time=true
-                                            on_change=Callback::new(move |(date, time): (String, Option<String>)| {
-                                                let (d, t) = if date.is_empty() {
-                                                    (Some(None), Some(None))
-                                                } else {
-                                                    (Some(Some(date)), time.map(Some))
-                                                };
-                                                spawn_save(list_id(), item_id(), toast.clone(), UpdateItemRequest {
-                                                    deadline: d,
-                                                    deadline_time: t,
-                                                    ..Default::default()
-                                                });
-                                            })
+                                            on_change=Callback::new(
+                                                move |(date, time): (String, Option<String>)| {
+                                                    let (d, t) = if date.is_empty() {
+                                                        (Some(None), Some(None))
+                                                    } else {
+                                                        (Some(Some(date)), time.map(Some))
+                                                    };
+                                                    spawn_save(
+                                                        list_id(),
+                                                        item_id(),
+                                                        toast.clone(),
+                                                        UpdateItemRequest {
+                                                            deadline: d,
+                                                            deadline_time: t,
+                                                            ..Default::default()
+                                                        },
+                                                    );
+                                                },
+                                            )
                                         />
                                     </div>
-                                }.into_any()
-                            } else { view! {}.into_any() }}
+                                }
+                                    .into_any()
+                            } else {
+                                view! {}.into_any()
+                            }}
 
                             {if cfg_hard {
                                 let no_time: Option<String> = None;
@@ -196,21 +234,31 @@ pub fn ItemDetailPage() -> impl IntoView {
                                             initial_date=item.hard_deadline.clone()
                                             initial_time=no_time
                                             has_time=false
-                                            on_change=Callback::new(move |(date, _time): (String, Option<String>)| {
-                                                let d = if date.is_empty() {
-                                                    Some(None)
-                                                } else {
-                                                    Some(Some(date))
-                                                };
-                                                spawn_save(list_id(), item_id(), toast.clone(), UpdateItemRequest {
-                                                    hard_deadline: d,
-                                                    ..Default::default()
-                                                });
-                                            })
+                                            on_change=Callback::new(
+                                                move |(date, _time): (String, Option<String>)| {
+                                                    let d = if date.is_empty() {
+                                                        Some(None)
+                                                    } else {
+                                                        Some(Some(date))
+                                                    };
+                                                    spawn_save(
+                                                        list_id(),
+                                                        item_id(),
+                                                        toast.clone(),
+                                                        UpdateItemRequest {
+                                                            hard_deadline: d,
+                                                            ..Default::default()
+                                                        },
+                                                    );
+                                                },
+                                            )
                                         />
                                     </div>
-                                }.into_any()
-                            } else { view! {}.into_any() }}
+                                }
+                                    .into_any()
+                            } else {
+                                view! {}.into_any()
+                            }}
 
                             // Quantity section
                             {if has_quantity {
@@ -224,15 +272,23 @@ pub fn ItemDetailPage() -> impl IntoView {
                                             initial_actual=item.actual_quantity.unwrap_or(0)
                                             unit=unit
                                             on_change=Callback::new(move |new_val: i32| {
-                                                spawn_save(list_id(), item_id(), toast.clone(), UpdateItemRequest {
-                                                    actual_quantity: Some(new_val),
-                                                    ..Default::default()
-                                                });
+                                                spawn_save(
+                                                    list_id(),
+                                                    item_id(),
+                                                    toast.clone(),
+                                                    UpdateItemRequest {
+                                                        actual_quantity: Some(new_val),
+                                                        ..Default::default()
+                                                    },
+                                                );
                                             })
                                         />
                                     </div>
-                                }.into_any()
-                            } else { view! {}.into_any() }}
+                                }
+                                    .into_any()
+                            } else {
+                                view! {}.into_any()
+                            }}
 
                             // Delete button
                             <div class="mt-8 pt-4 border-t border-base-300">
@@ -248,7 +304,12 @@ pub fn ItemDetailPage() -> impl IntoView {
                                                     toast.push("Usunięto".into(), ToastKind::Success);
                                                     nav(&format!("/lists/{lid}"), Default::default());
                                                 }
-                                                Err(e) => toast.push(format!("Błąd: {e}"), ToastKind::Error),
+                                                Err(e) => {
+                                                    toast.push(
+                                                        format!("Błąd: {e}"),
+                                                        ToastKind::Error,
+                                                    )
+                                                }
                                             }
                                         });
                                     })
@@ -258,12 +319,13 @@ pub fn ItemDetailPage() -> impl IntoView {
                                     confirm_class="btn btn-error btn-sm".to_string()
                                 />
                             </div>
-                        }.into_any()
+                        }
+                            .into_any()
                     }
-                    (Some(Err(e)), _) | (_, Some(Err(e))) => {
+                    Some(Err(e)) => {
                         view! { <p class="text-error">{format!("Błąd: {e}")}</p> }.into_any()
                     }
-                    _ => view! { <LoadingSpinner /> }.into_any(),
+                    None => view! { <LoadingSpinner /> }.into_any(),
                 }
             }}
         </Suspense>

--- a/crates/frontend/src/pages/item_detail.rs
+++ b/crates/frontend/src/pages/item_detail.rs
@@ -215,7 +215,7 @@ pub fn ItemDetailPage() -> impl IntoView {
                             } else { view! {}.into_any() }}
 
                             // Quantity section
-                            {if has_quantity && item.quantity.is_some() {
+                            {if has_quantity {
                                 let target = item.quantity.unwrap_or(0);
                                 let unit = item.unit.clone().unwrap_or_default();
                                 view! {

--- a/crates/frontend/src/pages/item_detail.rs
+++ b/crates/frontend/src/pages/item_detail.rs
@@ -26,10 +26,8 @@ pub fn ItemDetailPage() -> impl IntoView {
     let toast = expect_context::<ToastContext>();
     let navigate = leptos_router::hooks::use_navigate();
 
-    let list_id =
-        move || params.with(|p| p.get("list_id").unwrap_or_default().to_string());
-    let item_id =
-        move || params.with(|p| p.get("id").unwrap_or_default().to_string());
+    let list_id = move || params.with(|p| p.get("list_id").unwrap_or_default().to_string());
+    let item_id = move || params.with(|p| p.get("id").unwrap_or_default().to_string());
 
     // Fetch item
     let item_resource = LocalResource::new(move || {

--- a/crates/frontend/src/pages/item_detail.rs
+++ b/crates/frontend/src/pages/item_detail.rs
@@ -1,0 +1,273 @@
+use crate::api::{delete_item, fetch_item, fetch_list, update_item};
+use crate::app::{ToastContext, ToastKind};
+use crate::components::common::editable_description::EditableDescription;
+use crate::components::common::editable_title::EditableTitle;
+use crate::components::common::inline_confirm_button::InlineConfirmButton;
+use crate::components::common::loading::LoadingSpinner;
+use crate::components::items::date_editor::DateEditor;
+use crate::components::items::quantity_stepper::QuantityStepper;
+use kartoteka_shared::*;
+use leptos::prelude::*;
+use leptos_router::hooks::use_params_map;
+
+/// Helper: spawn an update_item call with toast feedback.
+fn spawn_save(list_id: String, item_id: String, toast: ToastContext, req: UpdateItemRequest) {
+    leptos::task::spawn_local(async move {
+        match update_item(&list_id, &item_id, &req).await {
+            Ok(_) => toast.push("Zapisano".into(), ToastKind::Success),
+            Err(e) => toast.push(format!("Błąd: {e}"), ToastKind::Error),
+        }
+    });
+}
+
+#[component]
+pub fn ItemDetailPage() -> impl IntoView {
+    let params = use_params_map();
+    let toast = expect_context::<ToastContext>();
+    let navigate = leptos_router::hooks::use_navigate();
+
+    let list_id =
+        move || params.with(|p| p.get("list_id").unwrap_or_default().to_string());
+    let item_id =
+        move || params.with(|p| p.get("id").unwrap_or_default().to_string());
+
+    // Fetch item
+    let item_resource = LocalResource::new(move || {
+        let lid = list_id();
+        let iid = item_id();
+        async move { fetch_item(&lid, &iid).await }
+    });
+
+    // Fetch list (for name in breadcrumbs + features)
+    let list_resource = LocalResource::new(move || {
+        let lid = list_id();
+        async move { fetch_list(&lid).await }
+    });
+
+    view! {
+        <Suspense fallback=move || view! { <LoadingSpinner /> }>
+            {move || {
+                let item_result = item_resource.get().map(|r| (*r).clone());
+                let list_result = list_resource.get().map(|r| (*r).clone());
+
+                match (item_result, list_result) {
+                    (Some(Ok(item)), Some(Ok(list))) => {
+                        let lid = list.id.clone();
+                        let list_name = list.name.clone();
+                        let features = list.features.clone();
+
+                        // Deadlines config
+                        let deadlines_config = features
+                            .iter()
+                            .find(|f| f.name == FEATURE_DEADLINES)
+                            .map(|f| f.config.clone())
+                            .unwrap_or(serde_json::Value::Null);
+                        let has_quantity = features.iter().any(|f| f.name == FEATURE_QUANTITY);
+
+                        let cfg_start = deadlines_config.get("has_start_date")
+                            .and_then(|v| v.as_bool()).unwrap_or(false);
+                        let cfg_deadline = deadlines_config.get("has_deadline")
+                            .and_then(|v| v.as_bool()).unwrap_or(false);
+                        let cfg_hard = deadlines_config.get("has_hard_deadline")
+                            .and_then(|v| v.as_bool()).unwrap_or(false);
+
+                        // Breadcrumbs (list name as link, item title as plain text)
+                        let crumbs = vec![
+                            (list_name, format!("/lists/{lid}")),
+                        ];
+                        let item_title_for_crumb = item.title.clone();
+
+                        // Completed toggle
+                        let completed = RwSignal::new(item.completed);
+
+                        // Delete
+                        let lid_for_delete = list_id();
+                        let iid_for_delete = item_id();
+                        let toast_del = toast.clone();
+                        let nav = navigate.clone();
+
+                        view! {
+                            // Breadcrumbs with item title as non-linked final crumb
+                            <div class="breadcrumbs text-sm mb-4">
+                                <ul>
+                                    <li><a href="/">"Home"</a></li>
+                                    {crumbs.into_iter().map(|(label, href)| {
+                                        view! { <li><a href=href>{label}</a></li> }
+                                    }).collect::<Vec<_>>()}
+                                    <li>{item_title_for_crumb}</li>
+                                </ul>
+                            </div>
+
+                            // Completed checkbox + title
+                            <div class="flex items-center gap-3 mb-4">
+                                <input
+                                    type="checkbox"
+                                    class="checkbox checkbox-secondary checkbox-lg"
+                                    checked=item.completed
+                                    on:change=move |_| {
+                                        let new_val = !completed.get();
+                                        completed.set(new_val);
+                                        spawn_save(list_id(), item_id(), toast.clone(), UpdateItemRequest {
+                                            completed: Some(new_val),
+                                            ..Default::default()
+                                        });
+                                    }
+                                />
+                                <EditableTitle
+                                    value=item.title.clone()
+                                    on_save=Callback::new(move |new_title: String| {
+                                        spawn_save(list_id(), item_id(), toast.clone(), UpdateItemRequest {
+                                            title: Some(new_title),
+                                            ..Default::default()
+                                        });
+                                    })
+                                />
+                            </div>
+
+                            // Description
+                            <EditableDescription
+                                value=item.description.clone()
+                                on_save=Callback::new(move |new_desc: Option<String>| {
+                                    spawn_save(list_id(), item_id(), toast.clone(), UpdateItemRequest {
+                                        description: new_desc,
+                                        ..Default::default()
+                                    });
+                                })
+                            />
+
+                            // Dates section
+                            {if cfg_start {
+                                view! {
+                                    <div class="mb-4">
+                                        <label class="label text-sm font-medium">"Data rozpoczęcia"</label>
+                                        <DateEditor
+                                            border_color="border-info"
+                                            initial_date=item.start_date.clone()
+                                            initial_time=item.start_time.clone()
+                                            has_time=true
+                                            on_change=Callback::new(move |(date, time): (String, Option<String>)| {
+                                                let (d, t) = if date.is_empty() {
+                                                    (Some(None), Some(None))
+                                                } else {
+                                                    (Some(Some(date)), time.map(Some))
+                                                };
+                                                spawn_save(list_id(), item_id(), toast.clone(), UpdateItemRequest {
+                                                    start_date: d,
+                                                    start_time: t,
+                                                    ..Default::default()
+                                                });
+                                            })
+                                        />
+                                    </div>
+                                }.into_any()
+                            } else { view! {}.into_any() }}
+
+                            {if cfg_deadline {
+                                view! {
+                                    <div class="mb-4">
+                                        <label class="label text-sm font-medium">"Termin"</label>
+                                        <DateEditor
+                                            border_color="border-warning"
+                                            initial_date=item.deadline.clone()
+                                            initial_time=item.deadline_time.clone()
+                                            has_time=true
+                                            on_change=Callback::new(move |(date, time): (String, Option<String>)| {
+                                                let (d, t) = if date.is_empty() {
+                                                    (Some(None), Some(None))
+                                                } else {
+                                                    (Some(Some(date)), time.map(Some))
+                                                };
+                                                spawn_save(list_id(), item_id(), toast.clone(), UpdateItemRequest {
+                                                    deadline: d,
+                                                    deadline_time: t,
+                                                    ..Default::default()
+                                                });
+                                            })
+                                        />
+                                    </div>
+                                }.into_any()
+                            } else { view! {}.into_any() }}
+
+                            {if cfg_hard {
+                                let no_time: Option<String> = None;
+                                view! {
+                                    <div class="mb-4">
+                                        <label class="label text-sm font-medium">"Twardy termin"</label>
+                                        <DateEditor
+                                            border_color="border-error"
+                                            initial_date=item.hard_deadline.clone()
+                                            initial_time=no_time
+                                            has_time=false
+                                            on_change=Callback::new(move |(date, _time): (String, Option<String>)| {
+                                                let d = if date.is_empty() {
+                                                    Some(None)
+                                                } else {
+                                                    Some(Some(date))
+                                                };
+                                                spawn_save(list_id(), item_id(), toast.clone(), UpdateItemRequest {
+                                                    hard_deadline: d,
+                                                    ..Default::default()
+                                                });
+                                            })
+                                        />
+                                    </div>
+                                }.into_any()
+                            } else { view! {}.into_any() }}
+
+                            // Quantity section
+                            {if has_quantity && item.quantity.is_some() {
+                                let target = item.quantity.unwrap_or(0);
+                                let unit = item.unit.clone().unwrap_or_default();
+                                view! {
+                                    <div class="mb-4">
+                                        <label class="label text-sm font-medium">"Ilość"</label>
+                                        <QuantityStepper
+                                            target=target
+                                            initial_actual=item.actual_quantity.unwrap_or(0)
+                                            unit=unit
+                                            on_change=Callback::new(move |new_val: i32| {
+                                                spawn_save(list_id(), item_id(), toast.clone(), UpdateItemRequest {
+                                                    actual_quantity: Some(new_val),
+                                                    ..Default::default()
+                                                });
+                                            })
+                                        />
+                                    </div>
+                                }.into_any()
+                            } else { view! {}.into_any() }}
+
+                            // Delete button
+                            <div class="mt-8 pt-4 border-t border-base-300">
+                                <InlineConfirmButton
+                                    on_confirm=Callback::new(move |()| {
+                                        let lid = lid_for_delete.clone();
+                                        let iid = iid_for_delete.clone();
+                                        let toast = toast_del.clone();
+                                        let nav = nav.clone();
+                                        leptos::task::spawn_local(async move {
+                                            match delete_item(&lid, &iid).await {
+                                                Ok(_) => {
+                                                    toast.push("Usunięto".into(), ToastKind::Success);
+                                                    nav(&format!("/lists/{lid}"), Default::default());
+                                                }
+                                                Err(e) => toast.push(format!("Błąd: {e}"), ToastKind::Error),
+                                            }
+                                        });
+                                    })
+                                    label="Usuń element".to_string()
+                                    confirm_label="Na pewno usunąć?".to_string()
+                                    class="btn btn-error btn-outline btn-sm".to_string()
+                                    confirm_class="btn btn-error btn-sm".to_string()
+                                />
+                            </div>
+                        }.into_any()
+                    }
+                    (Some(Err(e)), _) | (_, Some(Err(e))) => {
+                        view! { <p class="text-error">{format!("Błąd: {e}")}</p> }.into_any()
+                    }
+                    _ => view! { <LoadingSpinner /> }.into_any(),
+                }
+            }}
+        </Suspense>
+    }
+}

--- a/crates/frontend/src/pages/item_detail.rs
+++ b/crates/frontend/src/pages/item_detail.rs
@@ -133,7 +133,7 @@ pub fn ItemDetailPage() -> impl IntoView {
                                 />
                             </div>
 
-                            // Description (None from EditableDescription means "clear")
+                            // Description — empty string is the sentinel for "clear"
                             <EditableDescription
                                 value=item.description.clone()
                                 on_save=Callback::new(move |new_desc: Option<String>| {
@@ -142,7 +142,7 @@ pub fn ItemDetailPage() -> impl IntoView {
                                         item_id(),
                                         toast.clone(),
                                         UpdateItemRequest {
-                                            description: Some(new_desc),
+                                            description: Some(new_desc.unwrap_or_default()),
                                             ..Default::default()
                                         },
                                     );

--- a/crates/frontend/src/pages/mod.rs
+++ b/crates/frontend/src/pages/mod.rs
@@ -1,6 +1,7 @@
 pub mod calendar;
 pub mod container;
 pub mod home;
+pub mod item_detail;
 pub mod list;
 pub mod login;
 pub mod oauth_consent;

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -103,6 +103,11 @@ pub struct HomeData {
 pub const FEATURE_QUANTITY: &str = "quantity";
 pub const FEATURE_DEADLINES: &str = "deadlines";
 
+/// Date type identifiers used in date badge/editor components
+pub const DATE_TYPE_START: &str = "start";
+pub const DATE_TYPE_DEADLINE: &str = "deadline";
+pub const DATE_TYPE_HARD_DEADLINE: &str = "hard_deadline";
+
 pub const SETTING_MCP_AUTO_ENABLE_FEATURES: &str = "mcp_auto_enable_features";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -287,7 +292,7 @@ pub struct CreateItemRequest {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct UpdateItemRequest {
     pub title: Option<String>,
-    pub description: Option<String>,
+    pub description: Option<Option<String>>,
     pub completed: Option<bool>,
     pub position: Option<i32>,
     pub quantity: Option<i32>,
@@ -298,6 +303,15 @@ pub struct UpdateItemRequest {
     pub deadline: Option<Option<String>>,
     pub deadline_time: Option<Option<String>>,
     pub hard_deadline: Option<Option<String>>,
+}
+
+/// Response from GET /api/lists/:list_id/items/:id — item + list context in one call.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ItemDetailResponse {
+    #[serde(flatten)]
+    pub item: Item,
+    pub list_name: String,
+    pub list_features: Vec<ListFeature>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -292,7 +292,7 @@ pub struct CreateItemRequest {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct UpdateItemRequest {
     pub title: Option<String>,
-    pub description: Option<Option<String>>,
+    pub description: Option<String>,
     pub completed: Option<bool>,
     pub position: Option<i32>,
     pub quantity: Option<i32>,

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -284,7 +284,7 @@ pub struct CreateItemRequest {
     pub hard_deadline: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct UpdateItemRequest {
     pub title: Option<String>,
     pub description: Option<String>,

--- a/crates/shared/src/tests/items.rs
+++ b/crates/shared/src/tests/items.rs
@@ -24,31 +24,27 @@ fn update_item_value_field_is_some_some() {
     assert!(matches!(req.deadline, Some(Some(ref d)) if d == "2024-12-31"));
 }
 
-// --- UpdateItemRequest description (Option<Option<String>>) ---
+// --- UpdateItemRequest description sentinel convention ---
 
 #[test]
 fn update_item_description_absent_is_none() {
+    // None = don't touch description
     let req: UpdateItemRequest = serde_json::from_str(r#"{}"#).unwrap();
-    assert!(req.description.is_none(), "absent = don't touch");
+    assert!(req.description.is_none());
 }
 
 #[test]
-fn update_item_description_null_is_none() {
-    // serde collapses Option<Option<String>>: null == absent == None (outer).
-    // This means sending {"description": null} CANNOT clear the description —
-    // the backend sees None and skips the update entirely.
-    // Actual clearing requires a custom deserializer or a sentinel value.
-    let req: UpdateItemRequest = serde_json::from_str(r#"{"description": null}"#).unwrap();
-    assert!(
-        req.description.is_none(),
-        "null also becomes None — cannot clear via null JSON"
-    );
+fn update_item_description_empty_string_is_clear_sentinel() {
+    // Some("") = clear description (set NULL in DB). Empty string is the sentinel
+    // because serde cannot distinguish Option<Option<T>> null from absent.
+    let req: UpdateItemRequest = serde_json::from_str(r#"{"description": ""}"#).unwrap();
+    assert!(matches!(req.description, Some(ref d) if d.is_empty()));
 }
 
 #[test]
-fn update_item_description_value_is_some_some() {
+fn update_item_description_value_is_some_string() {
     let req: UpdateItemRequest = serde_json::from_str(r#"{"description": "hello"}"#).unwrap();
-    assert!(matches!(req.description, Some(Some(ref d)) if d == "hello"));
+    assert!(matches!(req.description, Some(ref d) if d == "hello"));
 }
 
 // --- DateItem -> Item conversion ---

--- a/crates/shared/src/tests/items.rs
+++ b/crates/shared/src/tests/items.rs
@@ -24,6 +24,33 @@ fn update_item_value_field_is_some_some() {
     assert!(matches!(req.deadline, Some(Some(ref d)) if d == "2024-12-31"));
 }
 
+// --- UpdateItemRequest description (Option<Option<String>>) ---
+
+#[test]
+fn update_item_description_absent_is_none() {
+    let req: UpdateItemRequest = serde_json::from_str(r#"{}"#).unwrap();
+    assert!(req.description.is_none(), "absent = don't touch");
+}
+
+#[test]
+fn update_item_description_null_is_none() {
+    // serde collapses Option<Option<String>>: null == absent == None (outer).
+    // This means sending {"description": null} CANNOT clear the description —
+    // the backend sees None and skips the update entirely.
+    // Actual clearing requires a custom deserializer or a sentinel value.
+    let req: UpdateItemRequest = serde_json::from_str(r#"{"description": null}"#).unwrap();
+    assert!(
+        req.description.is_none(),
+        "null also becomes None — cannot clear via null JSON"
+    );
+}
+
+#[test]
+fn update_item_description_value_is_some_some() {
+    let req: UpdateItemRequest = serde_json::from_str(r#"{"description": "hello"}"#).unwrap();
+    assert!(matches!(req.description, Some(Some(ref d)) if d == "hello"));
+}
+
 // --- DateItem -> Item conversion ---
 
 #[test]

--- a/docs/superpowers/plans/2026-03-29-item-detail-page.md
+++ b/docs/superpowers/plans/2026-03-29-item-detail-page.md
@@ -1,0 +1,1100 @@
+# Item Detail Page Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a dedicated item detail page with auto-save editing, and refactor shared components out of ItemRow/DateItemRow to reduce duplication.
+
+**Architecture:** New route `/lists/:list_id/items/:id` with a detail page component. API gets a new `GET` endpoint for single item fetch. Four shared components extracted from ItemRow/DateItemRow before building the detail page.
+
+**Tech Stack:** Rust, Leptos 0.7 CSR, worker crate (CF Workers), D1/SQLite, DaisyUI 5, gloo-net 0.6
+
+**Spec:** `docs/superpowers/specs/2026-03-29-item-detail-page-design.md`
+
+---
+
+## File Map
+
+### New files
+| File | Purpose |
+|---|---|
+| `crates/frontend/src/components/items/inline_date_editor_section.rs` | Shared: date type → DateEditor + close button |
+| `crates/frontend/src/components/items/date_badge_chips.rs` | Shared: clickable date badge rendering |
+| `crates/frontend/src/components/items/quantity_stepper.rs` | Shared: quantity actual/target stepper with progress |
+| `crates/frontend/src/components/common/inline_confirm_button.rs` | Shared: button with confirm-on-click + timeout |
+| `crates/frontend/src/pages/item_detail.rs` | Item detail page component |
+
+### Modified files
+| File | Changes |
+|---|---|
+| `crates/api/src/handlers/items.rs` | Add `get_one` handler |
+| `crates/api/src/router.rs` | Add GET route for single item |
+| `crates/frontend/src/api/items.rs` | Add `fetch_item` function |
+| `crates/frontend/src/components/items/item_row.rs` | Use shared components, title → link |
+| `crates/frontend/src/components/items/date_item_row.rs` | Use shared components |
+| `crates/frontend/src/components/items/mod.rs` | Add new module exports |
+| `crates/frontend/src/components/common/mod.rs` | Add `inline_confirm_button` module |
+| `crates/frontend/src/pages/mod.rs` | Add `item_detail` module |
+| `crates/frontend/src/app.rs` | Add route for item detail page |
+
+---
+
+## Task 1: API — GET single item endpoint
+
+**Files:**
+- Modify: `crates/api/src/handlers/items.rs`
+- Modify: `crates/api/src/router.rs`
+
+- [ ] **Step 1: Add `get_one` handler in `handlers/items.rs`**
+
+Add after the `list_all` function (after line 30):
+
+```rust
+pub async fn get_one(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
+    let user_id = ctx.data.clone();
+    let id = require_param(&ctx, "id")?;
+    let d1 = ctx.env.d1("DB")?;
+
+    if !check_item_ownership(&d1, &id, &user_id).await? {
+        return json_error("item_not_found", 404);
+    }
+
+    let query = format!("SELECT {} FROM items WHERE id = ?1", ITEM_COLS);
+    let item = d1
+        .prepare(&query)
+        .bind(&[id.into()])?
+        .first::<Item>(None)
+        .await?
+        .ok_or_else(|| Error::from("Not found"))?;
+    Response::from_json(&item)
+}
+```
+
+- [ ] **Step 2: Register route in `router.rs`**
+
+In `router.rs`, add after the existing `.post_async("/api/lists/:list_id/items", items::create)` line:
+
+```rust
+.get_async("/api/lists/:list_id/items/:id", items::get_one)
+```
+
+Place it before `.put_async("/api/lists/:list_id/items/:id", items::update)` so the GET comes first.
+
+- [ ] **Step 3: Verify compilation**
+
+Run: `just check`
+Expected: Compiles without errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/api/src/handlers/items.rs crates/api/src/router.rs
+git commit -m "feat(api): add GET single item endpoint"
+```
+
+---
+
+## Task 2: Frontend API — fetch_item function
+
+**Files:**
+- Modify: `crates/frontend/src/api/items.rs`
+
+- [ ] **Step 1: Add `fetch_item` to `api/items.rs`**
+
+Add after the existing `fetch_items` function:
+
+```rust
+pub async fn fetch_item(list_id: &str, item_id: &str) -> Result<Item, String> {
+    super::get(&format!(
+        "{}/lists/{list_id}/items/{item_id}",
+        super::API_BASE
+    ))
+    .send()
+    .await
+    .map_err(|e| e.to_string())?
+    .json()
+    .await
+    .map_err(|e| e.to_string())
+}
+```
+
+- [ ] **Step 2: Verify compilation**
+
+Run: `just check`
+Expected: Compiles without errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/frontend/src/api/items.rs
+git commit -m "feat(frontend): add fetch_item API function"
+```
+
+---
+
+## Task 3: Extract InlineConfirmButton component
+
+**Files:**
+- Create: `crates/frontend/src/components/common/inline_confirm_button.rs`
+- Modify: `crates/frontend/src/components/common/mod.rs`
+- Modify: `crates/frontend/src/components/items/date_item_row.rs`
+
+This extracts the confirm-with-timeout delete button from `DateItemRow` (lines 131-148 in `date_item_row.rs`). It is distinct from the existing `ConfirmDeleteModal`.
+
+- [ ] **Step 1: Create `inline_confirm_button.rs`**
+
+Create `crates/frontend/src/components/common/inline_confirm_button.rs`:
+
+```rust
+use leptos::prelude::*;
+
+/// Inline button that requires a second click to confirm.
+/// First click shows confirm_label for `timeout_ms`, then reverts.
+/// Distinct from `ConfirmDeleteModal` which is a modal dialog.
+#[component]
+pub fn InlineConfirmButton(
+    /// Callback when confirmed (second click)
+    on_confirm: Callback<()>,
+    /// Label shown normally
+    #[prop(default = "\u{2715}".to_string())]
+    label: String,
+    /// Label shown during confirm state
+    #[prop(default = "Na pewno?".to_string())]
+    confirm_label: String,
+    /// CSS class for normal state
+    #[prop(default = "btn btn-ghost btn-sm btn-square opacity-60 hover:opacity-100".to_string())]
+    class: String,
+    /// CSS class for confirm state
+    #[prop(default = "btn btn-error btn-sm".to_string())]
+    confirm_class: String,
+    /// Timeout in ms before reverting to normal state
+    #[prop(default = 2500)]
+    timeout_ms: u32,
+) -> impl IntoView {
+    let confirming = RwSignal::new(false);
+
+    view! {
+        <button
+            type="button"
+            class=move || if confirming.get() { confirm_class.clone() } else { class.clone() }
+            on:click=move |_| {
+                if confirming.get() {
+                    on_confirm.run(());
+                    confirming.set(false);
+                } else {
+                    confirming.set(true);
+                    set_timeout(
+                        move || confirming.set(false),
+                        std::time::Duration::from_millis(timeout_ms.into()),
+                    );
+                }
+            }
+        >
+            {move || if confirming.get() { confirm_label.clone() } else { label.clone() }}
+        </button>
+    }
+}
+```
+
+- [ ] **Step 2: Register module in `common/mod.rs`**
+
+Add to `crates/frontend/src/components/common/mod.rs`:
+
+```rust
+pub mod inline_confirm_button;
+```
+
+- [ ] **Step 3: Refactor `DateItemRow` to use `InlineConfirmButton`**
+
+In `crates/frontend/src/components/items/date_item_row.rs`:
+
+Replace the inline confirm block (the `let confirming = RwSignal::new(false); view! { <button ...` block around lines 131-148) with:
+
+```rust
+<InlineConfirmButton on_confirm=Callback::new(move |()| on_delete.run(id_delete.clone())) />
+```
+
+Add the import at the top:
+```rust
+use crate::components::common::inline_confirm_button::InlineConfirmButton;
+```
+
+Remove the now-unused `id_delete` clone that was used only in the old block — keep the one used by InlineConfirmButton's callback. Also remove `use gloo_timers::callback::Timeout;` or `set_timeout` import if it becomes unused.
+
+- [ ] **Step 4: Verify compilation**
+
+Run: `just check`
+Expected: Compiles without errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/frontend/src/components/common/inline_confirm_button.rs \
+       crates/frontend/src/components/common/mod.rs \
+       crates/frontend/src/components/items/date_item_row.rs
+git commit -m "refactor: extract InlineConfirmButton from DateItemRow"
+```
+
+---
+
+## Task 4: Extract InlineDateEditorSection component
+
+**Files:**
+- Create: `crates/frontend/src/components/items/inline_date_editor_section.rs`
+- Modify: `crates/frontend/src/components/items/mod.rs`
+- Modify: `crates/frontend/src/components/items/item_row.rs`
+- Modify: `crates/frontend/src/components/items/date_item_row.rs`
+
+This extracts the identical "match date_type → border color → DateEditor + close button" block that appears in both ItemRow (lines ~240-270) and DateItemRow (lines ~195-225).
+
+- [ ] **Step 1: Create `inline_date_editor_section.rs`**
+
+Create `crates/frontend/src/components/items/inline_date_editor_section.rs`:
+
+```rust
+use kartoteka_shared::Item;
+use leptos::prelude::*;
+
+use super::date_editor::DateEditor;
+
+/// Inline date editor section: resolves date_type to border color + initial values,
+/// renders DateEditor + close button. Used by ItemRow, DateItemRow.
+#[component]
+pub fn InlineDateEditorSection(
+    /// Which date type is being edited: "start", "deadline", or "hard_deadline"
+    date_type: String,
+    /// The item being edited (for initial date/time values)
+    item: Item,
+    /// Item ID for the save callback
+    item_id: String,
+    /// Called with (item_id, date_type, date_value, time_value)
+    on_save: Callback<(String, String, String, Option<String>)>,
+    /// Called when the close button is clicked
+    on_close: Callback<()>,
+    /// CSS class for the wrapper div
+    #[prop(default = "pl-14 pb-2".to_string())]
+    wrapper_class: String,
+) -> impl IntoView {
+    let (border, init_date, init_time, has_time) = match date_type.as_str() {
+        "start" => (
+            "border-info",
+            item.start_date.clone(),
+            item.start_time.clone(),
+            true,
+        ),
+        "hard_deadline" => ("border-error", item.hard_deadline.clone(), None, false),
+        _ => (
+            "border-warning",
+            item.deadline.clone(),
+            item.deadline_time.clone(),
+            true,
+        ),
+    };
+
+    let id_for_save = item_id;
+    let dt_for_save = date_type;
+
+    view! {
+        <div class=wrapper_class>
+            <DateEditor
+                border_color=border
+                initial_date=init_date
+                initial_time=init_time
+                has_time=has_time
+                on_change=Callback::new(move |(date, time): (String, Option<String>)| {
+                    on_save.run((id_for_save.clone(), dt_for_save.clone(), date, time));
+                })
+            />
+            <button type="button" class="btn btn-xs btn-ghost mt-1 opacity-50"
+                on:click=move |_| on_close.run(())
+            >"Zamknij"</button>
+        </div>
+    }
+}
+```
+
+- [ ] **Step 2: Register module in `items/mod.rs`**
+
+Add to `crates/frontend/src/components/items/mod.rs`:
+
+```rust
+pub mod inline_date_editor_section;
+```
+
+- [ ] **Step 3: Refactor ItemRow to use InlineDateEditorSection**
+
+In `crates/frontend/src/components/items/item_row.rs`, replace the inline date editor block (the `move || { let dt = editing_date.get(); if let (Some(dt), Some(on_save)) = ...` block around lines 240-270) with:
+
+```rust
+{move || {
+    let dt = editing_date.get();
+    if let (Some(dt), Some(on_save)) = (dt, on_date_save) {
+        view! {
+            <InlineDateEditorSection
+                date_type=dt
+                item=item_for_editor.clone()
+                item_id=id_for_editor.clone()
+                on_save=on_save
+                on_close=Callback::new(move |()| editing_date.set(None))
+            />
+        }.into_any()
+    } else {
+        view! {}.into_any()
+    }
+}}
+```
+
+This requires storing a clone of the item for the editor: add `let item_for_editor = item.clone();` near the top of the component (before other clones consume fields).
+
+Add import:
+```rust
+use super::inline_date_editor_section::InlineDateEditorSection;
+```
+
+Remove the now-unused individual date field clones (`item_start_date`, `item_start_time`, etc.) that were only used in the old inline block.
+
+- [ ] **Step 4: Refactor DateItemRow to use InlineDateEditorSection**
+
+In `crates/frontend/src/components/items/date_item_row.rs`, replace the inline date editor block (similar match + DateEditor + close button around lines 195-225) with:
+
+```rust
+{move || {
+    let dt = editing_date.get();
+    if let (Some(dt), Some(on_save)) = (dt, on_date_save) {
+        view! {
+            <InlineDateEditorSection
+                date_type=dt
+                item=item_for_editor.clone()
+                item_id=id_for_editor.clone()
+                on_save=on_save
+                on_close=Callback::new(move |()| editing_date.set(None))
+                wrapper_class="pl-10 pb-2".to_string()
+            />
+        }.into_any()
+    } else {
+        view! {}.into_any()
+    }
+}}
+```
+
+Note the different `wrapper_class` — DateItemRow uses `"pl-10 pb-2"` while ItemRow uses `"pl-14 pb-2"`.
+
+Add `let item_for_editor = item.clone();` near the top. Add import. Remove unused date field clones.
+
+- [ ] **Step 5: Verify compilation**
+
+Run: `just check`
+Expected: Compiles without errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/frontend/src/components/items/inline_date_editor_section.rs \
+       crates/frontend/src/components/items/mod.rs \
+       crates/frontend/src/components/items/item_row.rs \
+       crates/frontend/src/components/items/date_item_row.rs
+git commit -m "refactor: extract InlineDateEditorSection from ItemRow and DateItemRow"
+```
+
+---
+
+## Task 5: Extract DateBadgeChips component
+
+**Files:**
+- Create: `crates/frontend/src/components/items/date_badge_chips.rs`
+- Modify: `crates/frontend/src/components/items/mod.rs`
+- Modify: `crates/frontend/src/components/items/item_row.rs`
+- Modify: `crates/frontend/src/components/items/date_item_row.rs`
+
+Both ItemRow and DateItemRow have the same pattern: iterate over `item_date_badges()` result, render clickable buttons that toggle `editing_date` signal. ItemRow also has ghost chips.
+
+- [ ] **Step 1: Create `date_badge_chips.rs`**
+
+Create `crates/frontend/src/components/items/date_badge_chips.rs`:
+
+```rust
+use crate::components::common::date_utils::DateBadge;
+use leptos::prelude::*;
+
+/// Renders clickable date badge chips that toggle an editing_date signal.
+/// Used by ItemRow and DateItemRow.
+#[component]
+pub fn DateBadgeChips(
+    badges: Vec<DateBadge>,
+    editing_date: RwSignal<Option<String>>,
+    /// Show ghost chips for unset date types
+    #[prop(default = false)]
+    ghost_start: bool,
+    #[prop(default = false)]
+    ghost_deadline: bool,
+    #[prop(default = false)]
+    ghost_hard: bool,
+) -> impl IntoView {
+    let has_ghosts = ghost_start || ghost_deadline || ghost_hard;
+    if badges.is_empty() && !has_ghosts {
+        return view! {}.into_any();
+    }
+
+    view! {
+        <div class="flex gap-1 flex-wrap shrink-0">
+            {badges.into_iter().map(|b| {
+                let dt = b.date_type.to_string();
+                view! {
+                    <button type="button" class=format!("{} cursor-pointer", b.css)
+                        on:click=move |_| {
+                            let current = editing_date.get();
+                            if current.as_deref() == Some(dt.as_str()) {
+                                editing_date.set(None);
+                            } else {
+                                editing_date.set(Some(dt.clone()));
+                            }
+                        }
+                    >{b.label}</button>
+                }
+            }).collect::<Vec<_>>()}
+            {if ghost_start {
+                view! {
+                    <button type="button" class="badge badge-ghost badge-sm opacity-40 cursor-pointer"
+                        on:click=move |_| editing_date.set(Some("start".into()))
+                    >"+\u{1F4C5}"</button>
+                }.into_any()
+            } else { view! {}.into_any() }}
+            {if ghost_deadline {
+                view! {
+                    <button type="button" class="badge badge-ghost badge-sm opacity-40 cursor-pointer"
+                        on:click=move |_| editing_date.set(Some("deadline".into()))
+                    >"+\u{23F0}"</button>
+                }.into_any()
+            } else { view! {}.into_any() }}
+            {if ghost_hard {
+                view! {
+                    <button type="button" class="badge badge-ghost badge-sm opacity-40 cursor-pointer"
+                        on:click=move |_| editing_date.set(Some("hard_deadline".into()))
+                    >"+\u{1F6A8}"</button>
+                }.into_any()
+            } else { view! {}.into_any() }}
+        </div>
+    }.into_any()
+}
+```
+
+- [ ] **Step 2: Register in `items/mod.rs`**
+
+Add: `pub mod date_badge_chips;`
+
+- [ ] **Step 3: Refactor ItemRow to use DateBadgeChips**
+
+In `item_row.rs`, replace the date badges + ghost chips rendering block (the large `if date_badges.is_empty() && !has_ghosts` block around lines 66-145) with:
+
+```rust
+<DateBadgeChips
+    badges=date_badges
+    editing_date=editing_date
+    ghost_start=ghost_start
+    ghost_deadline=ghost_deadline
+    ghost_hard=ghost_hard
+/>
+```
+
+Add import: `use super::date_badge_chips::DateBadgeChips;`
+
+Keep the ghost chip computation logic (cfg_start, cfg_deadline, cfg_hard, ghost_start, etc.) — only the rendering moves to the component.
+
+- [ ] **Step 4: Refactor DateItemRow to use DateBadgeChips**
+
+In `date_item_row.rs`, replace the secondary badges rendering (inside the `has_secondary` block) with `DateBadgeChips`. DateItemRow doesn't have ghost chips, so all ghost props stay `false` (default).
+
+The DateItemRow secondary badges block also contains TagList in the same div — keep TagList, just replace the badge iteration with:
+
+```rust
+<DateBadgeChips badges=secondary_badges editing_date=editing_date />
+```
+
+- [ ] **Step 5: Verify compilation**
+
+Run: `just check`
+Expected: Compiles without errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/frontend/src/components/items/date_badge_chips.rs \
+       crates/frontend/src/components/items/mod.rs \
+       crates/frontend/src/components/items/item_row.rs \
+       crates/frontend/src/components/items/date_item_row.rs
+git commit -m "refactor: extract DateBadgeChips from ItemRow and DateItemRow"
+```
+
+---
+
+## Task 6: Extract QuantityStepper component
+
+**Files:**
+- Create: `crates/frontend/src/components/items/quantity_stepper.rs`
+- Modify: `crates/frontend/src/components/items/mod.rs`
+- Modify: `crates/frontend/src/components/items/item_row.rs`
+
+- [ ] **Step 1: Create `quantity_stepper.rs`**
+
+Create `crates/frontend/src/components/items/quantity_stepper.rs`:
+
+```rust
+use leptos::prelude::*;
+
+/// Quantity stepper: -/+ buttons, actual/target display, progress bar.
+/// Used by ItemRow and ItemDetailPage.
+#[component]
+pub fn QuantityStepper(
+    target: i32,
+    initial_actual: i32,
+    unit: String,
+    on_change: Callback<i32>,
+) -> impl IntoView {
+    let actual = RwSignal::new(initial_actual);
+
+    view! {
+        <div class="flex flex-col items-center gap-0.5">
+            <div class="flex items-center gap-1">
+                <button type="button" class="btn btn-xs btn-circle btn-ghost"
+                    on:click=move |_| {
+                        let new_val = (actual.get() - 1).max(0);
+                        actual.set(new_val);
+                        on_change.run(new_val);
+                    }
+                >"\u{2212}"</button>
+                <span class="text-sm font-mono">
+                    {move || actual.get()} " / " {target} " " {unit.clone()}
+                </span>
+                <button type="button" class="btn btn-xs btn-circle btn-ghost"
+                    on:click=move |_| {
+                        let new_val = actual.get() + 1;
+                        actual.set(new_val);
+                        on_change.run(new_val);
+                    }
+                >"+"</button>
+            </div>
+            <progress class="progress progress-primary w-20 h-1"
+                value=move || actual.get().to_string()
+                max=target.to_string()
+            />
+        </div>
+    }
+}
+```
+
+- [ ] **Step 2: Register in `items/mod.rs`**
+
+Add: `pub mod quantity_stepper;`
+
+- [ ] **Step 3: Refactor ItemRow to use QuantityStepper**
+
+In `item_row.rs`, replace the inline quantity stepper block (the `if show_stepper { ... }` block around lines 155-195) with:
+
+```rust
+{if show_stepper {
+    let id_for_stepper = id.clone();
+    view! {
+        <QuantityStepper
+            target=target_qty
+            initial_actual=item.actual_quantity.unwrap_or(0)
+            unit=unit_label.clone()
+            on_change=Callback::new(move |new_val: i32| {
+                if let Some(cb) = on_quantity_change {
+                    cb.run((id_for_stepper.clone(), new_val));
+                }
+            })
+        />
+    }.into_any()
+} else {
+    view! {}.into_any()
+}}
+```
+
+Add import: `use super::quantity_stepper::QuantityStepper;`
+
+Remove the now-unused `id_dec`, `id_inc`, `cb_dec`, `cb_inc`, `actual` signal, and inline stepper code.
+
+- [ ] **Step 4: Verify compilation**
+
+Run: `just check`
+Expected: Compiles without errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/frontend/src/components/items/quantity_stepper.rs \
+       crates/frontend/src/components/items/mod.rs \
+       crates/frontend/src/components/items/item_row.rs
+git commit -m "refactor: extract QuantityStepper from ItemRow"
+```
+
+---
+
+## Task 7: Replace ItemRow inline description with EditableDescription
+
+**Files:**
+- Modify: `crates/frontend/src/components/items/item_row.rs`
+
+- [ ] **Step 1: Refactor ItemRow description**
+
+In `item_row.rs`, replace the expandable description block (the `if expanded.get() { ... } else { ... }` block around lines 270-310) with `EditableDescription`.
+
+The current pattern: expand button toggles `expanded` signal, shows textarea on blur save. Replace with:
+
+Keep the expand/collapse toggle button. When expanded, show `EditableDescription`:
+
+```rust
+{move || {
+    if expanded.get() {
+        let id_desc = id_for_desc.clone();
+        view! {
+            <div class="pl-14 pb-2">
+                <EditableDescription
+                    value=Some(description_text.get())
+                    on_save=Callback::new(move |new_val: Option<String>| {
+                        let text = new_val.clone().unwrap_or_default();
+                        description_text.set(text);
+                        if let Some(cb) = on_description_save {
+                            cb.run((id_desc.clone(), new_val.unwrap_or_default()));
+                        }
+                    })
+                />
+            </div>
+        }.into_any()
+    } else {
+        let desc = description_text.get();
+        if desc.is_empty() {
+            view! {}.into_any()
+        } else {
+            view! {
+                <p class="pl-14 pb-1 text-sm text-base-content/60">{desc}</p>
+            }.into_any()
+        }
+    }
+}}
+```
+
+Add import: `use crate::components::common::editable_description::EditableDescription;`
+
+Remove the raw textarea code that was there before.
+
+- [ ] **Step 2: Verify compilation**
+
+Run: `just check`
+Expected: Compiles without errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/frontend/src/components/items/item_row.rs
+git commit -m "refactor: use EditableDescription in ItemRow"
+```
+
+---
+
+## Task 8: Make ItemRow title a link to detail page
+
+**Files:**
+- Modify: `crates/frontend/src/components/items/item_row.rs`
+
+- [ ] **Step 1: Change title span to anchor link**
+
+In `item_row.rs`, the title is currently:
+
+```rust
+<span class=title_class>{item.title}</span>
+```
+
+Replace with:
+
+```rust
+<a href=format!("/lists/{}/items/{}", item.list_id, id) class=format!("{title_class} hover:text-primary transition-colors no-underline")>
+    {item.title.clone()}
+</a>
+```
+
+The `item.list_id` is available on the `Item` struct. Make sure `item.title` is cloned before `item` is consumed by other uses — may need to reorder clones at the top of the function. Store `let item_title = item.title.clone();` and `let item_list_id = item.list_id.clone();` early.
+
+- [ ] **Step 2: Verify compilation**
+
+Run: `just check`
+Expected: Compiles without errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/frontend/src/components/items/item_row.rs
+git commit -m "feat: make ItemRow title a link to detail page"
+```
+
+---
+
+## Task 9: Item detail page component
+
+**Files:**
+- Create: `crates/frontend/src/pages/item_detail.rs`
+- Modify: `crates/frontend/src/pages/mod.rs`
+- Modify: `crates/frontend/src/app.rs`
+
+This is the main new page. It fetches the item + list (for name and features), then renders a form with auto-save.
+
+- [ ] **Step 1: Create `item_detail.rs`**
+
+Create `crates/frontend/src/pages/item_detail.rs`:
+
+```rust
+use crate::api::{delete_item, fetch_item, fetch_list, update_item};
+use crate::app::{ToastContext, ToastKind};
+use crate::components::common::breadcrumbs::Breadcrumbs;
+use crate::components::common::editable_description::EditableDescription;
+use crate::components::common::editable_title::EditableTitle;
+use crate::components::common::inline_confirm_button::InlineConfirmButton;
+use crate::components::common::loading::Loading;
+use crate::components::items::date_editor::DateEditor;
+use crate::components::items::quantity_stepper::QuantityStepper;
+use kartoteka_shared::*;
+use leptos::prelude::*;
+use leptos_router::hooks::use_params_map;
+
+/// Helper: spawn an update_item call with toast feedback.
+fn spawn_save(list_id: String, item_id: String, toast: ToastContext, req: UpdateItemRequest) {
+    leptos::task::spawn_local(async move {
+        match update_item(&list_id, &item_id, &req).await {
+            Ok(_) => toast.push("Zapisano".into(), ToastKind::Success),
+            Err(e) => toast.push(format!("Błąd: {e}"), ToastKind::Error),
+        }
+    });
+}
+
+#[component]
+pub fn ItemDetailPage() -> impl IntoView {
+    let params = use_params_map();
+    let toast = expect_context::<ToastContext>();
+    let navigate = leptos_router::hooks::use_navigate();
+
+    let list_id =
+        move || params.with(|p| p.get("list_id").unwrap_or_default().to_string());
+    let item_id =
+        move || params.with(|p| p.get("id").unwrap_or_default().to_string());
+
+    // Fetch item
+    let item_resource = LocalResource::new(move || {
+        let lid = list_id();
+        let iid = item_id();
+        async move { fetch_item(&lid, &iid).await }
+    });
+
+    // Fetch list (for name in breadcrumbs + features)
+    let list_resource = LocalResource::new(move || {
+        let lid = list_id();
+        async move { fetch_list(&lid).await }
+    });
+
+    view! {
+        <Suspense fallback=move || view! { <Loading /> }>
+            {move || {
+                let item_result = item_resource.get().map(|r| (*r).clone());
+                let list_result = list_resource.get().map(|r| (*r).clone());
+
+                match (item_result, list_result) {
+                    (Some(Ok(item)), Some(Ok(list))) => {
+                        let lid = list.id.clone();
+                        let list_name = list.name.clone();
+                        let features = list.features.clone();
+
+                        // Deadlines config
+                        let deadlines_config = features
+                            .iter()
+                            .find(|f| f.name == FEATURE_DEADLINES)
+                            .map(|f| f.config.clone())
+                            .unwrap_or(serde_json::Value::Null);
+                        let has_quantity = features.iter().any(|f| f.name == FEATURE_QUANTITY);
+
+                        let cfg_start = deadlines_config.get("has_start_date")
+                            .and_then(|v| v.as_bool()).unwrap_or(false);
+                        let cfg_deadline = deadlines_config.get("has_deadline")
+                            .and_then(|v| v.as_bool()).unwrap_or(false);
+                        let cfg_hard = deadlines_config.get("has_hard_deadline")
+                            .and_then(|v| v.as_bool()).unwrap_or(false);
+
+                        // Breadcrumbs (list name as link, item title as plain text below)
+                        let crumbs = vec![
+                            (list_name, format!("/lists/{lid}")),
+                        ];
+                        let item_title_for_crumb = item.title.clone();
+
+                        // Completed toggle
+                        let completed = RwSignal::new(item.completed);
+
+                        // Delete
+                        let lid_for_delete = list_id();
+                        let iid_for_delete = item_id();
+                        let toast_del = toast.clone();
+                        let nav = navigate.clone();
+
+                        view! {
+                            // Breadcrumbs with item title as non-linked final crumb
+                            <div class="breadcrumbs text-sm mb-4">
+                                <ul>
+                                    <li><a href="/">"Home"</a></li>
+                                    {crumbs.into_iter().map(|(label, href)| {
+                                        view! { <li><a href=href>{label}</a></li> }
+                                    }).collect::<Vec<_>>()}
+                                    <li>{item_title_for_crumb}</li>
+                                </ul>
+                            </div>
+
+                            // Completed checkbox + title
+                            <div class="flex items-center gap-3 mb-4">
+                                <input
+                                    type="checkbox"
+                                    class="checkbox checkbox-secondary checkbox-lg"
+                                    checked=item.completed
+                                    on:change=move |_| {
+                                        let new_val = !completed.get();
+                                        completed.set(new_val);
+                                        spawn_save(list_id(), item_id(), toast.clone(), UpdateItemRequest {
+                                            completed: Some(new_val),
+                                            ..Default::default()
+                                        });
+                                    }
+                                />
+                                <EditableTitle
+                                    value=item.title.clone()
+                                    on_save=Callback::new(move |new_title: String| {
+                                        spawn_save(list_id(), item_id(), toast.clone(), UpdateItemRequest {
+                                            title: Some(new_title),
+                                            ..Default::default()
+                                        });
+                                    })
+                                />
+                            </div>
+
+                            // Description
+                            <EditableDescription
+                                value=item.description.clone()
+                                on_save=Callback::new(move |new_desc: Option<String>| {
+                                    spawn_save(list_id(), item_id(), toast.clone(), UpdateItemRequest {
+                                        description: new_desc,
+                                        ..Default::default()
+                                    });
+                                })
+                            />
+
+                            // Dates section
+                            {if cfg_start {
+                                view! {
+                                    <div class="mb-4">
+                                        <label class="label text-sm font-medium">"Data rozpoczęcia"</label>
+                                        <DateEditor
+                                            border_color="border-info"
+                                            initial_date=item.start_date.clone()
+                                            initial_time=item.start_time.clone()
+                                            has_time=true
+                                            on_change=Callback::new(move |(date, time): (String, Option<String>)| {
+                                                let (d, t) = if date.is_empty() {
+                                                    (Some(None), Some(None))
+                                                } else {
+                                                    (Some(Some(date)), time.map(Some))
+                                                };
+                                                spawn_save(list_id(), item_id(), toast.clone(), UpdateItemRequest {
+                                                    start_date: d,
+                                                    start_time: t,
+                                                    ..Default::default()
+                                                });
+                                            })
+                                        />
+                                    </div>
+                                }.into_any()
+                            } else { view! {}.into_any() }}
+
+                            {if cfg_deadline {
+                                view! {
+                                    <div class="mb-4">
+                                        <label class="label text-sm font-medium">"Termin"</label>
+                                        <DateEditor
+                                            border_color="border-warning"
+                                            initial_date=item.deadline.clone()
+                                            initial_time=item.deadline_time.clone()
+                                            has_time=true
+                                            on_change=Callback::new(move |(date, time): (String, Option<String>)| {
+                                                let (d, t) = if date.is_empty() {
+                                                    (Some(None), Some(None))
+                                                } else {
+                                                    (Some(Some(date)), time.map(Some))
+                                                };
+                                                spawn_save(list_id(), item_id(), toast.clone(), UpdateItemRequest {
+                                                    deadline: d,
+                                                    deadline_time: t,
+                                                    ..Default::default()
+                                                });
+                                            })
+                                        />
+                                    </div>
+                                }.into_any()
+                            } else { view! {}.into_any() }}
+
+                            {if cfg_hard {
+                                view! {
+                                    <div class="mb-4">
+                                        <label class="label text-sm font-medium">"Twardy termin"</label>
+                                        <DateEditor
+                                            border_color="border-error"
+                                            initial_date=item.hard_deadline.clone()
+                                            initial_time=None::<String>
+                                            has_time=false
+                                            on_change=Callback::new(move |(date, _time): (String, Option<String>)| {
+                                                let d = if date.is_empty() {
+                                                    Some(None)
+                                                } else {
+                                                    Some(Some(date))
+                                                };
+                                                spawn_save(list_id(), item_id(), toast.clone(), UpdateItemRequest {
+                                                    hard_deadline: d,
+                                                    ..Default::default()
+                                                });
+                                            })
+                                        />
+                                    </div>
+                                }.into_any()
+                            } else { view! {}.into_any() }}
+
+                            // Quantity section
+                            {if has_quantity && item.quantity.is_some() {
+                                let target = item.quantity.unwrap_or(0);
+                                let unit = item.unit.clone().unwrap_or_default();
+                                view! {
+                                    <div class="mb-4">
+                                        <label class="label text-sm font-medium">"Ilość"</label>
+                                        <QuantityStepper
+                                            target=target
+                                            initial_actual=item.actual_quantity.unwrap_or(0)
+                                            unit=unit
+                                            on_change=Callback::new(move |new_val: i32| {
+                                                spawn_save(list_id(), item_id(), toast.clone(), UpdateItemRequest {
+                                                    actual_quantity: Some(new_val),
+                                                    ..Default::default()
+                                                });
+                                            })
+                                        />
+                                    </div>
+                                }.into_any()
+                            } else { view! {}.into_any() }}
+
+                            // Delete button
+                            <div class="mt-8 pt-4 border-t border-base-300">
+                                <InlineConfirmButton
+                                    on_confirm=Callback::new(move |()| {
+                                        let lid = lid_for_delete.clone();
+                                        let iid = iid_for_delete.clone();
+                                        let toast = toast_del.clone();
+                                        let nav = nav.clone();
+                                        leptos::task::spawn_local(async move {
+                                            match delete_item(&lid, &iid).await {
+                                                Ok(_) => {
+                                                    toast.push("Usunięto".into(), ToastKind::Success);
+                                                    nav(&format!("/lists/{lid}"), Default::default());
+                                                }
+                                                Err(e) => toast.push(format!("Błąd: {e}"), ToastKind::Error),
+                                            }
+                                        });
+                                    })
+                                    label="Usuń element".to_string()
+                                    confirm_label="Na pewno usunąć?".to_string()
+                                    class="btn btn-error btn-outline btn-sm".to_string()
+                                    confirm_class="btn btn-error btn-sm".to_string()
+                                />
+                            </div>
+                        }.into_any()
+                    }
+                    (Some(Err(e)), _) | (_, Some(Err(e))) => {
+                        view! { <p class="text-error">{format!("Błąd: {e}")}</p> }.into_any()
+                    }
+                    _ => view! { <Loading /> }.into_any(),
+                }
+            }}
+        </Suspense>
+    }
+}
+```
+
+**Important notes:**
+- `UpdateItemRequest` needs `Default` derive — add it in step 2.
+- The `spawn_save` helper function avoids the need to clone closures (closures are not `Clone`). Each callback calls `spawn_save` directly with fresh `list_id()`, `item_id()`, `toast.clone()`.
+- Breadcrumbs: we render inline HTML instead of using the `Breadcrumbs` component, because the component renders all crumbs as `<a>` links, but the spec requires the last crumb (item title) to be plain text (current page). The existing `Breadcrumbs` component is not modified.
+- Toast: use `toast.push(msg, ToastKind::Success/Error)` — there are no `toast.success()`/`toast.error()` shorthand methods.
+
+- [ ] **Step 2: Check if UpdateItemRequest has Default**
+
+In `crates/shared/src/lib.rs`, the `UpdateItemRequest` struct (line 286) currently derives `Debug, Clone, Serialize, Deserialize`. It needs `Default` added:
+
+```rust
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct UpdateItemRequest {
+```
+
+- [ ] **Step 3: Register module in `pages/mod.rs`**
+
+Add to `crates/frontend/src/pages/mod.rs`:
+
+```rust
+pub mod item_detail;
+```
+
+- [ ] **Step 4: Add route in `app.rs`**
+
+In `crates/frontend/src/app.rs`, add after the `"/lists/:id"` route:
+
+```rust
+<Route path=path!("/lists/:list_id/items/:id") view=ItemDetailPage/>
+```
+
+Add the import at the top (in the existing use block for pages):
+
+```rust
+use pages::item_detail::ItemDetailPage;
+```
+
+- [ ] **Step 5: Verify compilation**
+
+Run: `just check`
+Expected: Compiles without errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/shared/src/lib.rs \
+       crates/frontend/src/pages/item_detail.rs \
+       crates/frontend/src/pages/mod.rs \
+       crates/frontend/src/app.rs
+git commit -m "feat: add item detail page with auto-save"
+```
+
+---
+
+## Task 10: Smoke test & final verification
+
+- [ ] **Step 1: Run full check**
+
+Run: `just check`
+Expected: Compiles without errors.
+
+- [ ] **Step 2: Run tests**
+
+Run: `just test`
+Expected: All existing tests pass.
+
+- [ ] **Step 3: Run linter**
+
+Run: `just lint`
+Expected: No clippy warnings or fmt issues.
+
+- [ ] **Step 4: Fix any issues**
+
+If any step above fails, fix the issue and re-run.
+
+- [ ] **Step 5: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "fix: address lint/test issues from item detail page"
+```

--- a/docs/superpowers/specs/2026-03-29-item-detail-page-design.md
+++ b/docs/superpowers/specs/2026-03-29-item-detail-page-design.md
@@ -10,22 +10,25 @@ Dedicated detail page for viewing and editing a single item. Replaces the need t
 
 ## Routing & Navigation
 
-- New route: `/lists/:list_id/items/:id`
+- New route: `path!("/lists/:list_id/items/:id")` — params read via `use_params_map()` as `"list_id"` and `"id"`
+- Does not conflict with existing `path!("/lists/:id")` — the static segment `items` disambiguates
 - In `ItemRow`: item title becomes an `<a>` link to the detail page
-- Detail page shows breadcrumbs: Home > [List name] > [Item title]
+- Detail page shows breadcrumbs: Home > [List name (link to /lists/:list_id)] > Item title (no link, current page)
 - Back navigation returns to `/lists/:list_id`
 
 ## API
 
 ### New endpoint: `GET /api/lists/:list_id/items/:id`
 
+- New handler `get_one` in `handlers/items.rs`
+- New route `.get_async("/api/lists/:list_id/items/:id", items::get_one)` in `router.rs`
 - Returns a single `Item` (existing struct, no changes)
 - Ownership check via existing `check_item_ownership` helper
 - Returns 404 JSON error if not found
 
 ### New frontend function
 
-- `fetch_item(list_id: &str, item_id: &str) -> Result<Item, String>`
+- `fetch_item(list_id: &str, item_id: &str) -> Result<Item, String>` in `api/items.rs`
 
 ### Existing (no changes)
 
@@ -33,7 +36,7 @@ Dedicated detail page for viewing and editing a single item. Replaces the need t
 
 ## Detail Page Layout
 
-Full-page form with auto-save on blur (consistent with existing `EditableDescription` / `EditableTitle` patterns).
+Full-page form with auto-save on blur (consistent with existing `EditableDescription` / `EditableTitle` patterns). Components taking snapshot `String` values (not signals) must be wrapped in reactive closures (`move || view! { ... }`) so they re-render when the item resource updates after save.
 
 ### Header
 - Breadcrumbs (Home > List name > Item title)
@@ -42,11 +45,11 @@ Full-page form with auto-save on blur (consistent with existing `EditableDescrip
 ### Fields (vertical layout, full width)
 1. **Title** — `EditableTitle` component (existing, from `components/common/`)
 2. **Description** — `EditableDescription` component (existing, from `components/common/`)
-3. **Dates section** — `DateEditor` for each date type enabled in list features (deadlines config). All enabled date types visible immediately (not hidden behind badge clicks like in ItemRow). Date types: start_date/time, deadline/time, hard_deadline.
+3. **Dates section** — One `DateEditor` per enabled date type, always visible (not behind badge clicks). Border colors: start → `border-info`, deadline → `border-warning`, hard_deadline → `border-error`. Each editor fires `on_change` immediately (same as existing behavior); auto-save calls `update_item` on each change. Date types: start_date/time, deadline/time, hard_deadline.
 4. **Quantity section** — New `QuantityStepper` component. Visible only when list has `quantity` feature enabled. Shows: quantity input, actual_quantity stepper, unit.
 
 ### Actions
-- **Delete** — `ConfirmDeleteButton` component. After deletion, redirect to `/lists/:list_id`.
+- **Delete** — `InlineConfirmButton` component. After deletion, redirect to `/lists/:list_id`.
 
 ### Out of scope (MVP)
 - Tags (will add in follow-up)
@@ -66,7 +69,7 @@ Extract shared components from existing `ItemRow` and `DateItemRow` to reduce du
 | `InlineDateEditorSection` | ItemRow + DateItemRow (~30 lines each, identical) | ItemRow, DateItemRow, DetailPage |
 | `DateBadgeChips` | ItemRow + DateItemRow (identical badge click/toggle pattern) | ItemRow, DateItemRow |
 | `QuantityStepper` | ItemRow (~30 lines inline) | ItemRow, DetailPage |
-| `ConfirmDeleteButton` | DateItemRow (confirm with timeout pattern) | ItemRow, DateItemRow, DetailPage |
+| `InlineConfirmButton` | DateItemRow (confirm with 2500ms timeout pattern, distinct from existing `ConfirmDeleteModal`) | ItemRow, DateItemRow, DetailPage |
 
 ### Existing components to reuse more broadly
 
@@ -86,8 +89,8 @@ Extract shared components from existing `ItemRow` and `DateItemRow` to reduce du
 ### DateItemRow changes
 - Inline date editor block replaced with `InlineDateEditorSection`
 - Date badge rendering replaced with `DateBadgeChips`
-- Confirm delete button replaced with `ConfirmDeleteButton`
+- Confirm delete button replaced with `InlineConfirmButton`
 
 ## Auto-save behavior
 
-Each field sends `update_item` PATCH on blur with only the changed field. Success shows a toast confirmation; errors show error toast. Consistent with existing blur-save patterns in the app.
+Each field sends `update_item` PUT on blur with only the changed field (using `UpdateItemRequest` with `Option` fields — unchanged fields sent as `None`). Dates fire on every `DateEditor` change (not on blur, since `DateEditor` has no blur concept). Success shows a toast confirmation; errors show error toast. Consistent with existing blur-save patterns in the app.

--- a/docs/superpowers/specs/2026-03-29-item-detail-page-design.md
+++ b/docs/superpowers/specs/2026-03-29-item-detail-page-design.md
@@ -1,0 +1,93 @@
+# Item Detail Page — Design Spec
+
+**Issue**: #38
+**Date**: 2026-03-29
+**Status**: Approved
+
+## Summary
+
+Dedicated detail page for viewing and editing a single item. Replaces the need to edit everything inline in the crowded `ItemRow`. Auto-save on blur for all fields.
+
+## Routing & Navigation
+
+- New route: `/lists/:list_id/items/:id`
+- In `ItemRow`: item title becomes an `<a>` link to the detail page
+- Detail page shows breadcrumbs: Home > [List name] > [Item title]
+- Back navigation returns to `/lists/:list_id`
+
+## API
+
+### New endpoint: `GET /api/lists/:list_id/items/:id`
+
+- Returns a single `Item` (existing struct, no changes)
+- Ownership check via existing `check_item_ownership` helper
+- Returns 404 JSON error if not found
+
+### New frontend function
+
+- `fetch_item(list_id: &str, item_id: &str) -> Result<Item, String>`
+
+### Existing (no changes)
+
+- `PUT /api/lists/:list_id/items/:id` — used for auto-save updates
+
+## Detail Page Layout
+
+Full-page form with auto-save on blur (consistent with existing `EditableDescription` / `EditableTitle` patterns).
+
+### Header
+- Breadcrumbs (Home > List name > Item title)
+- Completed checkbox (toggle, same behavior as in ItemRow)
+
+### Fields (vertical layout, full width)
+1. **Title** — `EditableTitle` component (existing, from `components/common/`)
+2. **Description** — `EditableDescription` component (existing, from `components/common/`)
+3. **Dates section** — `DateEditor` for each date type enabled in list features (deadlines config). All enabled date types visible immediately (not hidden behind badge clicks like in ItemRow). Date types: start_date/time, deadline/time, hard_deadline.
+4. **Quantity section** — New `QuantityStepper` component. Visible only when list has `quantity` feature enabled. Shows: quantity input, actual_quantity stepper, unit.
+
+### Actions
+- **Delete** — `ConfirmDeleteButton` component. After deletion, redirect to `/lists/:list_id`.
+
+### Out of scope (MVP)
+- Tags (will add in follow-up)
+- Notes/comments
+- Attachments
+- Activity/change history
+- Per-item reminder overrides (#32 — blocked by this issue)
+
+## Refactoring
+
+Extract shared components from existing `ItemRow` and `DateItemRow` to reduce duplication and reuse in the detail page.
+
+### New shared components
+
+| Component | Extracted from | Reused in |
+|---|---|---|
+| `InlineDateEditorSection` | ItemRow + DateItemRow (~30 lines each, identical) | ItemRow, DateItemRow, DetailPage |
+| `DateBadgeChips` | ItemRow + DateItemRow (identical badge click/toggle pattern) | ItemRow, DateItemRow |
+| `QuantityStepper` | ItemRow (~30 lines inline) | ItemRow, DetailPage |
+| `ConfirmDeleteButton` | DateItemRow (confirm with timeout pattern) | ItemRow, DateItemRow, DetailPage |
+
+### Existing components to reuse more broadly
+
+| Component | Current usage | New usage |
+|---|---|---|
+| `EditableDescription` | List/Container pages | ItemRow (replace inline textarea), DetailPage |
+| `EditableTitle` | List/Container pages | DetailPage |
+| `DateEditor` | ItemRow, DateItemRow | DetailPage (directly, not via InlineDateEditorSection) |
+
+### ItemRow changes
+- Title `<span>` becomes `<a>` link to detail page
+- Inline description textarea replaced with `EditableDescription`
+- Inline quantity stepper replaced with `QuantityStepper`
+- Inline date editor block replaced with `InlineDateEditorSection`
+- Date badge rendering replaced with `DateBadgeChips`
+
+### DateItemRow changes
+- Inline date editor block replaced with `InlineDateEditorSection`
+- Date badge rendering replaced with `DateBadgeChips`
+- Confirm delete button replaced with `ConfirmDeleteButton`
+
+## Auto-save behavior
+
+Each field sends `update_item` PATCH on blur with only the changed field. Success shows a toast confirmation; errors show error toast. Consistent with existing blur-save patterns in the app.

--- a/justfile
+++ b/justfile
@@ -97,6 +97,7 @@ migrate-gateway-prod:
 deploy: deploy-migrate deploy-api deploy-gateway migrate-gateway-prod deploy-frontend
 
 deploy-gateway-dev:
+    cp -r locales gateway/locales
     cd gateway && npx wrangler deploy --env dev
 
 deploy-dev: migrate-dev deploy-api-dev deploy-gateway-dev migrate-gateway-dev deploy-frontend-dev
@@ -111,6 +112,7 @@ deploy-api-dev:
     cd crates/api && npx wrangler deploy --env dev
 
 deploy-gateway:
+    cp -r locales gateway/locales
     cd gateway && npx wrangler deploy
 
 deploy-frontend:


### PR DESCRIPTION
## Summary

- New dedicated page at `/lists/:list_id/items/:id` for viewing and editing a single item
- Auto-save on blur for title, description, and completed toggle; dates save on every change
- Four shared components extracted from `ItemRow`/`DateItemRow` to reduce duplication: `InlineConfirmButton`, `InlineDateEditorSection`, `DateBadgeChips`, `QuantityStepper`

## Changes

- `GET /api/lists/:list_id/items/:id` — new endpoint with ownership check
- `ItemDetailPage` component with breadcrumbs, all fields, delete with redirect
- `ItemRow` refactored: title is now a link to the detail page, inline sections replaced with shared components
- `DateItemRow` refactored: inline sections replaced with shared components
- `UpdateItemRequest` gains `Default` derive for partial update spread syntax

## Test Plan

- [ ] Navigate to a list, click an item title → detail page opens
- [ ] Edit title/description and blur → toast confirms save
- [ ] Toggle completed checkbox → saves immediately
- [ ] Date editors visible for lists with deadlines feature; save on change
- [ ] Quantity stepper visible for lists with quantity feature enabled
- [ ] Delete button → confirm → redirects to list page
- [ ] `just check && just test && just lint` — all pass

Closes #38