### PR TITLE
ci: release-please from develop + separate deploy-prod

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,16 @@
+name: Deploy Production
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy.yml
+    with:
+      environment: production
+      wrangler_env: ""
+      d1_database: kartoteka-db
+      pages_branch: main
+    secrets: inherit

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,7 +3,7 @@ name: Release Please
 on:
   push:
     branches:
-      - main
+      - develop
   workflow_dispatch:
 
 jobs:
@@ -14,25 +14,12 @@ jobs:
       contents: write
       pull-requests: write
     concurrency:
-      group: release-please-${{ github.ref }}
+      group: release-please
       cancel-in-progress: false
-    outputs:
-      releases_created: ${{ steps.release.outputs.releases_created }}
     steps:
-      - id: release
-        uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         with:
           release-type: simple
+          target-branch: main
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-
-  deploy-prod:
-    needs: release-please
-    if: needs.release-please.outputs.releases_created == 'true'
-    uses: ./.github/workflows/deploy.yml
-    with:
-      environment: production
-      wrangler_env: ""
-      d1_database: kartoteka-db
-      pages_branch: main
-    secrets: inherit


### PR DESCRIPTION
## Summary
- Release-please triggers on push to `develop`, creates Release PR targeting `main`
- New `deploy-prod.yml` triggers on push to `main` (when Release PR is merged)
- Decouples release-please from deploy — cleaner separation

## Flow
```
push to develop → release-please (Release PR: develop → main)
                → deploy-dev (auto-deploy dev)
merge Release PR → push to main → deploy-prod (auto-deploy prod)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)