### PR TITLE
chore(ci): improve CodeQL analysis coverage and scope

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,14 @@ name: "CodeQL"
 on:
   push:
     branches: [main, develop]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
   pull_request:
     branches: [main, develop]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
   schedule:
     - cron: "0 6 * * 1" # weekly Monday 6am
 
@@ -23,10 +29,13 @@ jobs:
         include:
           - language: javascript-typescript
             build-mode: none
+            paths: gateway
           - language: actions
             build-mode: none
+            paths: .github
           - language: rust
             build-mode: none
+            paths: crates
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -36,6 +45,8 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
+          queries: security-extended
+          paths: ${{ matrix.paths }}
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Summary
- Add `paths-ignore` for `**/*.md` and `docs/**` — analysis skips doc-only commits
- Switch to `security-extended` query suite for broader OWASP coverage across all languages
- Scope each language job to its source directory via `paths` matrix variable:
  - `rust` → `crates/`
  - `javascript-typescript` → `gateway/`
  - `actions` → `.github/`

## Test plan
- [ ] Verify CodeQL workflow runs on PR targeting develop
- [ ] Confirm each job analyzes only its scoped directory
- [ ] Check Security → Code scanning tab for any new findings from extended suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)