### PR TITLE
fix: add accountId and wranglerVersion to deploy workflows

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -29,6 +29,8 @@ jobs:
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: "4.78.0"
           workingDirectory: crates/api
           command: d1 migrations apply kartoteka-dev --env dev --remote
 
@@ -39,6 +41,8 @@ jobs:
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: "4.78.0"
           workingDirectory: crates/api
           command: deploy --env dev
 
@@ -63,6 +67,8 @@ jobs:
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: "4.78.0"
           workingDirectory: gateway
           command: deploy --env dev
 
@@ -90,4 +96,6 @@ jobs:
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: "4.78.0"
           command: pages deploy crates/frontend/dist --project-name=kartoteka --branch=dev --commit-dirty=true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -51,6 +51,8 @@ jobs:
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: "4.78.0"
           workingDirectory: crates/api
           command: d1 migrations apply kartoteka-db --remote
 
@@ -61,6 +63,8 @@ jobs:
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: "4.78.0"
           workingDirectory: crates/api
           command: deploy
 
@@ -85,6 +89,8 @@ jobs:
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: "4.78.0"
           workingDirectory: gateway
           command: deploy
 
@@ -111,4 +117,6 @@ jobs:
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: "4.78.0"
           command: pages deploy crates/frontend/dist --project-name=kartoteka --branch=main --commit-dirty=true


### PR DESCRIPTION
## Summary
- Add `accountId` and `wranglerVersion: "4.78.0"` to all `wrangler-action` steps
- Fixes: wrangler-action defaulting to wrangler 3.x (project uses 4.x)
- Fixes: "More than one account available" error when API token has multi-account access

🤖 Generated with [Claude Code](https://claude.com/claude-code)