### PR TITLE
ci: deduplicate deploy workflows + caching + GH Environments

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -6,96 +6,11 @@ on:
       - develop
 
 jobs:
-  deploy-dev:
-    name: Deploy Dev Environment
-    runs-on: ubuntu-latest
-    concurrency:
-      group: deploy-dev
-      cancel-in-progress: true
-    env:
-      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-    steps:
-      - uses: actions/checkout@v4
-
-      # --- API Worker (Rust) ---
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Run D1 migrations (API dev)
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          wranglerVersion: "4.78.0"
-          workingDirectory: crates/api
-          command: d1 migrations apply kartoteka-dev --env dev --remote
-
-      - name: Install worker-build
-        run: cargo install worker-build
-
-      - name: Deploy API Worker (dev)
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          wranglerVersion: "4.78.0"
-          workingDirectory: crates/api
-          command: deploy --env dev
-
-      # --- Gateway Worker (TypeScript) ---
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: "npm"
-          cache-dependency-path: gateway/package-lock.json
-
-      - name: Copy locales to gateway
-        run: |
-          cp -r locales gateway/locales
-          cp locales/en/mcp.ftl gateway/locales/en/mcp.txt
-          cp locales/pl/mcp.ftl gateway/locales/pl/mcp.txt
-
-      - name: Install gateway deps
-        run: cd gateway && npm ci
-
-      - name: Deploy Gateway Worker (dev)
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          wranglerVersion: "4.78.0"
-          workingDirectory: gateway
-          command: deploy --env dev
-
-      - name: Run Gateway auth migrations (dev)
-        env:
-          GATEWAY_DEV_URL: https://kartoteka-gateway-dev.jpalczewski.workers.dev
-          MIGRATE_SECRET_DEV: ${{ secrets.MIGRATE_SECRET_DEV }}
-        run: |
-          curl -sf -X POST "$GATEWAY_DEV_URL/migrate" \
-            -H "x-migrate-secret: $MIGRATE_SECRET_DEV"
-
-      # --- Frontend (Leptos CSR → CF Pages) ---
-      - name: Install trunk
-        run: cargo install trunk
-
-      - name: Install frontend deps
-        run: cd crates/frontend && npm install
-
-      - name: Build frontend (dev)
-        env:
-          API_BASE_URL: https://kartoteka-gateway-dev.jpalczewski.workers.dev/api
-        run: cd crates/frontend && trunk build --release
-
-      - name: Deploy frontend to CF Pages (dev branch)
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          wranglerVersion: "4.78.0"
-          command: pages deploy crates/frontend/dist --project-name=kartoteka --branch=dev --commit-dirty=true
+  deploy:
+    uses: ./.github/workflows/deploy.yml
+    with:
+      environment: dev
+      wrangler_env: dev
+      d1_database: kartoteka-dev
+      pages_branch: dev
+    secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,137 @@
+name: Deploy
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
+        description: "GitHub Environment name (dev or production)"
+      wrangler_env:
+        required: false
+        type: string
+        default: ""
+        description: "Wrangler --env flag value (empty for prod)"
+      d1_database:
+        required: true
+        type: string
+        description: "D1 database name for API migrations"
+      pages_branch:
+        required: true
+        type: string
+        description: "CF Pages branch (dev or main)"
+
+jobs:
+  deploy:
+    name: Deploy (${{ inputs.environment }})
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    concurrency:
+      group: deploy-${{ inputs.environment }}
+      cancel-in-progress: ${{ inputs.environment == 'dev' }}
+    env:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # --- Toolchain setup ---
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: deploy
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: gateway/package-lock.json
+
+      - name: Install trunk
+        uses: taiki-e/install-action@v2
+        with:
+          tool: trunk
+
+      - uses: cargo-bins/cargo-binstall@main
+
+      - name: Install worker-build
+        run: cargo binstall worker-build --no-confirm
+
+      # --- API Worker ---
+      - name: Run D1 migrations
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: "4.78.0"
+          workingDirectory: crates/api
+          command: >-
+            d1 migrations apply ${{ inputs.d1_database }}
+            ${{ inputs.wrangler_env != '' && format('--env {0}', inputs.wrangler_env) || '' }}
+            --remote
+
+      - name: Deploy API Worker
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: "4.78.0"
+          workingDirectory: crates/api
+          command: >-
+            deploy
+            ${{ inputs.wrangler_env != '' && format('--env {0}', inputs.wrangler_env) || '' }}
+
+      # --- Gateway Worker ---
+      - name: Copy locales to gateway
+        run: |
+          cp -r locales gateway/locales
+          cp locales/en/mcp.ftl gateway/locales/en/mcp.txt
+          cp locales/pl/mcp.ftl gateway/locales/pl/mcp.txt
+
+      - name: Install gateway deps
+        run: cd gateway && npm ci
+
+      - name: Deploy Gateway Worker
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: "4.78.0"
+          workingDirectory: gateway
+          command: >-
+            deploy
+            ${{ inputs.wrangler_env != '' && format('--env {0}', inputs.wrangler_env) || '' }}
+
+      - name: Run Gateway auth migrations
+        env:
+          GATEWAY_URL: ${{ secrets.GATEWAY_URL }}
+          MIGRATE_SECRET: ${{ secrets.MIGRATE_SECRET }}
+        run: |
+          curl -sf -X POST "$GATEWAY_URL/migrate" \
+            -H "x-migrate-secret: $MIGRATE_SECRET"
+
+      # --- Frontend ---
+      - name: Install frontend deps
+        run: cd crates/frontend && npm install
+
+      - name: Build frontend
+        env:
+          API_BASE_URL: ${{ secrets.GATEWAY_URL }}/api
+        run: cd crates/frontend && trunk build --release
+
+      - name: Deploy frontend to CF Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: "4.78.0"
+          command: >-
+            pages deploy crates/frontend/dist
+            --project-name=kartoteka
+            --branch=${{ inputs.pages_branch }}
+            --commit-dirty=true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,96 +27,12 @@ jobs:
           manifest-file: .release-please-manifest.json
 
   deploy-prod:
-    name: Deploy Production
     needs: release-please
     if: needs.release-please.outputs.releases_created == 'true'
-    runs-on: ubuntu-latest
-    concurrency:
-      group: deploy-prod
-      cancel-in-progress: false
-    env:
-      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-    steps:
-      - uses: actions/checkout@v4
-
-      # --- API Worker (Rust) ---
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Run D1 migrations (API)
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          wranglerVersion: "4.78.0"
-          workingDirectory: crates/api
-          command: d1 migrations apply kartoteka-db --remote
-
-      - name: Install worker-build
-        run: cargo install worker-build
-
-      - name: Deploy API Worker
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          wranglerVersion: "4.78.0"
-          workingDirectory: crates/api
-          command: deploy
-
-      # --- Gateway Worker (TypeScript) ---
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: "npm"
-          cache-dependency-path: gateway/package-lock.json
-
-      - name: Copy locales to gateway
-        run: |
-          cp -r locales gateway/locales
-          cp locales/en/mcp.ftl gateway/locales/en/mcp.txt
-          cp locales/pl/mcp.ftl gateway/locales/pl/mcp.txt
-
-      - name: Install gateway deps
-        run: cd gateway && npm ci
-
-      - name: Deploy Gateway Worker
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          wranglerVersion: "4.78.0"
-          workingDirectory: gateway
-          command: deploy
-
-      - name: Run Gateway auth migrations
-        env:
-          MIGRATE_SECRET: ${{ secrets.MIGRATE_SECRET }}
-        run: |
-          curl -sf -X POST https://kartoteka-gateway.jpalczewski.workers.dev/migrate \
-            -H "x-migrate-secret: $MIGRATE_SECRET"
-
-      # --- Frontend (Leptos CSR → CF Pages) ---
-      - name: Install trunk
-        run: cargo install trunk
-
-      - name: Install frontend deps
-        run: cd crates/frontend && npm install
-
-      - name: Build frontend
-        env:
-          API_BASE_URL: https://kartoteka-gateway.jpalczewski.workers.dev/api
-        run: cd crates/frontend && trunk build --release
-
-      - name: Deploy frontend to CF Pages
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          wranglerVersion: "4.78.0"
-          command: pages deploy crates/frontend/dist --project-name=kartoteka --branch=main --commit-dirty=true
+    uses: ./.github/workflows/deploy.yml
+    with:
+      environment: production
+      wrangler_env: ""
+      d1_database: kartoteka-db
+      pages_branch: main
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Extract reusable `deploy.yml` workflow — deploy-dev and release-please are now thin callers (~15 lines each)
- `taiki-e/install-action` for trunk (prebuilt binary, ~2s vs ~3min compile)
- `cargo-binstall` for worker-build (prebuilt if available)
- Shared `rust-cache` key between dev/prod deploys
- GitHub Environments (`dev`, `production`) with scoped secrets
- `GATEWAY_URL` and `MIGRATE_SECRET` moved to environment secrets — no hardcoded URLs

## Before/After
| | Before | After |
|---|---|---|
| deploy-dev.yml | ~100 lines | ~15 lines |
| release-please.yml deploy job | ~80 lines | ~10 lines |
| trunk install | ~3 min (cargo install) | ~2s (prebuilt) |
| URLs | hardcoded in YAML | environment secrets |

## Test plan
- [ ] Push to develop triggers deploy-dev → calls deploy.yml → deploys successfully
- [ ] GH UI shows deployment in Environments tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)