### PR TITLE
feat: instance settings, admin panel, invite-only registration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,13 @@ Kartoteka — aplikacja todo/listy na Cloudflare Workers (Rust API + TypeScript 
 - `require_param(ctx, name)` — wyciągnij param z RouteContext lub Error
 - `get_list_features(d1, list_id)` — lista feature names dla listy
 
+### Tracing / Logging
+
+- Crate `kartoteka-logging` — inicjalizacja przez `kartoteka_logging::init_cf()` w `#[event(start)]`
+- Handlery instrumentowane: `#[instrument(skip_all, fields(action = "create_list", list_id = tracing::field::Empty))]`
+- Dynamiczne pola: `Span::current().record("list_id", tracing::field::display(&id))` — **bez `&` przed `tracing::field::display`** (clippy `needless_borrows_for_generic_args` blokuje CI)
+- Gateway: `log()` z `gateway/src/logger.ts` — ten sam schemat JSON, korelacja przez `X-Request-Id`
+
 ## Komendy
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,9 +72,22 @@ Kartoteka — aplikacja todo/listy na Cloudflare Workers (Rust API + TypeScript 
 
 ### Tracing / Logging
 
-- Crate `kartoteka-logging` — inicjalizacja przez `kartoteka_logging::init_cf()` w `#[event(start)]`
-- Handlery instrumentowane: `#[instrument(skip_all, fields(action = "create_list", list_id = tracing::field::Empty))]`
-- Dynamiczne pola: `Span::current().record("list_id", tracing::field::display(&id))` — **bez `&` przed `tracing::field::display`** (clippy `needless_borrows_for_generic_args` blokuje CI)
+Każdy handler w `crates/api/src/handlers/` **musi** mieć `#[instrument]`. Wzorzec:
+
+```rust
+#[instrument(skip_all, fields(action = "create_list", list_id = tracing::field::Empty))]
+pub async fn create(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
+    let id = Uuid::new_v4().to_string();
+    Span::current().record("list_id", tracing::field::display(&id));
+    // ...
+}
+```
+
+- `skip_all` — pomija `req`/`ctx` (nie są `Debug`)
+- `action` — nazwa operacji w formacie `verb_noun` (`create_list`, `delete_item`, `toggle_item`)
+- Entity ID jako `tracing::field::Empty` w atrybucie, uzupełniane przez `Span::current().record(...)` po poznaniu wartości
+- **Bez `&` przed `tracing::field::display`** — clippy `needless_borrows_for_generic_args` blokuje CI
+- Inicjalizacja tracingu: `kartoteka_logging::init_cf()` w `#[event(start)]`
 - Gateway: `log()` z `gateway/src/logger.ts` — ten sam schemat JSON, korelacja przez `X-Request-Id`
 
 ## Komendy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,6 +366,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a74858bcfe44b22016cb49337d7b6f04618c58e5dbfdef61b06b8c434324a0bc"
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "derive-where"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,6 +703,19 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1094,11 +1116,15 @@ dependencies = [
 name = "kartoteka-api"
 version = "0.1.1"
 dependencies = [
+ "getrandom 0.2.17",
  "kartoteka-i18n",
+ "kartoteka-logging",
  "kartoteka-shared",
+ "nanoid",
  "serde",
  "serde_json",
  "sqlx-d1",
+ "tracing",
  "uuid",
  "worker",
 ]
@@ -1135,6 +1161,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "kartoteka-logging"
+version = "0.1.1"
+dependencies = [
+ "serde",
+ "time",
+ "tracing",
+ "tracing-subscriber",
+ "tracing-web",
+ "worker",
+]
+
+[[package]]
 name = "kartoteka-shared"
 version = "0.1.1"
 dependencies = [
@@ -1142,6 +1180,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -1159,7 +1203,7 @@ dependencies = [
  "cfg-if",
  "either_of",
  "futures",
- "getrandom",
+ "getrandom 0.4.2",
  "hydration_context",
  "leptos_config",
  "leptos_dom",
@@ -1432,6 +1476,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1444,10 +1497,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "nanoid"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
+dependencies = [
+ "rand",
+]
+
+[[package]]
 name = "next_tuple"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60993920e071b0c9b66f14e2b32740a4e27ffc82854dcd72035887f336a09a28"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-traits"
@@ -1569,6 +1646,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1675,6 +1767,36 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "reactive_graph"
@@ -2015,6 +2137,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2247,7 +2378,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -2294,12 +2425,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "throw_error"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0ed6038fcbc0795aca7c92963ddda636573b956679204e044492d2b13c8f64"
 dependencies = [
  "pin-project-lite",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "js-sys",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -2395,6 +2567,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "time",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
+]
+
+[[package]]
+name = "tracing-web"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e6a141feebd51f8d91ebfd785af50fca223c570b86852166caa3b141defe7c"
+dependencies = [
+ "js-sys",
+ "tracing-core",
+ "tracing-subscriber",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2523,10 +2752,16 @@ version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -2549,6 +2784,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -2920,6 +3161,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/api",
     "crates/frontend",
     "crates/i18n",
+    "crates/logging",
 ]
 
 [workspace.package]

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 [dependencies]
 kartoteka-shared = { path = "../shared", version = "0.1.1" }
 kartoteka-i18n = { path = "../i18n", version = "0.1.1" }
-kartoteka-logging = { path = "../logging" }
+kartoteka-logging = { path = "../logging", version = "0.1.1" }
 tracing = "0.1"
 nanoid = "0.4"
 getrandom = { version = "0.2", features = ["js"] }
@@ -22,3 +22,8 @@ sqlx-d1 = { version = "0.3", features = ["macros"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 uuid = { version = "1", features = ["v4", "js"] }
+
+[package.metadata.cargo-machete]
+# getrandom: required for nanoid WASM compat (features = ["js"]), not imported directly;
+# kartoteka-i18n: used via macro expansion; sqlx-d1: used via sqlx macros
+ignored = ["getrandom", "kartoteka-i18n", "sqlx-d1"]

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -16,6 +16,7 @@ kartoteka-i18n = { path = "../i18n", version = "0.1.1" }
 kartoteka-logging = { path = "../logging" }
 tracing = "0.1"
 nanoid = "0.4"
+getrandom = { version = "0.2", features = ["js"] }
 worker = { version = "0.7", features = ["d1"] }
 sqlx-d1 = { version = "0.3", features = ["macros"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -13,6 +13,9 @@ workspace = true
 [dependencies]
 kartoteka-shared = { path = "../shared", version = "0.1.1" }
 kartoteka-i18n = { path = "../i18n", version = "0.1.1" }
+kartoteka-logging = { path = "../logging" }
+tracing = "0.1"
+nanoid = "0.4"
 worker = { version = "0.7", features = ["d1"] }
 sqlx-d1 = { version = "0.3", features = ["macros"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/api/migrations/0013_instance_settings.sql
+++ b/crates/api/migrations/0013_instance_settings.sql
@@ -1,0 +1,31 @@
+-- Instance-wide settings (key-value store, JSON values)
+CREATE TABLE instance_settings (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Default: registration is open
+INSERT INTO instance_settings (key, value) VALUES ('registration_mode', '"open"');
+
+-- Users table: mirrors Better Auth user IDs, stores app-level fields
+-- Designed as future primary users table (issue #24 Rust binary migration)
+CREATE TABLE users (
+    id TEXT PRIMARY KEY,
+    email TEXT,
+    is_admin INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Invitation codes with reservation to prevent race conditions
+CREATE TABLE invitation_codes (
+    id TEXT PRIMARY KEY,
+    code TEXT UNIQUE NOT NULL,
+    created_by TEXT NOT NULL,
+    used_by TEXT,
+    reserved_by_email TEXT,
+    reserved_until TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    used_at TEXT,
+    expires_at TEXT
+);

--- a/crates/api/src/auth.rs
+++ b/crates/api/src/auth.rs
@@ -17,3 +17,13 @@ pub fn user_id_from_gateway(req: &Request) -> Result<String> {
         .get("X-User-Id")?
         .ok_or_else(|| Error::from("Missing X-User-Id header"))
 }
+
+/// Extracts user email from X-User-Email header set by Gateway Worker.
+/// Returns None if header is absent (e.g. in dev bypass mode).
+pub fn user_email_from_gateway(req: &Request) -> Option<String> {
+    req.headers()
+        .get("X-User-Email")
+        .ok()
+        .flatten()
+        .filter(|s| !s.is_empty())
+}

--- a/crates/api/src/handlers/admin.rs
+++ b/crates/api/src/handlers/admin.rs
@@ -87,7 +87,10 @@ pub async fn list_codes(_req: Request, ctx: RouteContext<String>) -> Result<Resp
                 id: row.get("id")?.as_str().map(String::from)?,
                 code: row.get("code")?.as_str().map(String::from)?,
                 created_by: row.get("created_by")?.as_str().map(String::from)?,
-                used_by: row.get("used_by").and_then(|v| v.as_str()).map(String::from),
+                used_by: row
+                    .get("used_by")
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
                 reserved_by_email: row
                     .get("reserved_by_email")
                     .and_then(|v| v.as_str())
@@ -97,7 +100,10 @@ pub async fn list_codes(_req: Request, ctx: RouteContext<String>) -> Result<Resp
                     .and_then(|v| v.as_str())
                     .map(String::from),
                 created_at: row.get("created_at")?.as_str().map(String::from)?,
-                used_at: row.get("used_at").and_then(|v| v.as_str()).map(String::from),
+                used_at: row
+                    .get("used_at")
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
                 expires_at: row
                     .get("expires_at")
                     .and_then(|v| v.as_str())

--- a/crates/api/src/handlers/admin.rs
+++ b/crates/api/src/handlers/admin.rs
@@ -1,11 +1,13 @@
 use crate::helpers::{opt_str_to_js, require_admin, require_param};
 use kartoteka_shared::dto::requests::{CreateInvitationCodeRequest, UpsertSettingRequest};
 use kartoteka_shared::models::{InvitationCode, UserSetting};
+use tracing::instrument;
 use uuid::Uuid;
 use worker::*;
 
 // ── Instance Settings ──────────────────────────────────────────────────────
 
+#[instrument(skip_all)]
 pub async fn list_settings(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let d1 = ctx.env.d1("DB")?;
@@ -32,6 +34,7 @@ pub async fn list_settings(_req: Request, ctx: RouteContext<String>) -> Result<R
     Response::from_json(&settings)
 }
 
+#[instrument(skip_all, fields(action = "update_instance_setting"))]
 pub async fn update_setting(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let key = require_param(&ctx, "key")?;
@@ -59,6 +62,7 @@ pub async fn update_setting(mut req: Request, ctx: RouteContext<String>) -> Resu
 
 // ── Invitation Codes ───────────────────────────────────────────────────────
 
+#[instrument(skip_all)]
 pub async fn list_codes(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let d1 = ctx.env.d1("DB")?;
@@ -105,6 +109,7 @@ pub async fn list_codes(_req: Request, ctx: RouteContext<String>) -> Result<Resp
     Response::from_json(&codes)
 }
 
+#[instrument(skip_all, fields(action = "create_invitation_code"))]
 pub async fn create_code(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let d1 = ctx.env.d1("DB")?;
@@ -150,6 +155,7 @@ pub async fn create_code(mut req: Request, ctx: RouteContext<String>) -> Result<
     })
 }
 
+#[instrument(skip_all, fields(action = "delete_invitation_code"))]
 pub async fn delete_code(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;

--- a/crates/api/src/handlers/admin.rs
+++ b/crates/api/src/handlers/admin.rs
@@ -1,0 +1,167 @@
+use crate::helpers::{opt_str_to_js, require_admin, require_param};
+use kartoteka_shared::dto::requests::{CreateInvitationCodeRequest, UpsertSettingRequest};
+use kartoteka_shared::models::{InvitationCode, UserSetting};
+use uuid::Uuid;
+use worker::*;
+
+// ── Instance Settings ──────────────────────────────────────────────────────
+
+pub async fn list_settings(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
+    let user_id = ctx.data.clone();
+    let d1 = ctx.env.d1("DB")?;
+    if let Some(r) = require_admin(&d1, &user_id).await? {
+        return Ok(r);
+    }
+
+    let rows = d1
+        .prepare("SELECT key, value FROM instance_settings ORDER BY key")
+        .all()
+        .await?
+        .results::<serde_json::Value>()?;
+
+    let settings: Vec<UserSetting> = rows
+        .into_iter()
+        .filter_map(|row| {
+            let key = row.get("key")?.as_str().map(String::from)?;
+            let raw = row.get("value")?.as_str()?;
+            let value = serde_json::from_str(raw).ok()?;
+            Some(UserSetting { key, value })
+        })
+        .collect();
+
+    Response::from_json(&settings)
+}
+
+pub async fn update_setting(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
+    let user_id = ctx.data.clone();
+    let key = require_param(&ctx, "key")?;
+    let d1 = ctx.env.d1("DB")?;
+    if let Some(r) = require_admin(&d1, &user_id).await? {
+        return Ok(r);
+    }
+
+    let body: UpsertSettingRequest = req.json().await?;
+    let value_str = body.value.to_string();
+
+    d1.prepare(
+        "INSERT OR REPLACE INTO instance_settings (key, value, updated_at) \
+         VALUES (?1, ?2, datetime('now'))",
+    )
+    .bind(&[key.as_str().into(), value_str.as_str().into()])?
+    .run()
+    .await?;
+
+    Response::from_json(&UserSetting {
+        key,
+        value: body.value,
+    })
+}
+
+// ── Invitation Codes ───────────────────────────────────────────────────────
+
+pub async fn list_codes(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
+    let user_id = ctx.data.clone();
+    let d1 = ctx.env.d1("DB")?;
+    if let Some(r) = require_admin(&d1, &user_id).await? {
+        return Ok(r);
+    }
+
+    let rows = d1
+        .prepare(
+            "SELECT id, code, created_by, used_by, reserved_by_email, reserved_until, \
+                    created_at, used_at, expires_at \
+             FROM invitation_codes ORDER BY created_at DESC",
+        )
+        .all()
+        .await?
+        .results::<serde_json::Value>()?;
+
+    let codes: Vec<InvitationCode> = rows
+        .into_iter()
+        .filter_map(|row| {
+            Some(InvitationCode {
+                id: row.get("id")?.as_str().map(String::from)?,
+                code: row.get("code")?.as_str().map(String::from)?,
+                created_by: row.get("created_by")?.as_str().map(String::from)?,
+                used_by: row.get("used_by").and_then(|v| v.as_str()).map(String::from),
+                reserved_by_email: row
+                    .get("reserved_by_email")
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
+                reserved_until: row
+                    .get("reserved_until")
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
+                created_at: row.get("created_at")?.as_str().map(String::from)?,
+                used_at: row.get("used_at").and_then(|v| v.as_str()).map(String::from),
+                expires_at: row
+                    .get("expires_at")
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
+            })
+        })
+        .collect();
+
+    Response::from_json(&codes)
+}
+
+pub async fn create_code(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
+    let user_id = ctx.data.clone();
+    let d1 = ctx.env.d1("DB")?;
+    if let Some(r) = require_admin(&d1, &user_id).await? {
+        return Ok(r);
+    }
+
+    let body: CreateInvitationCodeRequest = req.json().await?;
+    let id = Uuid::new_v4().to_string();
+    // Generate an 8-character uppercase alphanumeric code from a UUID
+    let code = Uuid::new_v4()
+        .to_string()
+        .replace('-', "")
+        .to_uppercase()
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .take(8)
+        .collect::<String>();
+
+    d1.prepare(
+        "INSERT INTO invitation_codes (id, code, created_by, expires_at) \
+         VALUES (?1, ?2, ?3, ?4)",
+    )
+    .bind(&[
+        id.as_str().into(),
+        code.as_str().into(),
+        user_id.as_str().into(),
+        opt_str_to_js(&body.expires_at),
+    ])?
+    .run()
+    .await?;
+
+    Response::from_json(&InvitationCode {
+        id,
+        code,
+        created_by: user_id,
+        used_by: None,
+        reserved_by_email: None,
+        reserved_until: None,
+        created_at: String::new(), // DB sets this; not read back here
+        used_at: None,
+        expires_at: body.expires_at,
+    })
+}
+
+pub async fn delete_code(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
+    let user_id = ctx.data.clone();
+    let id = require_param(&ctx, "id")?;
+    let d1 = ctx.env.d1("DB")?;
+    if let Some(r) = require_admin(&d1, &user_id).await? {
+        return Ok(r);
+    }
+
+    d1.prepare("DELETE FROM invitation_codes WHERE id = ?1")
+        .bind(&[id.into()])?
+        .run()
+        .await?;
+
+    Ok(Response::empty()?.with_status(204))
+}

--- a/crates/api/src/handlers/admin.rs
+++ b/crates/api/src/handlers/admin.rs
@@ -1,6 +1,7 @@
 use crate::helpers::{opt_str_to_js, require_admin, require_param};
-use kartoteka_shared::dto::requests::{CreateInvitationCodeRequest, UpsertSettingRequest};
-use kartoteka_shared::models::{InvitationCode, UserSetting};
+use kartoteka_shared::{
+    CreateInvitationCodeRequest, InvitationCode, UpsertSettingRequest, UserSetting,
+};
 use tracing::instrument;
 use uuid::Uuid;
 use worker::*;

--- a/crates/api/src/handlers/containers.rs
+++ b/crates/api/src/handlers/containers.rs
@@ -4,6 +4,7 @@ use kartoteka_shared::{
     Container, ContainerDetail, CreateContainerRequest, List, MoveContainerRequest,
     UpdateContainerRequest,
 };
+use tracing::instrument;
 use wasm_bindgen::JsValue;
 use worker::*;
 
@@ -13,6 +14,7 @@ const CONTAINER_SELECT: &str = "\
     c.created_at, c.updated_at \
     FROM containers c";
 
+#[instrument(skip_all)]
 pub async fn list_all(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let d1 = ctx.env.d1("DB")?;
@@ -27,10 +29,12 @@ pub async fn list_all(_req: Request, ctx: RouteContext<String>) -> Result<Respon
     Response::from_json(&containers)
 }
 
+#[instrument(skip_all, fields(action = "create_container", container_id = tracing::field::Empty))]
 pub async fn create(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let body: CreateContainerRequest = req.json().await?;
     let id = uuid::Uuid::new_v4().to_string();
+    tracing::Span::current().record("container_id", &tracing::field::display(&id));
     let d1 = ctx.env.d1("DB")?;
 
     // Validate: parent must not be a project (status != NULL)
@@ -101,6 +105,7 @@ pub async fn create(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
     Ok(resp)
 }
 
+#[instrument(skip_all)]
 pub async fn get_one(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
@@ -185,9 +190,11 @@ pub async fn get_one(_req: Request, ctx: RouteContext<String>) -> Result<Respons
     Response::from_json(&detail)
 }
 
+#[instrument(skip_all, fields(action = "update_container", container_id = tracing::field::Empty))]
 pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
+    tracing::Span::current().record("container_id", &tracing::field::display(&id));
     let body: UpdateContainerRequest = req.json().await?;
     let d1 = ctx.env.d1("DB")?;
 
@@ -241,9 +248,11 @@ pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
     Response::from_json(&container)
 }
 
+#[instrument(skip_all, fields(action = "delete_container", container_id = tracing::field::Empty))]
 pub async fn delete(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
+    tracing::Span::current().record("container_id", &tracing::field::display(&id));
     let d1 = ctx.env.d1("DB")?;
 
     if !check_ownership(&d1, "containers", &id, &user_id).await? {
@@ -258,6 +267,7 @@ pub async fn delete(_req: Request, ctx: RouteContext<String>) -> Result<Response
     Ok(Response::empty()?.with_status(204))
 }
 
+#[instrument(skip_all)]
 pub async fn get_children(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
@@ -296,9 +306,11 @@ pub async fn get_children(_req: Request, ctx: RouteContext<String>) -> Result<Re
     Response::from_json(&resp)
 }
 
+#[instrument(skip_all, fields(action = "move_container", container_id = tracing::field::Empty))]
 pub async fn move_container(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
+    tracing::Span::current().record("container_id", &tracing::field::display(&id));
     let body: MoveContainerRequest = req.json().await?;
     let d1 = ctx.env.d1("DB")?;
 
@@ -347,9 +359,11 @@ pub async fn move_container(mut req: Request, ctx: RouteContext<String>) -> Resu
     Response::from_json(&container)
 }
 
+#[instrument(skip_all, fields(action = "toggle_container_pin", container_id = tracing::field::Empty))]
 pub async fn toggle_pin(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
+    tracing::Span::current().record("container_id", &tracing::field::display(&id));
     let d1 = ctx.env.d1("DB")?;
 
     if toggle_bool_field(&d1, "containers", "pinned", &id, &user_id)
@@ -373,6 +387,7 @@ pub async fn toggle_pin(_req: Request, ctx: RouteContext<String>) -> Result<Resp
 
 // === Home endpoint ===
 
+#[instrument(skip_all)]
 pub async fn home(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let d1 = ctx.env.d1("DB")?;

--- a/crates/api/src/handlers/containers.rs
+++ b/crates/api/src/handlers/containers.rs
@@ -34,7 +34,7 @@ pub async fn create(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
     let user_id = ctx.data.clone();
     let body: CreateContainerRequest = req.json().await?;
     let id = uuid::Uuid::new_v4().to_string();
-    tracing::Span::current().record("container_id", &tracing::field::display(&id));
+    tracing::Span::current().record("container_id", tracing::field::display(&id));
     let d1 = ctx.env.d1("DB")?;
 
     // Validate: parent must not be a project (status != NULL)
@@ -194,7 +194,7 @@ pub async fn get_one(_req: Request, ctx: RouteContext<String>) -> Result<Respons
 pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
-    tracing::Span::current().record("container_id", &tracing::field::display(&id));
+    tracing::Span::current().record("container_id", tracing::field::display(&id));
     let body: UpdateContainerRequest = req.json().await?;
     let d1 = ctx.env.d1("DB")?;
 
@@ -252,7 +252,7 @@ pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
 pub async fn delete(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
-    tracing::Span::current().record("container_id", &tracing::field::display(&id));
+    tracing::Span::current().record("container_id", tracing::field::display(&id));
     let d1 = ctx.env.d1("DB")?;
 
     if !check_ownership(&d1, "containers", &id, &user_id).await? {
@@ -310,7 +310,7 @@ pub async fn get_children(_req: Request, ctx: RouteContext<String>) -> Result<Re
 pub async fn move_container(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
-    tracing::Span::current().record("container_id", &tracing::field::display(&id));
+    tracing::Span::current().record("container_id", tracing::field::display(&id));
     let body: MoveContainerRequest = req.json().await?;
     let d1 = ctx.env.d1("DB")?;
 
@@ -363,7 +363,7 @@ pub async fn move_container(mut req: Request, ctx: RouteContext<String>) -> Resu
 pub async fn toggle_pin(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
-    tracing::Span::current().record("container_id", &tracing::field::display(&id));
+    tracing::Span::current().record("container_id", tracing::field::display(&id));
     let d1 = ctx.env.d1("DB")?;
 
     if toggle_bool_field(&d1, "containers", "pinned", &id, &user_id)

--- a/crates/api/src/handlers/items.rs
+++ b/crates/api/src/handlers/items.rs
@@ -1,6 +1,7 @@
 use crate::error::json_error;
 use crate::helpers::*;
 use kartoteka_shared::*;
+use tracing::instrument;
 use wasm_bindgen::JsValue;
 use worker::*;
 
@@ -12,6 +13,7 @@ const DATE_ITEM_COLS: &str = "i.id, i.list_id, i.title, i.description, i.complet
     i.quantity, i.actual_quantity, i.unit, i.start_date, i.start_time, i.deadline, i.deadline_time, i.hard_deadline, \
     i.created_at, i.updated_at, l.name as list_name, l.list_type";
 
+#[instrument(skip_all)]
 pub async fn list_all(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let list_id = require_param(&ctx, "list_id")?;
@@ -30,6 +32,7 @@ pub async fn list_all(_req: Request, ctx: RouteContext<String>) -> Result<Respon
     Response::from_json(&items)
 }
 
+#[instrument(skip_all)]
 pub async fn get_one(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let list_id = require_param(&ctx, "list_id")?;
@@ -76,11 +79,13 @@ pub async fn get_one(_req: Request, ctx: RouteContext<String>) -> Result<Respons
     })
 }
 
+#[instrument(skip_all, fields(action = "create_item", item_id = tracing::field::Empty))]
 pub async fn create(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let list_id = require_param(&ctx, "list_id")?;
     let body: CreateItemRequest = req.json().await?;
     let id = uuid::Uuid::new_v4().to_string();
+    tracing::Span::current().record("item_id", &tracing::field::display(&id));
 
     let d1 = ctx.env.d1("DB")?;
 
@@ -193,9 +198,11 @@ fn check_item_features(
     Ok(None)
 }
 
+#[instrument(skip_all, fields(action = "update_item", item_id = tracing::field::Empty))]
 pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
+    tracing::Span::current().record("item_id", &tracing::field::display(&id));
     let body: UpdateItemRequest = req.json().await?;
     let d1 = ctx.env.d1("DB")?;
 
@@ -328,9 +335,11 @@ pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
     Response::from_json(&item)
 }
 
+#[instrument(skip_all, fields(action = "delete_item", item_id = tracing::field::Empty))]
 pub async fn delete(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
+    tracing::Span::current().record("item_id", &tracing::field::display(&id));
     let d1 = ctx.env.d1("DB")?;
 
     if !check_item_ownership(&d1, &id, &user_id).await? {
@@ -344,9 +353,11 @@ pub async fn delete(_req: Request, ctx: RouteContext<String>) -> Result<Response
     Ok(Response::empty()?.with_status(204))
 }
 
+#[instrument(skip_all, fields(action = "move_item", item_id = tracing::field::Empty))]
 pub async fn move_item(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
+    tracing::Span::current().record("item_id", &tracing::field::display(&id));
     let body: serde_json::Value = req.json().await?;
     let target_list_id = body
         .get("target_list_id")
@@ -390,6 +401,7 @@ pub async fn move_item(mut req: Request, ctx: RouteContext<String>) -> Result<Re
 }
 
 /// GET /api/items/by-date?date=YYYY-MM-DD&date_field=deadline&include_overdue=true
+#[instrument(skip_all)]
 pub async fn by_date(req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let url = req.url()?;
@@ -484,6 +496,7 @@ pub async fn by_date(req: Request, ctx: RouteContext<String>) -> Result<Response
 }
 
 /// GET /api/items/calendar?from=YYYY-MM-DD&to=YYYY-MM-DD&date_field=deadline&detail=counts|full
+#[instrument(skip_all)]
 pub async fn calendar(req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let url = req.url()?;

--- a/crates/api/src/handlers/items.rs
+++ b/crates/api/src/handlers/items.rs
@@ -85,7 +85,7 @@ pub async fn create(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
     let list_id = require_param(&ctx, "list_id")?;
     let body: CreateItemRequest = req.json().await?;
     let id = uuid::Uuid::new_v4().to_string();
-    tracing::Span::current().record("item_id", &tracing::field::display(&id));
+    tracing::Span::current().record("item_id", tracing::field::display(&id));
 
     let d1 = ctx.env.d1("DB")?;
 
@@ -202,7 +202,7 @@ fn check_item_features(
 pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
-    tracing::Span::current().record("item_id", &tracing::field::display(&id));
+    tracing::Span::current().record("item_id", tracing::field::display(&id));
     let body: UpdateItemRequest = req.json().await?;
     let d1 = ctx.env.d1("DB")?;
 
@@ -339,7 +339,7 @@ pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
 pub async fn delete(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
-    tracing::Span::current().record("item_id", &tracing::field::display(&id));
+    tracing::Span::current().record("item_id", tracing::field::display(&id));
     let d1 = ctx.env.d1("DB")?;
 
     if !check_item_ownership(&d1, &id, &user_id).await? {
@@ -357,7 +357,7 @@ pub async fn delete(_req: Request, ctx: RouteContext<String>) -> Result<Response
 pub async fn move_item(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
-    tracing::Span::current().record("item_id", &tracing::field::display(&id));
+    tracing::Span::current().record("item_id", tracing::field::display(&id));
     let body: serde_json::Value = req.json().await?;
     let target_list_id = body
         .get("target_list_id")

--- a/crates/api/src/handlers/lists.rs
+++ b/crates/api/src/handlers/lists.rs
@@ -1,6 +1,7 @@
 use crate::error::json_error;
 use crate::helpers::*;
 use kartoteka_shared::*;
+use tracing::instrument;
 use worker::*;
 
 pub const LIST_SELECT: &str = "\
@@ -11,6 +12,7 @@ pub const LIST_SELECT: &str = "\
     FROM list_features lf WHERE lf.list_id = l.id), '[]') as features \
     FROM lists l";
 
+#[instrument(skip_all)]
 pub async fn list_all(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let d1 = ctx.env.d1("DB")?;
@@ -25,10 +27,12 @@ pub async fn list_all(_req: Request, ctx: RouteContext<String>) -> Result<Respon
     Response::from_json(&lists)
 }
 
+#[instrument(skip_all, fields(action = "create_list", list_id = tracing::field::Empty))]
 pub async fn create(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let body: CreateListRequest = req.json().await?;
     let id = uuid::Uuid::new_v4().to_string();
+    tracing::Span::current().record("list_id", &tracing::field::display(&id));
     let list_type_str = serde_json::to_value(&body.list_type)
         .map_err(|e| Error::from(e.to_string()))?
         .as_str()
@@ -74,6 +78,7 @@ pub async fn create(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
     Ok(resp)
 }
 
+#[instrument(skip_all)]
 pub async fn get_one(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
@@ -98,9 +103,11 @@ pub async fn get_one(_req: Request, ctx: RouteContext<String>) -> Result<Respons
     }
 }
 
+#[instrument(skip_all, fields(action = "update_list", list_id = tracing::field::Empty))]
 pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
+    tracing::Span::current().record("list_id", &tracing::field::display(&id));
     let body: UpdateListRequest = req.json().await?;
     let d1 = ctx.env.d1("DB")?;
 
@@ -152,9 +159,11 @@ pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
     Response::from_json(&list)
 }
 
+#[instrument(skip_all, fields(action = "delete_list", list_id = tracing::field::Empty))]
 pub async fn delete(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
+    tracing::Span::current().record("list_id", &tracing::field::display(&id));
     let d1 = ctx.env.d1("DB")?;
     d1.prepare("DELETE FROM lists WHERE id = ?1 AND user_id = ?2")
         .bind(&[id.into(), user_id.into()])?
@@ -163,6 +172,7 @@ pub async fn delete(_req: Request, ctx: RouteContext<String>) -> Result<Response
     Ok(Response::empty()?.with_status(204))
 }
 
+#[instrument(skip_all)]
 pub async fn list_sublists(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let parent_id = require_param(&ctx, "id")?;
@@ -183,6 +193,7 @@ pub async fn list_sublists(_req: Request, ctx: RouteContext<String>) -> Result<R
     Response::from_json(&sublists)
 }
 
+#[instrument(skip_all)]
 pub async fn list_archived(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let d1 = ctx.env.d1("DB")?;
@@ -197,9 +208,11 @@ pub async fn list_archived(_req: Request, ctx: RouteContext<String>) -> Result<R
     Response::from_json(&lists)
 }
 
+#[instrument(skip_all, fields(action = "toggle_archive", list_id = tracing::field::Empty))]
 pub async fn toggle_archive(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
+    tracing::Span::current().record("list_id", &tracing::field::display(&id));
     let d1 = ctx.env.d1("DB")?;
 
     if toggle_bool_field(&d1, "lists", "archived", &id, &user_id)
@@ -219,9 +232,11 @@ pub async fn toggle_archive(_req: Request, ctx: RouteContext<String>) -> Result<
     Response::from_json(&list)
 }
 
+#[instrument(skip_all, fields(action = "reset_list", list_id = tracing::field::Empty))]
 pub async fn reset(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
+    tracing::Span::current().record("list_id", &tracing::field::display(&id));
     let d1 = ctx.env.d1("DB")?;
 
     if !check_ownership(&d1, "lists", &id, &user_id).await? {
@@ -248,6 +263,7 @@ pub async fn reset(_req: Request, ctx: RouteContext<String>) -> Result<Response>
     Ok(Response::empty()?.with_status(204))
 }
 
+#[instrument(skip_all, fields(action = "create_sublist", list_id = tracing::field::Empty))]
 pub async fn create_sublist(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let parent_id = require_param(&ctx, "id")?;
@@ -258,6 +274,7 @@ pub async fn create_sublist(mut req: Request, ctx: RouteContext<String>) -> Resu
         .ok_or_else(|| Error::from("Missing name"))?
         .to_string();
     let id = uuid::Uuid::new_v4().to_string();
+    tracing::Span::current().record("list_id", &tracing::field::display(&id));
     let d1 = ctx.env.d1("DB")?;
 
     // Verify parent belongs to user and is a top-level list
@@ -306,9 +323,11 @@ pub async fn create_sublist(mut req: Request, ctx: RouteContext<String>) -> Resu
 
 // === Feature CRUD ===
 
+#[instrument(skip_all, fields(action = "add_list_feature", list_id = tracing::field::Empty))]
 pub async fn add_feature(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let list_id = require_param(&ctx, "id")?;
+    tracing::Span::current().record("list_id", &tracing::field::display(&list_id));
     let feature_name = require_param(&ctx, "name")?;
 
     let d1 = ctx.env.d1("DB")?;
@@ -351,9 +370,11 @@ pub async fn add_feature(mut req: Request, ctx: RouteContext<String>) -> Result<
     Response::from_json(&list)
 }
 
+#[instrument(skip_all, fields(action = "remove_list_feature", list_id = tracing::field::Empty))]
 pub async fn remove_feature(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let list_id = require_param(&ctx, "id")?;
+    tracing::Span::current().record("list_id", &tracing::field::display(&list_id));
     let feature_name = require_param(&ctx, "name")?;
 
     let d1 = ctx.env.d1("DB")?;
@@ -380,9 +401,11 @@ pub async fn remove_feature(_req: Request, ctx: RouteContext<String>) -> Result<
 
 // === Container assignment ===
 
+#[instrument(skip_all, fields(action = "move_list", list_id = tracing::field::Empty))]
 pub async fn move_list(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
+    tracing::Span::current().record("list_id", &tracing::field::display(&id));
     let body: MoveListRequest = req.json().await?;
     let d1 = ctx.env.d1("DB")?;
 
@@ -414,9 +437,11 @@ pub async fn move_list(mut req: Request, ctx: RouteContext<String>) -> Result<Re
     Response::from_json(&list)
 }
 
+#[instrument(skip_all, fields(action = "toggle_list_pin", list_id = tracing::field::Empty))]
 pub async fn toggle_pin(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
+    tracing::Span::current().record("list_id", &tracing::field::display(&id));
     let d1 = ctx.env.d1("DB")?;
 
     if toggle_bool_field(&d1, "lists", "pinned", &id, &user_id)

--- a/crates/api/src/handlers/lists.rs
+++ b/crates/api/src/handlers/lists.rs
@@ -32,7 +32,7 @@ pub async fn create(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
     let user_id = ctx.data.clone();
     let body: CreateListRequest = req.json().await?;
     let id = uuid::Uuid::new_v4().to_string();
-    tracing::Span::current().record("list_id", &tracing::field::display(&id));
+    tracing::Span::current().record("list_id", tracing::field::display(&id));
     let list_type_str = serde_json::to_value(&body.list_type)
         .map_err(|e| Error::from(e.to_string()))?
         .as_str()
@@ -107,7 +107,7 @@ pub async fn get_one(_req: Request, ctx: RouteContext<String>) -> Result<Respons
 pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
-    tracing::Span::current().record("list_id", &tracing::field::display(&id));
+    tracing::Span::current().record("list_id", tracing::field::display(&id));
     let body: UpdateListRequest = req.json().await?;
     let d1 = ctx.env.d1("DB")?;
 
@@ -163,7 +163,7 @@ pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
 pub async fn delete(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
-    tracing::Span::current().record("list_id", &tracing::field::display(&id));
+    tracing::Span::current().record("list_id", tracing::field::display(&id));
     let d1 = ctx.env.d1("DB")?;
     d1.prepare("DELETE FROM lists WHERE id = ?1 AND user_id = ?2")
         .bind(&[id.into(), user_id.into()])?
@@ -212,7 +212,7 @@ pub async fn list_archived(_req: Request, ctx: RouteContext<String>) -> Result<R
 pub async fn toggle_archive(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
-    tracing::Span::current().record("list_id", &tracing::field::display(&id));
+    tracing::Span::current().record("list_id", tracing::field::display(&id));
     let d1 = ctx.env.d1("DB")?;
 
     if toggle_bool_field(&d1, "lists", "archived", &id, &user_id)
@@ -236,7 +236,7 @@ pub async fn toggle_archive(_req: Request, ctx: RouteContext<String>) -> Result<
 pub async fn reset(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
-    tracing::Span::current().record("list_id", &tracing::field::display(&id));
+    tracing::Span::current().record("list_id", tracing::field::display(&id));
     let d1 = ctx.env.d1("DB")?;
 
     if !check_ownership(&d1, "lists", &id, &user_id).await? {
@@ -274,7 +274,7 @@ pub async fn create_sublist(mut req: Request, ctx: RouteContext<String>) -> Resu
         .ok_or_else(|| Error::from("Missing name"))?
         .to_string();
     let id = uuid::Uuid::new_v4().to_string();
-    tracing::Span::current().record("list_id", &tracing::field::display(&id));
+    tracing::Span::current().record("list_id", tracing::field::display(&id));
     let d1 = ctx.env.d1("DB")?;
 
     // Verify parent belongs to user and is a top-level list
@@ -327,7 +327,7 @@ pub async fn create_sublist(mut req: Request, ctx: RouteContext<String>) -> Resu
 pub async fn add_feature(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let list_id = require_param(&ctx, "id")?;
-    tracing::Span::current().record("list_id", &tracing::field::display(&list_id));
+    tracing::Span::current().record("list_id", tracing::field::display(&list_id));
     let feature_name = require_param(&ctx, "name")?;
 
     let d1 = ctx.env.d1("DB")?;
@@ -374,7 +374,7 @@ pub async fn add_feature(mut req: Request, ctx: RouteContext<String>) -> Result<
 pub async fn remove_feature(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let list_id = require_param(&ctx, "id")?;
-    tracing::Span::current().record("list_id", &tracing::field::display(&list_id));
+    tracing::Span::current().record("list_id", tracing::field::display(&list_id));
     let feature_name = require_param(&ctx, "name")?;
 
     let d1 = ctx.env.d1("DB")?;
@@ -405,7 +405,7 @@ pub async fn remove_feature(_req: Request, ctx: RouteContext<String>) -> Result<
 pub async fn move_list(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
-    tracing::Span::current().record("list_id", &tracing::field::display(&id));
+    tracing::Span::current().record("list_id", tracing::field::display(&id));
     let body: MoveListRequest = req.json().await?;
     let d1 = ctx.env.d1("DB")?;
 
@@ -441,7 +441,7 @@ pub async fn move_list(mut req: Request, ctx: RouteContext<String>) -> Result<Re
 pub async fn toggle_pin(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
-    tracing::Span::current().record("list_id", &tracing::field::display(&id));
+    tracing::Span::current().record("list_id", tracing::field::display(&id));
     let d1 = ctx.env.d1("DB")?;
 
     if toggle_bool_field(&d1, "lists", "pinned", &id, &user_id)

--- a/crates/api/src/handlers/me.rs
+++ b/crates/api/src/handlers/me.rs
@@ -1,6 +1,6 @@
 use crate::auth::user_email_from_gateway;
 use crate::helpers::ensure_user_exists;
-use kartoteka_shared::dto::responses::MeResponse;
+use kartoteka_shared::MeResponse;
 use tracing::instrument;
 use worker::*;
 
@@ -30,9 +30,9 @@ pub async fn get_me(req: Request, ctx: RouteContext<String>) -> Result<Response>
             "UPDATE invitation_codes \
              SET used_by = ?1, used_at = datetime('now'), \
                  reserved_by_email = NULL, reserved_until = NULL \
-             WHERE code = ?2 AND used_by IS NULL",
+             WHERE code = ?2 AND used_by IS NULL AND reserved_by_email = ?3",
         )
-        .bind(&[user_id.into(), invite_code.into()])?
+        .bind(&[user_id.into(), invite_code.into(), email.as_str().into()])?
         .run()
         .await?;
     }

--- a/crates/api/src/handlers/me.rs
+++ b/crates/api/src/handlers/me.rs
@@ -1,0 +1,35 @@
+use crate::auth::user_email_from_gateway;
+use crate::helpers::ensure_user_exists;
+use kartoteka_shared::dto::responses::MeResponse;
+use worker::*;
+
+pub async fn get_me(req: Request, ctx: RouteContext<String>) -> Result<Response> {
+    let user_id = ctx.data.clone();
+    let d1 = ctx.env.d1("DB")?;
+
+    let email = user_email_from_gateway(&req).unwrap_or_default();
+    let initial_admin_email = ctx
+        .env
+        .var("INITIAL_ADMIN_EMAIL")
+        .ok()
+        .map(|v| v.to_string())
+        .unwrap_or_default();
+
+    let is_admin = ensure_user_exists(&d1, &user_id, &email, &initial_admin_email).await?;
+
+    // Optional: finalize an invite code after successful signup
+    let url = req.url()?;
+    if let Some(invite_code) = url.query_pairs().find(|(k, _)| k == "invite_code").map(|(_, v)| v.into_owned()) {
+        d1.prepare(
+            "UPDATE invitation_codes \
+             SET used_by = ?1, used_at = datetime('now'), \
+                 reserved_by_email = NULL, reserved_until = NULL \
+             WHERE code = ?2 AND used_by IS NULL",
+        )
+        .bind(&[user_id.into(), invite_code.into()])?
+        .run()
+        .await?;
+    }
+
+    Response::from_json(&MeResponse { is_admin })
+}

--- a/crates/api/src/handlers/me.rs
+++ b/crates/api/src/handlers/me.rs
@@ -1,8 +1,10 @@
 use crate::auth::user_email_from_gateway;
 use crate::helpers::ensure_user_exists;
 use kartoteka_shared::dto::responses::MeResponse;
+use tracing::instrument;
 use worker::*;
 
+#[instrument(skip_all)]
 pub async fn get_me(req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let d1 = ctx.env.d1("DB")?;

--- a/crates/api/src/handlers/me.rs
+++ b/crates/api/src/handlers/me.rs
@@ -21,7 +21,11 @@ pub async fn get_me(req: Request, ctx: RouteContext<String>) -> Result<Response>
 
     // Optional: finalize an invite code after successful signup
     let url = req.url()?;
-    if let Some(invite_code) = url.query_pairs().find(|(k, _)| k == "invite_code").map(|(_, v)| v.into_owned()) {
+    if let Some(invite_code) = url
+        .query_pairs()
+        .find(|(k, _)| k == "invite_code")
+        .map(|(_, v)| v.into_owned())
+    {
         d1.prepare(
             "UPDATE invitation_codes \
              SET used_by = ?1, used_at = datetime('now'), \

--- a/crates/api/src/handlers/mod.rs
+++ b/crates/api/src/handlers/mod.rs
@@ -1,6 +1,9 @@
+pub mod admin;
 pub mod containers;
 pub mod items;
 pub mod lists;
+pub mod me;
 pub mod preferences;
+pub mod public;
 pub mod settings;
 pub mod tags;

--- a/crates/api/src/handlers/preferences.rs
+++ b/crates/api/src/handlers/preferences.rs
@@ -1,5 +1,6 @@
 use crate::error::json_error;
 use serde::{Deserialize, Serialize};
+use tracing::instrument;
 use worker::*;
 
 #[derive(Serialize)]
@@ -12,6 +13,7 @@ struct UpdatePreferencesBody {
     locale: String,
 }
 
+#[instrument(skip_all)]
 pub async fn get_preferences(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
 
@@ -32,6 +34,7 @@ pub async fn get_preferences(_req: Request, ctx: RouteContext<String>) -> Result
     Response::from_json(&PreferencesResponse { locale })
 }
 
+#[instrument(skip_all, fields(action = "update_preferences"))]
 pub async fn put_preferences(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
 

--- a/crates/api/src/handlers/public.rs
+++ b/crates/api/src/handlers/public.rs
@@ -1,9 +1,11 @@
 use kartoteka_shared::constants::INSTANCE_SETTING_REGISTRATION_MODE;
 use kartoteka_shared::dto::requests::ValidateInviteRequest;
 use kartoteka_shared::dto::responses::{RegistrationModeResponse, ValidateInviteResponse};
+use tracing::instrument;
 use worker::*;
 
 /// GET /api/public/registration-mode — no auth required
+#[instrument(skip_all)]
 pub async fn get_registration_mode(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let d1 = ctx.env.d1("DB")?;
 
@@ -22,6 +24,7 @@ pub async fn get_registration_mode(_req: Request, ctx: RouteContext<String>) -> 
 }
 
 /// POST /api/public/validate-invite — no auth required
+#[instrument(skip_all, fields(action = "validate_invite"))]
 pub async fn validate_invite(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let body: ValidateInviteRequest = req.json().await?;
     let d1 = ctx.env.d1("DB")?;

--- a/crates/api/src/handlers/public.rs
+++ b/crates/api/src/handlers/public.rs
@@ -1,0 +1,82 @@
+use kartoteka_shared::constants::INSTANCE_SETTING_REGISTRATION_MODE;
+use kartoteka_shared::dto::requests::ValidateInviteRequest;
+use kartoteka_shared::dto::responses::{RegistrationModeResponse, ValidateInviteResponse};
+use worker::*;
+
+/// GET /api/public/registration-mode — no auth required
+pub async fn get_registration_mode(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
+    let d1 = ctx.env.d1("DB")?;
+
+    let row = d1
+        .prepare("SELECT value FROM instance_settings WHERE key = ?1")
+        .bind(&[INSTANCE_SETTING_REGISTRATION_MODE.into()])?
+        .first::<serde_json::Value>(None)
+        .await?;
+
+    let mode = row
+        .and_then(|v| v.get("value")?.as_str().map(String::from))
+        .and_then(|s| serde_json::from_str::<String>(&s).ok())
+        .unwrap_or_else(|| "open".to_string());
+
+    Response::from_json(&RegistrationModeResponse { mode })
+}
+
+/// POST /api/public/validate-invite — no auth required
+pub async fn validate_invite(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
+    let body: ValidateInviteRequest = req.json().await?;
+    let d1 = ctx.env.d1("DB")?;
+
+    // Check that the code exists, is unused, and not expired
+    let existing = d1
+        .prepare(
+            "SELECT id, reserved_by_email, reserved_until \
+             FROM invitation_codes \
+             WHERE code = ?1 AND used_by IS NULL \
+               AND (expires_at IS NULL OR expires_at > datetime('now'))",
+        )
+        .bind(&[body.code.as_str().into()])?
+        .first::<serde_json::Value>(None)
+        .await?;
+
+    let Some(_row) = existing else {
+        return Response::from_json(&ValidateInviteResponse {
+            valid: false,
+            error: Some("invalid_code".to_string()),
+        });
+    };
+
+    // Row exists; attempt atomic reservation.
+    // The UPDATE only succeeds if not currently reserved by someone else (or reservation expired).
+    // Atomically try to reserve: only succeeds if not reserved or reservation expired
+    d1.prepare(
+        "UPDATE invitation_codes \
+         SET reserved_by_email = ?1, reserved_until = datetime('now', '+10 minutes') \
+         WHERE code = ?2 AND used_by IS NULL \
+           AND (reserved_until IS NULL OR reserved_until < datetime('now'))",
+    )
+    .bind(&[body.email.as_str().into(), body.code.as_str().into()])?
+    .run()
+    .await?;
+
+    // Confirm reservation belongs to this email
+    let confirmed = d1
+        .prepare(
+            "SELECT id FROM invitation_codes \
+             WHERE code = ?1 AND reserved_by_email = ?2 AND reserved_until > datetime('now')",
+        )
+        .bind(&[body.code.as_str().into(), body.email.as_str().into()])?
+        .first::<serde_json::Value>(None)
+        .await?;
+
+    if confirmed.is_some() {
+        Response::from_json(&ValidateInviteResponse {
+            valid: true,
+            error: None,
+        })
+    } else {
+        Response::from_json(&ValidateInviteResponse {
+            valid: false,
+            error: Some("code_in_use".to_string()),
+        })
+    }
+}

--- a/crates/api/src/handlers/public.rs
+++ b/crates/api/src/handlers/public.rs
@@ -1,6 +1,7 @@
-use kartoteka_shared::constants::INSTANCE_SETTING_REGISTRATION_MODE;
-use kartoteka_shared::dto::requests::ValidateInviteRequest;
-use kartoteka_shared::dto::responses::{RegistrationModeResponse, ValidateInviteResponse};
+use kartoteka_shared::{
+    INSTANCE_SETTING_REGISTRATION_MODE, RegistrationModeResponse, ValidateInviteRequest,
+    ValidateInviteResponse,
+};
 use tracing::instrument;
 use worker::*;
 

--- a/crates/api/src/handlers/settings.rs
+++ b/crates/api/src/handlers/settings.rs
@@ -1,8 +1,10 @@
 use crate::helpers::require_param;
 use kartoteka_shared::*;
 use std::collections::HashMap;
+use tracing::instrument;
 use worker::*;
 
+#[instrument(skip_all)]
 pub async fn list_all(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let d1 = ctx.env.d1("DB")?;
@@ -28,6 +30,7 @@ pub async fn list_all(_req: Request, ctx: RouteContext<String>) -> Result<Respon
     Response::from_json(&map)
 }
 
+#[instrument(skip_all, fields(action = "upsert_setting"))]
 pub async fn upsert(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let key = require_param(&ctx, "key")?;
@@ -46,6 +49,7 @@ pub async fn upsert(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
     Ok(Response::empty()?.with_status(204))
 }
 
+#[instrument(skip_all, fields(action = "delete_setting"))]
 pub async fn delete(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let key = require_param(&ctx, "key")?;

--- a/crates/api/src/handlers/tags.rs
+++ b/crates/api/src/handlers/tags.rs
@@ -25,7 +25,7 @@ pub async fn create(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
     let user_id = ctx.data.clone();
     let body: CreateTagRequest = req.json().await?;
     let id = uuid::Uuid::new_v4().to_string();
-    tracing::Span::current().record("tag_id", &tracing::field::display(&id));
+    tracing::Span::current().record("tag_id", tracing::field::display(&id));
 
     let parent_val = opt_str_to_js(&body.parent_tag_id);
 
@@ -60,7 +60,7 @@ pub async fn create(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
 pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
-    tracing::Span::current().record("tag_id", &tracing::field::display(&id));
+    tracing::Span::current().record("tag_id", tracing::field::display(&id));
     let body: UpdateTagRequest = req.json().await?;
     let d1 = ctx.env.d1("DB")?;
 
@@ -133,7 +133,7 @@ pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
 pub async fn delete(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
-    tracing::Span::current().record("tag_id", &tracing::field::display(&id));
+    tracing::Span::current().record("tag_id", tracing::field::display(&id));
     let d1 = ctx.env.d1("DB")?;
     d1.prepare("DELETE FROM tags WHERE id = ?1 AND user_id = ?2")
         .bind(&[id.into(), user_id.into()])?
@@ -147,7 +147,7 @@ pub async fn delete(_req: Request, ctx: RouteContext<String>) -> Result<Response
 pub async fn merge(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let source_id = require_param(&ctx, "id")?;
-    tracing::Span::current().record("tag_id", &tracing::field::display(&source_id));
+    tracing::Span::current().record("tag_id", tracing::field::display(&source_id));
     let body: kartoteka_shared::MergeTagRequest = req.json().await?;
     let target_id = body.target_tag_id;
     let d1 = ctx.env.d1("DB")?;

--- a/crates/api/src/handlers/tags.rs
+++ b/crates/api/src/handlers/tags.rs
@@ -1,10 +1,12 @@
 use crate::error::json_error;
 use crate::helpers::*;
 use kartoteka_shared::*;
+use tracing::instrument;
 use wasm_bindgen::JsValue;
 use worker::*;
 
 /// GET /api/tags
+#[instrument(skip_all)]
 pub async fn list_all(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.as_str();
     let d1 = ctx.env.d1("DB")?;
@@ -18,10 +20,12 @@ pub async fn list_all(_req: Request, ctx: RouteContext<String>) -> Result<Respon
 }
 
 /// POST /api/tags
+#[instrument(skip_all, fields(action = "create_tag", tag_id = tracing::field::Empty))]
 pub async fn create(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let body: CreateTagRequest = req.json().await?;
     let id = uuid::Uuid::new_v4().to_string();
+    tracing::Span::current().record("tag_id", &tracing::field::display(&id));
 
     let parent_val = opt_str_to_js(&body.parent_tag_id);
 
@@ -52,9 +56,11 @@ pub async fn create(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
 }
 
 /// PUT /api/tags/:id
+#[instrument(skip_all, fields(action = "update_tag", tag_id = tracing::field::Empty))]
 pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
+    tracing::Span::current().record("tag_id", &tracing::field::display(&id));
     let body: UpdateTagRequest = req.json().await?;
     let d1 = ctx.env.d1("DB")?;
 
@@ -123,9 +129,11 @@ pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
 }
 
 /// DELETE /api/tags/:id
+#[instrument(skip_all, fields(action = "delete_tag", tag_id = tracing::field::Empty))]
 pub async fn delete(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
+    tracing::Span::current().record("tag_id", &tracing::field::display(&id));
     let d1 = ctx.env.d1("DB")?;
     d1.prepare("DELETE FROM tags WHERE id = ?1 AND user_id = ?2")
         .bind(&[id.into(), user_id.into()])?
@@ -135,9 +143,11 @@ pub async fn delete(_req: Request, ctx: RouteContext<String>) -> Result<Response
 }
 
 /// POST /api/tags/:id/merge
+#[instrument(skip_all, fields(action = "merge_tags", tag_id = tracing::field::Empty))]
 pub async fn merge(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let source_id = require_param(&ctx, "id")?;
+    tracing::Span::current().record("tag_id", &tracing::field::display(&source_id));
     let body: kartoteka_shared::MergeTagRequest = req.json().await?;
     let target_id = body.target_tag_id;
     let d1 = ctx.env.d1("DB")?;
@@ -188,6 +198,7 @@ pub async fn merge(mut req: Request, ctx: RouteContext<String>) -> Result<Respon
 }
 
 /// POST /api/items/:item_id/tags
+#[instrument(skip_all, fields(action = "assign_tag_to_item"))]
 pub async fn assign_to_item(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let item_id = require_param(&ctx, "item_id")?;
@@ -210,6 +221,7 @@ pub async fn assign_to_item(mut req: Request, ctx: RouteContext<String>) -> Resu
 }
 
 /// DELETE /api/items/:item_id/tags/:tag_id
+#[instrument(skip_all, fields(action = "remove_tag_from_item"))]
 pub async fn remove_from_item(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let item_id = require_param(&ctx, "item_id")?;
@@ -228,6 +240,7 @@ pub async fn remove_from_item(_req: Request, ctx: RouteContext<String>) -> Resul
 }
 
 /// POST /api/lists/:list_id/tags
+#[instrument(skip_all, fields(action = "assign_tag_to_list"))]
 pub async fn assign_to_list(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let list_id = require_param(&ctx, "list_id")?;
@@ -250,6 +263,7 @@ pub async fn assign_to_list(mut req: Request, ctx: RouteContext<String>) -> Resu
 }
 
 /// DELETE /api/lists/:list_id/tags/:tag_id
+#[instrument(skip_all, fields(action = "remove_tag_from_list"))]
 pub async fn remove_from_list(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let list_id = require_param(&ctx, "list_id")?;
@@ -268,6 +282,7 @@ pub async fn remove_from_list(_req: Request, ctx: RouteContext<String>) -> Resul
 }
 
 /// GET /api/tags/:id/items
+#[instrument(skip_all)]
 pub async fn tag_items(req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let tag_id = require_param(&ctx, "id")?;
@@ -326,6 +341,7 @@ pub async fn tag_items(req: Request, ctx: RouteContext<String>) -> Result<Respon
 }
 
 /// GET /api/tag-links/items
+#[instrument(skip_all)]
 pub async fn all_item_tag_links(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let d1 = ctx.env.d1("DB")?;
@@ -339,6 +355,7 @@ pub async fn all_item_tag_links(_req: Request, ctx: RouteContext<String>) -> Res
 }
 
 /// GET /api/tag-links/lists
+#[instrument(skip_all)]
 pub async fn all_list_tag_links(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let d1 = ctx.env.d1("DB")?;

--- a/crates/api/src/helpers.rs
+++ b/crates/api/src/helpers.rs
@@ -1,6 +1,63 @@
 use wasm_bindgen::JsValue;
 use worker::*;
 
+/// Ensure a user row exists in the `users` table. Creates one if absent.
+/// If `initial_admin_email` is non-empty and matches the user's email,
+/// promotes the user to admin on first creation.
+/// Returns `is_admin` flag.
+pub async fn ensure_user_exists(
+    d1: &D1Database,
+    user_id: &str,
+    email: &str,
+    initial_admin_email: &str,
+) -> Result<bool> {
+    d1.prepare(
+        "INSERT OR IGNORE INTO users (id, email, is_admin) VALUES (?1, ?2, 0)",
+    )
+    .bind(&[user_id.into(), email.into()])?
+    .run()
+    .await?;
+
+    if !initial_admin_email.is_empty() && email == initial_admin_email {
+        d1.prepare("UPDATE users SET is_admin = 1 WHERE id = ?1 AND is_admin = 0")
+            .bind(&[user_id.into()])?
+            .run()
+            .await?;
+    }
+
+    let row = d1
+        .prepare("SELECT is_admin FROM users WHERE id = ?1")
+        .bind(&[user_id.into()])?
+        .first::<serde_json::Value>(None)
+        .await?;
+
+    Ok(row
+        .and_then(|v| v.get("is_admin")?.as_f64())
+        .map(|f| f != 0.0)
+        .unwrap_or(false))
+}
+
+/// Returns a 403 Forbidden response if the user is not an admin.
+/// Call at the top of admin handlers.
+pub async fn require_admin(d1: &D1Database, user_id: &str) -> Result<Option<Response>> {
+    let row = d1
+        .prepare("SELECT is_admin FROM users WHERE id = ?1")
+        .bind(&[user_id.into()])?
+        .first::<serde_json::Value>(None)
+        .await?;
+
+    let is_admin = row
+        .and_then(|v| v.get("is_admin")?.as_f64())
+        .map(|f| f != 0.0)
+        .unwrap_or(false);
+
+    if !is_admin {
+        Ok(Some(Response::error("Forbidden", 403)?))
+    } else {
+        Ok(None)
+    }
+}
+
 /// Check if a resource belongs to the user. Returns `true` if owned.
 pub async fn check_ownership(
     d1: &D1Database,

--- a/crates/api/src/helpers.rs
+++ b/crates/api/src/helpers.rs
@@ -11,17 +11,12 @@ pub async fn ensure_user_exists(
     email: &str,
     initial_admin_email: &str,
 ) -> Result<bool> {
-    d1.prepare("INSERT OR IGNORE INTO users (id, email, is_admin) VALUES (?1, ?2, 0)")
-        .bind(&[user_id.into(), email.into()])?
+    let initial_admin = !initial_admin_email.is_empty() && email == initial_admin_email;
+    let is_admin_val: i32 = if initial_admin { 1 } else { 0 };
+    d1.prepare("INSERT OR IGNORE INTO users (id, email, is_admin) VALUES (?1, ?2, ?3)")
+        .bind(&[user_id.into(), email.into(), is_admin_val.into()])?
         .run()
         .await?;
-
-    if !initial_admin_email.is_empty() && email == initial_admin_email {
-        d1.prepare("UPDATE users SET is_admin = 1 WHERE id = ?1 AND is_admin = 0")
-            .bind(&[user_id.into()])?
-            .run()
-            .await?;
-    }
 
     let row = d1
         .prepare("SELECT is_admin FROM users WHERE id = ?1")

--- a/crates/api/src/helpers.rs
+++ b/crates/api/src/helpers.rs
@@ -11,12 +11,10 @@ pub async fn ensure_user_exists(
     email: &str,
     initial_admin_email: &str,
 ) -> Result<bool> {
-    d1.prepare(
-        "INSERT OR IGNORE INTO users (id, email, is_admin) VALUES (?1, ?2, 0)",
-    )
-    .bind(&[user_id.into(), email.into()])?
-    .run()
-    .await?;
+    d1.prepare("INSERT OR IGNORE INTO users (id, email, is_admin) VALUES (?1, ?2, 0)")
+        .bind(&[user_id.into(), email.into()])?
+        .run()
+        .await?;
 
     if !initial_admin_email.is_empty() && email == initial_admin_email {
         d1.prepare("UPDATE users SET is_admin = 1 WHERE id = ?1 AND is_admin = 0")

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -1,3 +1,4 @@
+use tracing::Instrument;
 use worker::*;
 
 mod auth;
@@ -6,7 +7,46 @@ mod handlers;
 pub(crate) mod helpers;
 mod router;
 
+#[event(start)]
+fn start() {
+    kartoteka_logging::init_cf();
+}
+
 #[event(fetch, respond_with_errors)]
 pub async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
-    router::handle(req, env).await
+    let request_id = req
+        .headers()
+        .get("X-Request-Id")
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| nanoid::nanoid!());
+
+    let user_id = req
+        .headers()
+        .get("X-User-Id")
+        .ok()
+        .flatten()
+        .unwrap_or_default();
+
+    let span = tracing::info_span!("request",
+        request_id = %request_id,
+        method = %req.method(),
+        path = %req.path(),
+        user_id = %user_id,
+    );
+
+    let response = router::handle(req, env).instrument(span.clone()).await;
+
+    match &response {
+        Ok(resp) => {
+            let _enter = span.enter();
+            tracing::info!(status = resp.status_code(), "request completed");
+        }
+        Err(e) => {
+            let _enter = span.enter();
+            tracing::error!(error = %e, "request failed");
+        }
+    }
+
+    response
 }

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -1,4 +1,3 @@
-use tracing::Instrument;
 use worker::*;
 
 mod auth;
@@ -35,15 +34,18 @@ pub async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
         user_id = %user_id,
     );
 
-    let response = router::handle(req, env).instrument(span.clone()).await;
+    let response = {
+        let _guard = span.enter();
+        router::handle(req, env).await
+    };
 
     match &response {
         Ok(resp) => {
-            let _enter = span.enter();
+            let _guard = span.enter();
             tracing::info!(status = resp.status_code(), "request completed");
         }
         Err(e) => {
-            let _enter = span.enter();
+            let _guard = span.enter();
             tracing::error!(error = %e, "request failed");
         }
     }

--- a/crates/api/src/router.rs
+++ b/crates/api/src/router.rs
@@ -13,7 +13,10 @@ pub async fn handle(req: Request, env: Env) -> Result<Response> {
     if path.starts_with("/api/public/") {
         let public_router = Router::with_data(String::new());
         return public_router
-            .get_async("/api/public/registration-mode", public::get_registration_mode)
+            .get_async(
+                "/api/public/registration-mode",
+                public::get_registration_mode,
+            )
             .post_async("/api/public/validate-invite", public::validate_invite)
             .run(req, env)
             .await;

--- a/crates/api/src/router.rs
+++ b/crates/api/src/router.rs
@@ -1,12 +1,22 @@
 use worker::*;
 
 use crate::auth;
-use crate::handlers::{containers, items, lists, preferences, settings, tags};
+use crate::handlers::{admin, containers, items, lists, me, preferences, public, settings, tags};
 
 pub async fn handle(req: Request, env: Env) -> Result<Response> {
     let path = req.path();
     if path == "/api/health" {
         return Response::ok("ok");
+    }
+
+    // Public routes — no auth required
+    if path.starts_with("/api/public/") {
+        let public_router = Router::with_data(String::new());
+        return public_router
+            .get_async("/api/public/registration-mode", public::get_registration_mode)
+            .post_async("/api/public/validate-invite", public::validate_invite)
+            .run(req, env)
+            .await;
     }
 
     let user_id = if let Some(uid) = auth::dev_bypass_user_id(&env) {
@@ -17,6 +27,8 @@ pub async fn handle(req: Request, env: Env) -> Result<Response> {
 
     let router = Router::with_data(user_id);
     router
+        // Me
+        .get_async("/api/me", me::get_me)
         // Home
         .get_async("/api/home", containers::home)
         // Containers
@@ -79,6 +91,13 @@ pub async fn handle(req: Request, env: Env) -> Result<Response> {
         // Tag link queries
         .get_async("/api/tag-links/items", tags::all_item_tag_links)
         .get_async("/api/tag-links/lists", tags::all_list_tag_links)
+        // Admin — instance settings
+        .get_async("/api/admin/instance-settings", admin::list_settings)
+        .put_async("/api/admin/instance-settings/:key", admin::update_setting)
+        // Admin — invitation codes
+        .get_async("/api/admin/invitation-codes", admin::list_codes)
+        .post_async("/api/admin/invitation-codes", admin::create_code)
+        .delete_async("/api/admin/invitation-codes/:id", admin::delete_code)
         .run(req, env)
         .await
 }

--- a/crates/api/wrangler.toml
+++ b/crates/api/wrangler.toml
@@ -36,3 +36,6 @@ binding = "DB"
 database_name = "kartoteka-dev"
 database_id = "94ab37c2-8a21-40ad-a878-fd546d741e92"
 migrations_dir = "./migrations"
+
+[observability]
+enabled = true

--- a/crates/api/wrangler.toml
+++ b/crates/api/wrangler.toml
@@ -19,6 +19,10 @@ name = "kartoteka-api-local"
 
 [env.local.vars]
 DEV_AUTH_USER_ID = "dev-user-00000000-0000-0000-0000-000000000001"
+# Auto-promotes the first user with this email to admin on /api/me.
+# In local dev the gateway sets X-User-Email = "dev@local" for the bypass user,
+# so the dev user becomes admin automatically.
+INITIAL_ADMIN_EMAIL = "dev@local"
 
 [[env.local.d1_databases]]
 binding = "DB"
@@ -39,3 +43,7 @@ migrations_dir = "./migrations"
 
 [observability]
 enabled = true
+
+# Optional secrets — configure via `wrangler secret put`:
+#   INITIAL_ADMIN_EMAIL   First user with this email gets auto-promoted to admin on /api/me.
+#                         Set once after deploy, then remove or leave for re-promotion on re-signup.

--- a/crates/frontend/Cargo.toml
+++ b/crates/frontend/Cargo.toml
@@ -28,5 +28,10 @@ js-sys = "0.3"
 name = "kartoteka-frontend"
 test = false
 
+[package.metadata.cargo-machete]
+# kartoteka-i18n: pulled in by leptos-fluent macro; leptos_meta: used in components via view! macro;
+# wasm-bindgen: required as a transitive dep for WASM target — not directly imported
+ignored = ["kartoteka-i18n", "leptos_meta", "wasm-bindgen"]
+
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/frontend/src/api/admin.rs
+++ b/crates/frontend/src/api/admin.rs
@@ -1,9 +1,13 @@
+// All functions in this module are called from #[cfg(target_arch = "wasm32")] blocks.
+// Suppress dead_code warnings on non-wasm targets (e.g. CI native clippy).
+#![cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
+
 use kartoteka_shared::{
     CreateInvitationCodeRequest, InvitationCode, MeResponse, RegistrationModeResponse,
     UpsertSettingRequest, UserSetting, ValidateInviteResponse,
 };
 
-use super::{api_delete, api_get, api_post, api_put, ApiError, HttpClient, API_BASE};
+use super::{API_BASE, ApiError, HttpClient, api_delete, api_get, api_post, api_put};
 
 /// GET /api/me — creates user row if needed, returns admin flag.
 /// Pass `invite_code` to finalize invite code after signup.
@@ -19,7 +23,9 @@ pub async fn get_me(
 }
 
 /// GET /api/public/registration-mode — no auth, usable before login.
-pub async fn get_registration_mode(client: &impl HttpClient) -> Result<RegistrationModeResponse, ApiError> {
+pub async fn get_registration_mode(
+    client: &impl HttpClient,
+) -> Result<RegistrationModeResponse, ApiError> {
     api_get(client, &format!("{API_BASE}/public/registration-mode")).await
 }
 
@@ -78,9 +84,6 @@ pub async fn create_invitation_code(
     .await
 }
 
-pub async fn delete_invitation_code(
-    client: &impl HttpClient,
-    id: &str,
-) -> Result<(), ApiError> {
+pub async fn delete_invitation_code(client: &impl HttpClient, id: &str) -> Result<(), ApiError> {
     api_delete(client, &format!("{API_BASE}/admin/invitation-codes/{id}")).await
 }

--- a/crates/frontend/src/api/admin.rs
+++ b/crates/frontend/src/api/admin.rs
@@ -1,0 +1,86 @@
+use kartoteka_shared::{
+    CreateInvitationCodeRequest, InvitationCode, MeResponse, RegistrationModeResponse,
+    UpsertSettingRequest, UserSetting, ValidateInviteResponse,
+};
+
+use super::{api_delete, api_get, api_post, api_put, ApiError, HttpClient, API_BASE};
+
+/// GET /api/me — creates user row if needed, returns admin flag.
+/// Pass `invite_code` to finalize invite code after signup.
+pub async fn get_me(
+    client: &impl HttpClient,
+    invite_code: Option<&str>,
+) -> Result<MeResponse, ApiError> {
+    let url = match invite_code {
+        Some(code) => format!("{API_BASE}/me?invite_code={code}"),
+        None => format!("{API_BASE}/me"),
+    };
+    api_get(client, &url).await
+}
+
+/// GET /api/public/registration-mode — no auth, usable before login.
+pub async fn get_registration_mode(client: &impl HttpClient) -> Result<RegistrationModeResponse, ApiError> {
+    api_get(client, &format!("{API_BASE}/public/registration-mode")).await
+}
+
+/// POST /api/public/validate-invite — validates an invite code (and reserves it).
+pub async fn validate_invite(
+    client: &impl HttpClient,
+    code: &str,
+    email: &str,
+) -> Result<ValidateInviteResponse, ApiError> {
+    api_post(
+        client,
+        &format!("{API_BASE}/public/validate-invite"),
+        &serde_json::json!({ "code": code, "email": email }),
+    )
+    .await
+}
+
+// ── Admin: Instance Settings ───────────────────────────────────────────────
+
+pub async fn list_instance_settings(
+    client: &impl HttpClient,
+) -> Result<Vec<UserSetting>, ApiError> {
+    api_get(client, &format!("{API_BASE}/admin/instance-settings")).await
+}
+
+pub async fn update_instance_setting(
+    client: &impl HttpClient,
+    key: &str,
+    value: serde_json::Value,
+) -> Result<UserSetting, ApiError> {
+    api_put(
+        client,
+        &format!("{API_BASE}/admin/instance-settings/{key}"),
+        &UpsertSettingRequest { value },
+    )
+    .await
+}
+
+// ── Admin: Invitation Codes ────────────────────────────────────────────────
+
+pub async fn list_invitation_codes(
+    client: &impl HttpClient,
+) -> Result<Vec<InvitationCode>, ApiError> {
+    api_get(client, &format!("{API_BASE}/admin/invitation-codes")).await
+}
+
+pub async fn create_invitation_code(
+    client: &impl HttpClient,
+    expires_at: Option<String>,
+) -> Result<InvitationCode, ApiError> {
+    api_post(
+        client,
+        &format!("{API_BASE}/admin/invitation-codes"),
+        &CreateInvitationCodeRequest { expires_at },
+    )
+    .await
+}
+
+pub async fn delete_invitation_code(
+    client: &impl HttpClient,
+    id: &str,
+) -> Result<(), ApiError> {
+    api_delete(client, &format!("{API_BASE}/admin/invitation-codes/{id}")).await
+}

--- a/crates/frontend/src/api/mod.rs
+++ b/crates/frontend/src/api/mod.rs
@@ -1,3 +1,4 @@
+pub mod admin;
 pub mod client;
 mod containers;
 mod items;

--- a/crates/frontend/src/app.rs
+++ b/crates/frontend/src/app.rs
@@ -10,11 +10,13 @@ use crate::components::nav::Nav;
 use crate::components::sync_locale::SyncLocale;
 use crate::components::toast_container::ToastContainer;
 use crate::pages::{
-    calendar::CalendarPage, calendar::day::CalendarDayPage, container::ContainerPage,
-    home::HomePage, item_detail::ItemDetailPage, list::ListPage, login::LoginPage,
-    oauth_consent::OAuthConsentPage, settings::McpRedirect, settings::SettingsPage,
-    signup::SignupPage, tags::TagsPage, tags::detail::TagDetailPage, today::TodayPage,
+    admin::AdminPage, calendar::CalendarPage, calendar::day::CalendarDayPage,
+    container::ContainerPage, home::HomePage, item_detail::ItemDetailPage, list::ListPage,
+    login::LoginPage, oauth_consent::OAuthConsentPage, settings::McpRedirect,
+    settings::SettingsPage, signup::SignupPage, tags::TagsPage, tags::detail::TagDetailPage,
+    today::TodayPage,
 };
+use crate::state::AdminContext;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum ToastKind {
@@ -86,8 +88,25 @@ pub fn App() -> impl IntoView {
     let toast_ctx = ToastContext::new();
     provide_context(toast_ctx);
 
+    let admin_ctx = AdminContext::new();
+    provide_context(admin_ctx);
+
     #[cfg(target_arch = "wasm32")]
     provide_context(GlooClient);
+
+    // Fetch /api/me after session check to populate is_admin signal
+    #[cfg(target_arch = "wasm32")]
+    {
+        let client = GlooClient;
+        leptos::task::spawn_local(async move {
+            if let Some(session) = crate::api::get_session().await {
+                let _ = session; // session is valid
+                if let Ok(me) = crate::api::admin::get_me(&client, None).await {
+                    admin_ctx.is_admin.set(me.is_admin);
+                }
+            }
+        });
+    }
 
     view! {
         <I18nProvider>
@@ -111,6 +130,7 @@ pub fn App() -> impl IntoView {
                         <Route path=path!("/lists/:list_id/items/:id") view=ItemDetailPage/>
                         <Route path=path!("/lists/:id") view=ListPage/>
                         <Route path=path!("/containers/:id") view=ContainerPage/>
+                        <Route path=path!("/admin") view=AdminPage/>
                     </Routes>
                 </main>
             </Router>

--- a/crates/frontend/src/components/nav.rs
+++ b/crates/frontend/src/components/nav.rs
@@ -2,10 +2,12 @@ use leptos::prelude::*;
 use leptos_fluent::move_tr;
 
 use crate::api;
+use crate::state::AdminContext;
 
 #[component]
 pub fn Nav() -> impl IntoView {
     let (menu_open, set_menu_open) = signal(false);
+    let admin_ctx = use_context::<AdminContext>();
 
     let session_res = LocalResource::new(api::get_session);
 
@@ -42,6 +44,11 @@ pub fn Nav() -> impl IntoView {
                                                 class="menu bg-base-200 rounded-box border border-base-300 shadow-lg z-50 min-w-40 absolute right-0 top-full mt-1"
                                                 style:display=move || if menu_open.get() { "block" } else { "none" }
                                             >
+                                                {move || admin_ctx.map(|ctx| {
+                                                    ctx.is_admin.get().then(|| view! {
+                                                        <li><a href="/admin">{move_tr!("nav-admin")}</a></li>
+                                                    })
+                                                })}
                                                 <li><a href="/tags">{move_tr!("nav-tags")}</a></li>
                                                 <li><a href="/settings">{move_tr!("nav-settings")}</a></li>
                                                 <li><button type="button" on:click=on_logout>{move_tr!("nav-logout")}</button></li>

--- a/crates/frontend/src/lib.rs
+++ b/crates/frontend/src/lib.rs
@@ -2,3 +2,5 @@
 /// The full application runs from main.rs (binary target).
 pub mod api;
 pub mod state;
+
+pub use state::AdminContext;

--- a/crates/frontend/src/pages/admin/mod.rs
+++ b/crates/frontend/src/pages/admin/mod.rs
@@ -37,20 +37,23 @@ fn InstanceSettingsSection() -> impl IntoView {
     let saving = RwSignal::new(false);
 
     #[cfg(target_arch = "wasm32")]
-    {
-        let client = GlooClient;
-        leptos::task::spawn_local(async move {
-            if let Ok(settings) = crate::api::admin::list_instance_settings(&client).await {
-                for s in settings {
-                    if s.key == kartoteka_shared::INSTANCE_SETTING_REGISTRATION_MODE {
-                        if let Some(m) = s.value.as_str() {
-                            reg_mode.set(m.to_string());
+    let _settings_res = {
+        let client = use_context::<GlooClient>().expect("GlooClient not provided");
+        LocalResource::new(move || {
+            let client = client.clone();
+            async move {
+                if let Ok(settings) = crate::api::admin::list_instance_settings(&client).await {
+                    for s in settings {
+                        if s.key == kartoteka_shared::INSTANCE_SETTING_REGISTRATION_MODE {
+                            if let Some(m) = s.value.as_str() {
+                                reg_mode.set(m.to_string());
+                            }
                         }
                     }
                 }
             }
-        });
-    }
+        })
+    };
 
     let on_save = move |_| {
         saving.set(true);
@@ -59,7 +62,7 @@ fn InstanceSettingsSection() -> impl IntoView {
         leptos::task::spawn_local(async move {
             #[cfg(target_arch = "wasm32")]
             {
-                let client = GlooClient;
+                let client = use_context::<GlooClient>().expect("GlooClient not provided");
                 let _ = crate::api::admin::update_instance_setting(
                     &client,
                     kartoteka_shared::INSTANCE_SETTING_REGISTRATION_MODE,
@@ -109,21 +112,24 @@ fn InvitationCodesSection() -> impl IntoView {
     let generating = RwSignal::new(false);
 
     #[cfg(target_arch = "wasm32")]
-    {
-        let client = GlooClient;
-        leptos::task::spawn_local(async move {
-            if let Ok(list) = crate::api::admin::list_invitation_codes(&client).await {
-                codes.set(list);
+    let _codes_res = {
+        let client = use_context::<GlooClient>().expect("GlooClient not provided");
+        LocalResource::new(move || {
+            let client = client.clone();
+            async move {
+                if let Ok(list) = crate::api::admin::list_invitation_codes(&client).await {
+                    codes.set(list);
+                }
             }
-        });
-    }
+        })
+    };
 
     let on_generate = move |_| {
         generating.set(true);
         leptos::task::spawn_local(async move {
             #[cfg(target_arch = "wasm32")]
             {
-                let client = GlooClient;
+                let client = use_context::<GlooClient>().expect("GlooClient not provided");
                 match crate::api::admin::create_invitation_code(&client, None).await {
                     Ok(new_code) => codes.update(|list| list.insert(0, new_code)),
                     Err(_) => {}
@@ -167,7 +173,7 @@ fn InvitationCodesSection() -> impl IntoView {
                                     leptos::task::spawn_local(async move {
                                         #[cfg(target_arch = "wasm32")]
                                         {
-                                            let client = GlooClient;
+                                            let client = use_context::<GlooClient>().expect("GlooClient not provided");
                                             if crate::api::admin::delete_invitation_code(&client, &id).await.is_ok() {
                                                 codes.update(|list| list.retain(|item| item.id != id));
                                             }

--- a/crates/frontend/src/pages/admin/mod.rs
+++ b/crates/frontend/src/pages/admin/mod.rs
@@ -1,0 +1,203 @@
+use leptos::prelude::*;
+use leptos_fluent::move_tr;
+use leptos_router::hooks::use_navigate;
+
+#[cfg(target_arch = "wasm32")]
+use crate::api::client::GlooClient;
+use crate::state::AdminContext;
+
+#[component]
+pub fn AdminPage() -> impl IntoView {
+    let navigate = use_navigate();
+    let admin_ctx = use_context::<AdminContext>();
+
+    // Guard: redirect non-admins
+    Effect::new(move |_| {
+        if let Some(ctx) = admin_ctx {
+            if !ctx.is_admin.get() {
+                navigate("/", Default::default());
+            }
+        }
+    });
+
+    view! {
+        <div class="p-6 max-w-2xl mx-auto space-y-8">
+            <h1 class="text-3xl font-bold">{move_tr!("admin-panel")}</h1>
+            <InstanceSettingsSection/>
+            <InvitationCodesSection/>
+        </div>
+    }
+}
+
+// ── Instance Settings section ──────────────────────────────────────────────
+
+#[component]
+fn InstanceSettingsSection() -> impl IntoView {
+    let reg_mode = RwSignal::new("open".to_string());
+    let saving = RwSignal::new(false);
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        let client = GlooClient;
+        leptos::task::spawn_local(async move {
+            if let Ok(settings) = crate::api::admin::list_instance_settings(&client).await {
+                for s in settings {
+                    if s.key == kartoteka_shared::INSTANCE_SETTING_REGISTRATION_MODE {
+                        if let Some(m) = s.value.as_str() {
+                            reg_mode.set(m.to_string());
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    let on_save = move |_| {
+        saving.set(true);
+        #[cfg(target_arch = "wasm32")]
+        let mode = reg_mode.get_untracked();
+        leptos::task::spawn_local(async move {
+            #[cfg(target_arch = "wasm32")]
+            {
+                let client = GlooClient;
+                let _ = crate::api::admin::update_instance_setting(
+                    &client,
+                    kartoteka_shared::INSTANCE_SETTING_REGISTRATION_MODE,
+                    serde_json::Value::String(mode),
+                )
+                .await;
+            }
+            saving.set(false);
+        });
+    };
+
+    view! {
+        <section class="card bg-base-200 border border-base-300">
+            <div class="card-body">
+                <h2 class="card-title">{move_tr!("instance-settings")}</h2>
+                <div class="form-control">
+                    <label class="label"><span class="label-text">{move_tr!("registration-mode")}</span></label>
+                    <select
+                        class="select select-bordered w-full max-w-xs"
+                        on:change=move |ev| reg_mode.set(event_target_value(&ev))
+                        prop:value=move || reg_mode.get()
+                    >
+                        <option value="open">{move_tr!("registration-open")}</option>
+                        <option value="invite">{move_tr!("registration-invite")}</option>
+                        <option value="closed">{move_tr!("registration-closed")}</option>
+                    </select>
+                </div>
+                <div class="card-actions justify-end mt-4">
+                    <button
+                        class="btn btn-primary"
+                        disabled=move || saving.get()
+                        on:click=on_save
+                    >
+                        {move_tr!("common-save")}
+                    </button>
+                </div>
+            </div>
+        </section>
+    }
+}
+
+// ── Invitation Codes section ───────────────────────────────────────────────
+
+#[component]
+fn InvitationCodesSection() -> impl IntoView {
+    let codes = RwSignal::new(Vec::<kartoteka_shared::InvitationCode>::new());
+    let generating = RwSignal::new(false);
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        let client = GlooClient;
+        leptos::task::spawn_local(async move {
+            if let Ok(list) = crate::api::admin::list_invitation_codes(&client).await {
+                codes.set(list);
+            }
+        });
+    }
+
+    let on_generate = move |_| {
+        generating.set(true);
+        leptos::task::spawn_local(async move {
+            #[cfg(target_arch = "wasm32")]
+            {
+                let client = GlooClient;
+                match crate::api::admin::create_invitation_code(&client, None).await {
+                    Ok(new_code) => codes.update(|list| list.insert(0, new_code)),
+                    Err(_) => {}
+                }
+            }
+            generating.set(false);
+        });
+    };
+
+    view! {
+        <section class="card bg-base-200 border border-base-300">
+            <div class="card-body">
+                <div class="flex justify-between items-center">
+                    <h2 class="card-title">{move_tr!("invitation-codes")}</h2>
+                    <button
+                        class="btn btn-primary btn-sm"
+                        disabled=move || generating.get()
+                        on:click=on_generate
+                    >
+                        {move_tr!("generate-code")}
+                    </button>
+                </div>
+                <div class="overflow-x-auto mt-4">
+                    <table class="table table-sm">
+                        <thead>
+                            <tr>
+                                <th>{move_tr!("invite-code")}</th>
+                                <th>{move_tr!("common-status")}</th>
+                                <th>{move_tr!("common-created")}</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {move || codes.get().into_iter().map(|c| {
+                                let id_del = c.id.clone();
+                                let dimmed = c.used_by.is_some();
+                                // Inline delete callback — Fn-compatible (codes is Copy RwSignal)
+                                let delete_this = move |_: web_sys::MouseEvent| {
+                                    let id = id_del.clone();
+                                    leptos::task::spawn_local(async move {
+                                        #[cfg(target_arch = "wasm32")]
+                                        {
+                                            let client = GlooClient;
+                                            if crate::api::admin::delete_invitation_code(&client, &id).await.is_ok() {
+                                                codes.update(|list| list.retain(|item| item.id != id));
+                                            }
+                                        }
+                                    });
+                                };
+                                let delete_btn = if !dimmed {
+                                    view! {
+                                        <button
+                                            class="btn btn-ghost btn-xs text-error"
+                                            on:click=delete_this
+                                        >
+                                            "✕"
+                                        </button>
+                                    }.into_any()
+                                } else {
+                                    view! { <span></span> }.into_any()
+                                };
+                                view! {
+                                    <tr class=if dimmed { "opacity-50" } else { "" }>
+                                        <td><code class="font-mono">{c.code.clone()}</code></td>
+                                        <td>{if dimmed { move_tr!("code-used").get() } else { move_tr!("code-active").get() }}</td>
+                                        <td class="text-xs">{c.created_at.clone()}</td>
+                                        <td>{delete_btn}</td>
+                                    </tr>
+                                }
+                            }).collect_view()}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </section>
+    }
+}

--- a/crates/frontend/src/pages/admin/mod.rs
+++ b/crates/frontend/src/pages/admin/mod.rs
@@ -162,6 +162,7 @@ fn InvitationCodesSection() -> impl IntoView {
                                 let dimmed = c.used_by.is_some();
                                 // Inline delete callback — Fn-compatible (codes is Copy RwSignal)
                                 let delete_this = move |_: web_sys::MouseEvent| {
+                                    #[allow(unused_variables)]
                                     let id = id_del.clone();
                                     leptos::task::spawn_local(async move {
                                         #[cfg(target_arch = "wasm32")]

--- a/crates/frontend/src/pages/mod.rs
+++ b/crates/frontend/src/pages/mod.rs
@@ -1,3 +1,4 @@
+pub mod admin;
 pub mod calendar;
 pub mod container;
 pub mod home;

--- a/crates/frontend/src/pages/signup.rs
+++ b/crates/frontend/src/pages/signup.rs
@@ -71,7 +71,9 @@ pub fn SignupPage() -> impl IntoView {
                         }
                         Err(_) => {
                             loading.set(false);
-                            error.set(Some(move_tr!("error-network").get()));
+                            error.set(Some(
+                                move_tr!("error-network", { "detail" => "connection error" }).get(),
+                            ));
                             return;
                         }
                         _ => {}

--- a/crates/frontend/src/pages/signup.rs
+++ b/crates/frontend/src/pages/signup.rs
@@ -38,6 +38,7 @@ pub fn SignupPage() -> impl IntoView {
 
         // Read cached mode synchronously before spawning to avoid an extra network round-trip.
         // The Gateway always validates independently, so stale-by-submit-time is safe.
+        #[allow(unused_variables)]
         let current_mode = reg_mode
             .get_untracked()
             .unwrap_or_else(|| "open".to_string());

--- a/crates/frontend/src/pages/signup.rs
+++ b/crates/frontend/src/pages/signup.rs
@@ -1,13 +1,35 @@
 use leptos::prelude::*;
 use leptos_fluent::move_tr;
 
+#[cfg(target_arch = "wasm32")]
+use crate::api::client::GlooClient;
+
 #[component]
 pub fn SignupPage() -> impl IntoView {
     let name = RwSignal::new(String::new());
     let email = RwSignal::new(String::new());
     let password = RwSignal::new(String::new());
+    let invite_code = RwSignal::new(String::new());
     let error = RwSignal::new(Option::<String>::None);
     let loading = RwSignal::new(false);
+
+    // Fetch registration mode on mount
+    #[cfg(target_arch = "wasm32")]
+    let reg_mode = {
+        let client = GlooClient;
+        LocalResource::new(move || {
+            let client = client.clone();
+            async move {
+                crate::api::admin::get_registration_mode(&client)
+                    .await
+                    .map(|r| r.mode)
+                    .unwrap_or_else(|_| "open".to_string())
+            }
+        })
+    };
+
+    #[cfg(not(target_arch = "wasm32"))]
+    let reg_mode = LocalResource::new(|| async { "open".to_string() });
 
     let on_submit = move |ev: web_sys::SubmitEvent| {
         ev.prevent_default();
@@ -15,11 +37,55 @@ pub fn SignupPage() -> impl IntoView {
         error.set(None);
 
         leptos::task::spawn_local(async move {
-            let body = serde_json::json!({
+            let current_email = email.get_untracked();
+            let code = invite_code.get_untracked();
+
+            // Validate invite code inline if mode is invite
+            // (Gateway will also validate, but this gives instant feedback)
+            #[cfg(target_arch = "wasm32")]
+            {
+                let client = GlooClient;
+                let mode = crate::api::admin::get_registration_mode(&client)
+                    .await
+                    .map(|r| r.mode)
+                    .unwrap_or_else(|_| "open".to_string());
+
+                if mode == "closed" {
+                    loading.set(false);
+                    error.set(Some(move_tr!("registration-closed-message").get()));
+                    return;
+                }
+
+                if mode == "invite" && !code.is_empty() {
+                    match crate::api::admin::validate_invite(&client, &code, &current_email).await {
+                        Ok(res) if !res.valid => {
+                            loading.set(false);
+                            let key = match res.error.as_deref() {
+                                Some("code_in_use") => move_tr!("invite-code-in-use").get(),
+                                _ => move_tr!("invite-code-invalid").get(),
+                            };
+                            error.set(Some(key));
+                            return;
+                        }
+                        Err(_) => {
+                            loading.set(false);
+                            error.set(Some(move_tr!("error-network").get()));
+                            return;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+
+            let mut body = serde_json::json!({
                 "name": name.get_untracked(),
-                "email": email.get_untracked(),
+                "email": current_email,
                 "password": password.get_untracked(),
             });
+            if !code.is_empty() {
+                body["inviteCode"] = serde_json::Value::String(code.clone());
+            }
+
             let url = format!("{}/auth/api/sign-up/email", crate::api::auth_base());
             let json = match serde_json::to_string(&body) {
                 Ok(s) => s,
@@ -29,33 +95,61 @@ pub fn SignupPage() -> impl IntoView {
                     return;
                 }
             };
-            let request = match gloo_net::http::Request::post(&url)
-                .header("Content-Type", "application/json")
-                .credentials(web_sys::RequestCredentials::Include)
-                .body(json)
-            {
-                Ok(r) => r,
-                Err(e) => {
-                    loading.set(false);
-                    error.set(Some(format!("Błąd: {e}")));
-                    return;
-                }
-            };
-            let result = request.send().await;
 
-            loading.set(false);
-            match result {
-                Ok(resp) if resp.ok() => {
-                    if let Some(window) = web_sys::window() {
-                        let _ = window.location().set_href("/");
+            #[cfg(target_arch = "wasm32")]
+            {
+                let request = match gloo_net::http::Request::post(&url)
+                    .header("Content-Type", "application/json")
+                    .credentials(web_sys::RequestCredentials::Include)
+                    .body(json)
+                {
+                    Ok(r) => r,
+                    Err(e) => {
+                        loading.set(false);
+                        error.set(Some(format!("Błąd: {e}")));
+                        return;
+                    }
+                };
+
+                loading.set(false);
+                match request.send().await {
+                    Ok(resp) if resp.ok() => {
+                        // Finalize invite code via /api/me after successful signup
+                        if !code.is_empty() {
+                            let client = GlooClient;
+                            let _ = crate::api::admin::get_me(&client, Some(&code)).await;
+                        } else {
+                            let client = GlooClient;
+                            let _ = crate::api::admin::get_me(&client, None).await;
+                        }
+                        if let Some(window) = web_sys::window() {
+                            let _ = window.location().set_href("/");
+                        }
+                    }
+                    Ok(resp) => {
+                        let status = resp.status();
+                        let msg = resp
+                            .text()
+                            .await
+                            .ok()
+                            .and_then(|t| {
+                                serde_json::from_str::<serde_json::Value>(&t)
+                                    .ok()
+                                    .and_then(|v| v.get("error")?.as_str().map(String::from))
+                            })
+                            .unwrap_or_else(|| format!("Błąd rejestracji ({status})"));
+                        error.set(Some(msg));
+                    }
+                    Err(e) => {
+                        error.set(Some(format!("Błąd sieci: {e}")));
                     }
                 }
-                Ok(resp) => {
-                    error.set(Some(format!("Błąd rejestracji ({})", resp.status())));
-                }
-                Err(e) => {
-                    error.set(Some(format!("Błąd sieci: {e}")));
-                }
+            }
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                let _ = json;
+                let _ = url;
+                loading.set(false);
             }
         });
     };
@@ -66,55 +160,91 @@ pub fn SignupPage() -> impl IntoView {
                 <div class="card-body items-center">
                     <h2 class="card-title text-2xl mb-4">{move_tr!("auth-signup-title")}</h2>
 
+                    // Show "registration closed" message if mode is closed
+                    <Suspense>
+                        {move || reg_mode.get().map(|mode| {
+                            if mode.as_str() == "closed" {
+                                view! {
+                                    <div class="alert alert-warning mb-4">
+                                        <span>{move_tr!("registration-closed-message")}</span>
+                                    </div>
+                                }.into_any()
+                            } else {
+                                view! { <span></span> }.into_any()
+                            }
+                        })}
+                    </Suspense>
+
                     {move || error.get().map(|e| view! {
                         <div class="alert alert-error mb-4">
                             <span>{e}</span>
                         </div>
                     })}
 
-                    <form on:submit=on_submit class="w-full space-y-4">
-                        <label class="input input-bordered flex items-center gap-2 w-full">
-                            <input
-                                type="text"
-                                placeholder=move_tr!("auth-name-placeholder")
-                                class="grow"
-                                required=true
-                                on:input=move |ev| name.set(event_target_value(&ev))
-                            />
-                        </label>
-                        <label class="input input-bordered flex items-center gap-2 w-full">
-                            <input
-                                type="email"
-                                placeholder=move_tr!("auth-email-placeholder")
-                                class="grow"
-                                required=true
-                                on:input=move |ev| email.set(event_target_value(&ev))
-                            />
-                        </label>
-                        <label class="input input-bordered flex items-center gap-2 w-full">
-                            <input
-                                type="password"
-                                placeholder=move_tr!("auth-password-placeholder")
-                                class="grow"
-                                required=true
-                                on:input=move |ev| password.set(event_target_value(&ev))
-                            />
-                        </label>
-                        <button
-                            type="submit"
-                            class="btn btn-primary w-full"
-                            disabled=move || loading.get()
-                        >
-                            {move || if loading.get() {
-                                move_tr!("auth-signup-loading").get()
-                            } else {
-                                move_tr!("auth-signup-button").get()
-                            }}
-                        </button>
-                    </form>
+                    // Hide form when closed
+                    <Show when=move || {
+                        reg_mode.get().map(|m| m.as_str() != "closed").unwrap_or(true)
+                    }>
+                        <form on:submit=on_submit class="w-full space-y-4">
+                            <label class="input input-bordered flex items-center gap-2 w-full">
+                                <input
+                                    type="text"
+                                    placeholder=move_tr!("auth-name-placeholder")
+                                    class="grow"
+                                    required=true
+                                    on:input=move |ev| name.set(event_target_value(&ev))
+                                />
+                            </label>
+                            <label class="input input-bordered flex items-center gap-2 w-full">
+                                <input
+                                    type="email"
+                                    placeholder=move_tr!("auth-email-placeholder")
+                                    class="grow"
+                                    required=true
+                                    on:input=move |ev| email.set(event_target_value(&ev))
+                                />
+                            </label>
+                            <label class="input input-bordered flex items-center gap-2 w-full">
+                                <input
+                                    type="password"
+                                    placeholder=move_tr!("auth-password-placeholder")
+                                    class="grow"
+                                    required=true
+                                    on:input=move |ev| password.set(event_target_value(&ev))
+                                />
+                            </label>
 
-                    <div class="divider">{move_tr!("common-or")}</div>
-                    <a href="/login" class="link link-primary">{move_tr!("auth-signup-have-account")}</a>
+                            // Show invite code field when mode is "invite"
+                            <Show when=move || {
+                                reg_mode.get().map(|m| m.as_str() == "invite").unwrap_or(false)
+                            }>
+                                <label class="input input-bordered flex items-center gap-2 w-full">
+                                    <input
+                                        type="text"
+                                        placeholder=move_tr!("invite-code")
+                                        class="grow"
+                                        required=true
+                                        on:input=move |ev| invite_code.set(event_target_value(&ev))
+                                    />
+                                </label>
+                            </Show>
+
+                            <button
+                                type="submit"
+                                class="btn btn-primary w-full"
+                                disabled=move || loading.get()
+                            >
+                                {move || if loading.get() {
+                                    move_tr!("auth-signup-loading").get()
+                                } else {
+                                    move_tr!("auth-signup-button").get()
+                                }}
+                            </button>
+                        </form>
+
+                        <div class="divider">{move_tr!("common-or")}</div>
+                        <a href="/login" class="link link-primary">{move_tr!("auth-signup-have-account")}</a>
+                    </Show>
                 </div>
             </div>
         </div>

--- a/crates/frontend/src/pages/signup.rs
+++ b/crates/frontend/src/pages/signup.rs
@@ -36,6 +36,12 @@ pub fn SignupPage() -> impl IntoView {
         loading.set(true);
         error.set(None);
 
+        // Read cached mode synchronously before spawning to avoid an extra network round-trip.
+        // The Gateway always validates independently, so stale-by-submit-time is safe.
+        let current_mode = reg_mode
+            .get_untracked()
+            .unwrap_or_else(|| "open".to_string());
+
         leptos::task::spawn_local(async move {
             let current_email = email.get_untracked();
             let code = invite_code.get_untracked();
@@ -45,18 +51,14 @@ pub fn SignupPage() -> impl IntoView {
             #[cfg(target_arch = "wasm32")]
             {
                 let client = GlooClient;
-                let mode = crate::api::admin::get_registration_mode(&client)
-                    .await
-                    .map(|r| r.mode)
-                    .unwrap_or_else(|_| "open".to_string());
 
-                if mode == "closed" {
+                if current_mode == "closed" {
                     loading.set(false);
                     error.set(Some(move_tr!("registration-closed-message").get()));
                     return;
                 }
 
-                if mode == "invite" && !code.is_empty() {
+                if current_mode == "invite" && !code.is_empty() {
                     match crate::api::admin::validate_invite(&client, &code, &current_email).await {
                         Ok(res) if !res.valid => {
                             loading.set(false);

--- a/crates/frontend/src/state/admin.rs
+++ b/crates/frontend/src/state/admin.rs
@@ -1,0 +1,21 @@
+use leptos::prelude::*;
+
+/// App-wide admin state. Provided at app root, updated after session check.
+#[derive(Clone, Copy)]
+pub struct AdminContext {
+    pub is_admin: RwSignal<bool>,
+}
+
+impl AdminContext {
+    pub fn new() -> Self {
+        Self {
+            is_admin: RwSignal::new(false),
+        }
+    }
+}
+
+impl Default for AdminContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/frontend/src/state/mod.rs
+++ b/crates/frontend/src/state/mod.rs
@@ -1,1 +1,4 @@
+pub mod admin;
 pub mod transforms;
+
+pub use admin::AdminContext;

--- a/crates/logging/Cargo.toml
+++ b/crates/logging/Cargo.toml
@@ -17,7 +17,6 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter", "time"] }
 worker = { version = "0.7", default-features = false }
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
 
 # CF-only
 tracing-web = { version = "0.1", optional = true }

--- a/crates/logging/Cargo.toml
+++ b/crates/logging/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "kartoteka-logging"
+version.workspace = true
+edition.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[features]
+default = ["cf"]
+cf = ["tracing-web", "dep:time"]
+axum = ["tracing-subscriber/ansi"]
+
+[dependencies]
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["json", "env-filter", "time"] }
+worker = { version = "0.7", default-features = false }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+# CF-only
+tracing-web = { version = "0.1", optional = true }
+time = { version = "0.3", features = ["wasm-bindgen"], optional = true }

--- a/crates/logging/Cargo.toml
+++ b/crates/logging/Cargo.toml
@@ -21,3 +21,7 @@ serde = { version = "1", features = ["derive"] }
 # CF-only
 tracing-web = { version = "0.1", optional = true }
 time = { version = "0.3", features = ["wasm-bindgen"], optional = true }
+
+[package.metadata.cargo-machete]
+# time: used via UtcTime in #[cfg(feature = "cf")] — machete doesn't see conditional usage
+ignored = ["time"]

--- a/crates/logging/src/error.rs
+++ b/crates/logging/src/error.rs
@@ -66,6 +66,19 @@ struct ErrorBody {
     status: u16,
 }
 
+fn log_and_build_error_response(e: &ApiError) -> worker::Result<Response> {
+    match e.log_level() {
+        tracing::Level::ERROR => tracing::error!(error = %e, "failed"),
+        tracing::Level::WARN => tracing::warn!(error = %e, "failed"),
+        _ => tracing::debug!(error = %e, "failed"),
+    }
+    let body = ErrorBody {
+        code: e.code().to_string(),
+        status: e.status_code(),
+    };
+    Response::from_json(&body).map(|r| r.with_status(e.status_code()))
+}
+
 /// Convert `ApiResult<T>` to `worker::Result<Response>`, logging at the appropriate level.
 pub fn into_response<T: Serialize>(result: ApiResult<T>, status: u16) -> worker::Result<Response> {
     match result {
@@ -73,18 +86,7 @@ pub fn into_response<T: Serialize>(result: ApiResult<T>, status: u16) -> worker:
             tracing::info!("success");
             Response::from_json(&data).map(|r| r.with_status(status))
         }
-        Err(ref e) => {
-            match e.log_level() {
-                tracing::Level::ERROR => tracing::error!(error = %e, "failed"),
-                tracing::Level::WARN => tracing::warn!(error = %e, "failed"),
-                _ => tracing::debug!(error = %e, "failed"),
-            }
-            let body = ErrorBody {
-                code: e.code().to_string(),
-                status: e.status_code(),
-            };
-            Response::from_json(&body).map(|r| r.with_status(e.status_code()))
-        }
+        Err(ref e) => log_and_build_error_response(e),
     }
 }
 
@@ -105,17 +107,6 @@ pub fn no_content_response(result: ApiResult<()>) -> worker::Result<Response> {
             tracing::info!("success");
             Ok(Response::empty()?.with_status(204))
         }
-        Err(ref e) => {
-            match e.log_level() {
-                tracing::Level::ERROR => tracing::error!(error = %e, "failed"),
-                tracing::Level::WARN => tracing::warn!(error = %e, "failed"),
-                _ => tracing::debug!(error = %e, "failed"),
-            }
-            let body = ErrorBody {
-                code: e.code().to_string(),
-                status: e.status_code(),
-            };
-            Response::from_json(&body).map(|r| r.with_status(e.status_code()))
-        }
+        Err(ref e) => log_and_build_error_response(e),
     }
 }

--- a/crates/logging/src/error.rs
+++ b/crates/logging/src/error.rs
@@ -1,0 +1,121 @@
+use serde::Serialize;
+use std::fmt;
+use worker::Response;
+
+/// Typed API error with automatic log-level mapping.
+pub enum ApiError {
+    /// 404 — resource not found. Log at DEBUG (client mistake).
+    NotFound(String),
+    /// 403 — forbidden. Log at WARN (suspicious).
+    Forbidden,
+    /// 400 — bad request. Log at DEBUG (client mistake).
+    BadRequest(String),
+    /// 500 — internal error. Log at ERROR (our problem).
+    Internal(String),
+}
+
+/// Convenience alias for handler return types.
+pub type ApiResult<T> = Result<T, ApiError>;
+
+impl ApiError {
+    pub fn status_code(&self) -> u16 {
+        match self {
+            Self::NotFound(_) => 404,
+            Self::Forbidden => 403,
+            Self::BadRequest(_) => 400,
+            Self::Internal(_) => 500,
+        }
+    }
+
+    pub fn log_level(&self) -> tracing::Level {
+        match self {
+            Self::NotFound(_) | Self::BadRequest(_) => tracing::Level::DEBUG,
+            Self::Forbidden => tracing::Level::WARN,
+            Self::Internal(_) => tracing::Level::ERROR,
+        }
+    }
+
+    pub fn code(&self) -> &str {
+        match self {
+            Self::NotFound(c) | Self::BadRequest(c) | Self::Internal(c) => c.as_str(),
+            Self::Forbidden => "forbidden",
+        }
+    }
+}
+
+impl fmt::Display for ApiError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotFound(c) => write!(f, "not found: {c}"),
+            Self::Forbidden => write!(f, "forbidden"),
+            Self::BadRequest(c) => write!(f, "bad request: {c}"),
+            Self::Internal(c) => write!(f, "internal error: {c}"),
+        }
+    }
+}
+
+impl From<worker::Error> for ApiError {
+    fn from(e: worker::Error) -> Self {
+        Self::Internal(e.to_string())
+    }
+}
+
+#[derive(Serialize)]
+struct ErrorBody {
+    code: String,
+    status: u16,
+}
+
+/// Convert `ApiResult<T>` to `worker::Result<Response>`, logging at the appropriate level.
+pub fn into_response<T: Serialize>(result: ApiResult<T>, status: u16) -> worker::Result<Response> {
+    match result {
+        Ok(data) => {
+            tracing::info!("success");
+            Response::from_json(&data).map(|r| r.with_status(status))
+        }
+        Err(ref e) => {
+            match e.log_level() {
+                tracing::Level::ERROR => tracing::error!(error = %e, "failed"),
+                tracing::Level::WARN => tracing::warn!(error = %e, "failed"),
+                _ => tracing::debug!(error = %e, "failed"),
+            }
+            let body = ErrorBody {
+                code: e.code().to_string(),
+                status: e.status_code(),
+            };
+            Response::from_json(&body).map(|r| r.with_status(e.status_code()))
+        }
+    }
+}
+
+/// Shortcut for 200 OK response with logging.
+pub fn ok_response<T: Serialize>(result: ApiResult<T>) -> worker::Result<Response> {
+    into_response(result, 200)
+}
+
+/// Shortcut for 201 Created response with logging.
+pub fn created_response<T: Serialize>(result: ApiResult<T>) -> worker::Result<Response> {
+    into_response(result, 201)
+}
+
+/// Shortcut for 204 No Content response with logging.
+pub fn no_content_response(result: ApiResult<()>) -> worker::Result<Response> {
+    match result {
+        Ok(()) => {
+            tracing::info!("success");
+            Ok(Response::empty()?.with_status(204))
+        }
+        Err(ref e) => {
+            match e.log_level() {
+                tracing::Level::ERROR => tracing::error!(error = %e, "failed"),
+                tracing::Level::WARN => tracing::warn!(error = %e, "failed"),
+                _ => tracing::debug!(error = %e, "failed"),
+            }
+            let body = ErrorBody {
+                code: e.code().to_string(),
+                status: e.status_code(),
+            };
+            Response::from_json(&body).map(|r| r.with_status(e.status_code()))
+        }
+    }
+}

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -6,6 +6,7 @@ pub use error::{ApiError, ApiResult, created_response, into_response, no_content
 pub fn init_cf() {
     use tracing_subscriber::fmt::format::Pretty;
     use tracing_subscriber::fmt::time::UtcTime;
+    use tracing_subscriber::EnvFilter;
     use tracing_subscriber::prelude::*;
     use tracing_web::{MakeConsoleWriter, performance_layer};
 
@@ -15,10 +16,11 @@ pub fn init_cf() {
         .with_timer(UtcTime::rfc_3339())
         .with_writer(MakeConsoleWriter);
     let perf_layer = performance_layer().with_details_from_fields(Pretty::default());
-    tracing_subscriber::registry()
+    let _ = tracing_subscriber::registry()
+        .with(EnvFilter::new("info"))
         .with(fmt_layer)
         .with(perf_layer)
-        .init();
+        .try_init();
 }
 
 #[cfg(feature = "axum")]

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -1,0 +1,35 @@
+pub mod error;
+
+pub use error::{ApiError, ApiResult, created_response, into_response, no_content_response, ok_response};
+
+#[cfg(feature = "cf")]
+pub fn init_cf() {
+    use tracing_subscriber::fmt::format::Pretty;
+    use tracing_subscriber::fmt::time::UtcTime;
+    use tracing_subscriber::prelude::*;
+    use tracing_web::{MakeConsoleWriter, performance_layer};
+
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .json()
+        .with_ansi(false)
+        .with_timer(UtcTime::rfc_3339())
+        .with_writer(MakeConsoleWriter);
+    let perf_layer = performance_layer().with_details_from_fields(Pretty::default());
+    tracing_subscriber::registry()
+        .with(fmt_layer)
+        .with(perf_layer)
+        .init();
+}
+
+#[cfg(feature = "axum")]
+pub fn init_axum() {
+    use tracing_subscriber::fmt::format::FmtSpan;
+    use tracing_subscriber::EnvFilter;
+
+    tracing_subscriber::fmt()
+        .json()
+        .with_env_filter(EnvFilter::from_default_env())
+        .with_target(true)
+        .with_span_events(FmtSpan::CLOSE)
+        .init();
+}

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -1,12 +1,14 @@
 pub mod error;
 
-pub use error::{ApiError, ApiResult, created_response, into_response, no_content_response, ok_response};
+pub use error::{
+    ApiError, ApiResult, created_response, into_response, no_content_response, ok_response,
+};
 
 #[cfg(feature = "cf")]
 pub fn init_cf() {
+    use tracing_subscriber::EnvFilter;
     use tracing_subscriber::fmt::format::Pretty;
     use tracing_subscriber::fmt::time::UtcTime;
-    use tracing_subscriber::EnvFilter;
     use tracing_subscriber::prelude::*;
     use tracing_web::{MakeConsoleWriter, performance_layer};
 
@@ -25,8 +27,8 @@ pub fn init_cf() {
 
 #[cfg(feature = "axum")]
 pub fn init_axum() {
-    use tracing_subscriber::fmt::format::FmtSpan;
     use tracing_subscriber::EnvFilter;
+    use tracing_subscriber::fmt::format::FmtSpan;
 
     tracing_subscriber::fmt()
         .json()

--- a/crates/shared/src/constants.rs
+++ b/crates/shared/src/constants.rs
@@ -6,3 +6,5 @@ pub const DATE_TYPE_DEADLINE: &str = "deadline";
 pub const DATE_TYPE_HARD_DEADLINE: &str = "hard_deadline";
 
 pub const SETTING_MCP_AUTO_ENABLE_FEATURES: &str = "mcp_auto_enable_features";
+
+pub const INSTANCE_SETTING_REGISTRATION_MODE: &str = "registration_mode";

--- a/crates/shared/src/dto/requests.rs
+++ b/crates/shared/src/dto/requests.rs
@@ -104,3 +104,14 @@ pub struct TagAssignment {
 pub struct UpsertSettingRequest {
     pub value: serde_json::Value,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateInvitationCodeRequest {
+    pub expires_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidateInviteRequest {
+    pub code: String,
+    pub email: String,
+}

--- a/crates/shared/src/dto/responses.rs
+++ b/crates/shared/src/dto/responses.rs
@@ -1,6 +1,25 @@
 use crate::models::{Container, Item, List, ListFeature};
 use serde::{Deserialize, Serialize};
 
+/// Response from GET /api/me
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MeResponse {
+    pub is_admin: bool,
+}
+
+/// Response from GET /api/public/registration-mode
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegistrationModeResponse {
+    pub mode: String,
+}
+
+/// Response from POST /api/public/validate-invite
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidateInviteResponse {
+    pub valid: bool,
+    pub error: Option<String>,
+}
+
 /// Response from GET /api/lists/:list_id/items/:id
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ItemDetailResponse {

--- a/crates/shared/src/models/invitation_code.rs
+++ b/crates/shared/src/models/invitation_code.rs
@@ -1,0 +1,14 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InvitationCode {
+    pub id: String,
+    pub code: String,
+    pub created_by: String,
+    pub used_by: Option<String>,
+    pub reserved_by_email: Option<String>,
+    pub reserved_until: Option<String>,
+    pub created_at: String,
+    pub used_at: Option<String>,
+    pub expires_at: Option<String>,
+}

--- a/crates/shared/src/models/mod.rs
+++ b/crates/shared/src/models/mod.rs
@@ -1,11 +1,15 @@
 pub mod container;
+pub mod invitation_code;
 pub mod item;
 pub mod list;
 pub mod settings;
 pub mod tag;
+pub mod user;
 
 pub use container::*;
+pub use invitation_code::*;
 pub use item::*;
 pub use list::*;
 pub use settings::*;
 pub use tag::*;
+pub use user::*;

--- a/crates/shared/src/models/user.rs
+++ b/crates/shared/src/models/user.rs
@@ -1,0 +1,6 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserProfile {
+    pub is_admin: bool,
+}

--- a/docs/superpowers/plans/2026-03-29-structured-logging.md
+++ b/docs/superpowers/plans/2026-03-29-structured-logging.md
@@ -1,0 +1,741 @@
+# Structured Logging Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add structured JSON logging across Rust API and TypeScript Gateway, using `tracing` facade with CF Workers-native output, designed for seamless migration to Axum.
+
+**Architecture:** New `kartoteka-logging` crate provides `init_cf()` (tracing-web + MakeConsoleWriter) and `ApiError`/`ApiResult` types. API worker gets a request span in `lib.rs`, handlers use `#[instrument]` and `ApiResult<T>`. Gateway gets a request logging middleware with `X-Request-Id` propagation. Both workers enable CF Workers Logs via `[observability]` in wrangler.toml.
+
+**Tech Stack:** tracing 0.1, tracing-subscriber 0.3 (json, env-filter, time), tracing-web 0.1, time 0.3 (wasm-bindgen), nanoid, Hono middleware
+
+---
+
+## File Map
+
+### New files
+
+| File | Responsibility |
+|------|---------------|
+| `crates/logging/Cargo.toml` | Crate manifest with `cf`/`axum` feature flags |
+| `crates/logging/src/lib.rs` | `init_cf()`, `init_axum()`, re-exports |
+| `crates/logging/src/error.rs` | `ApiError`, `ApiResult<T>`, `log_level()`, `Display` |
+| `gateway/src/logger.ts` | Structured JSON logger + request logging middleware |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `Cargo.toml` (workspace root) | Add `crates/logging` to workspace members |
+| `crates/api/Cargo.toml` | Add `kartoteka-logging`, `tracing`, `nanoid` deps |
+| `crates/api/src/lib.rs` | Add `#[event(start)]` for tracing init, request span in `main()` |
+| `crates/api/src/error.rs` | Replace `json_error` with `into_response` wrapper using `ApiError` |
+| `crates/api/src/handlers/containers.rs` | Add `#[instrument]` + `ApiResult` to all handlers |
+| `crates/api/src/handlers/lists.rs` | Add `#[instrument]` + `ApiResult` to all handlers |
+| `crates/api/src/handlers/items.rs` | Add `#[instrument]` + `ApiResult` to all handlers |
+| `crates/api/src/handlers/tags.rs` | Add `#[instrument]` + `ApiResult` to all handlers |
+| `crates/api/src/handlers/preferences.rs` | Add `#[instrument]` + `ApiResult` to all handlers |
+| `crates/api/src/handlers/settings.rs` | Add `#[instrument]` + `ApiResult` to all handlers |
+| `crates/api/src/handlers/admin.rs` | Add `#[instrument]` + `ApiResult` to all handlers |
+| `crates/api/src/handlers/me.rs` | Add `#[instrument]` + `ApiResult` to all handlers |
+| `crates/api/src/handlers/public.rs` | Add `#[instrument]` + `ApiResult` to all handlers |
+| `crates/api/wrangler.toml` | Add `[observability]` section to enable Workers Logs |
+| `gateway/wrangler.toml` | Add `[observability]` section to enable Workers Logs |
+| `gateway/src/index.ts` | Add request logging middleware, generate/propagate `X-Request-Id` |
+| `gateway/src/proxy.ts` | Propagate `X-Request-Id` header to API Worker |
+| `gateway/src/middleware.ts` | Log auth events |
+
+---
+
+## Task 1: Create `kartoteka-logging` crate
+
+**Files:**
+- Create: `crates/logging/Cargo.toml`
+- Create: `crates/logging/src/lib.rs`
+- Create: `crates/logging/src/error.rs`
+- Modify: `Cargo.toml` (workspace root)
+
+- [ ] **Step 1: Add `crates/logging` to workspace members**
+
+In `Cargo.toml` (workspace root), add `"crates/logging"` to the members list:
+
+```toml
+[workspace]
+resolver = "2"
+members = [
+    "crates/shared",
+    "crates/api",
+    "crates/frontend",
+    "crates/i18n",
+    "crates/logging",
+]
+```
+
+- [ ] **Step 2: Create `crates/logging/Cargo.toml`**
+
+```toml
+[package]
+name = "kartoteka-logging"
+version.workspace = true
+edition.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[features]
+default = ["cf"]
+cf = ["tracing-web", "dep:time"]
+axum = ["tracing-subscriber/ansi"]
+
+[dependencies]
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["json", "env-filter", "time"] }
+worker = { version = "0.7", default-features = false }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+# CF-only
+tracing-web = { version = "0.1", optional = true }
+time = { version = "0.3", features = ["wasm-bindgen"], optional = true }
+```
+
+Note: `worker` dependency is needed because `ApiError` needs `worker::Error` for `From` impl. Uses `default-features = false` to keep it light.
+
+- [ ] **Step 3: Create `crates/logging/src/error.rs`**
+
+```rust
+use serde::Serialize;
+use std::fmt;
+use worker::Response;
+
+/// Typed API error with automatic log-level mapping.
+pub enum ApiError {
+    /// 404 — resource not found. Log at DEBUG (client mistake).
+    NotFound(String),
+    /// 403 — forbidden. Log at WARN (suspicious).
+    Forbidden,
+    /// 400 — bad request. Log at DEBUG (client mistake).
+    BadRequest(String),
+    /// 500 — internal error. Log at ERROR (our problem).
+    Internal(String),
+}
+
+/// Convenience alias for handler return types.
+pub type ApiResult<T> = Result<T, ApiError>;
+
+impl ApiError {
+    pub fn status_code(&self) -> u16 {
+        match self {
+            Self::NotFound(_) => 404,
+            Self::Forbidden => 403,
+            Self::BadRequest(_) => 400,
+            Self::Internal(_) => 500,
+        }
+    }
+
+    pub fn log_level(&self) -> tracing::Level {
+        match self {
+            Self::NotFound(_) | Self::BadRequest(_) => tracing::Level::DEBUG,
+            Self::Forbidden => tracing::Level::WARN,
+            Self::Internal(_) => tracing::Level::ERROR,
+        }
+    }
+
+    pub fn code(&self) -> &str {
+        match self {
+            Self::NotFound(c) | Self::BadRequest(c) | Self::Internal(c) => c.as_str(),
+            Self::Forbidden => "forbidden",
+        }
+    }
+}
+
+impl fmt::Display for ApiError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotFound(c) => write!(f, "not found: {c}"),
+            Self::Forbidden => write!(f, "forbidden"),
+            Self::BadRequest(c) => write!(f, "bad request: {c}"),
+            Self::Internal(c) => write!(f, "internal error: {c}"),
+        }
+    }
+}
+
+impl From<worker::Error> for ApiError {
+    fn from(e: worker::Error) -> Self {
+        Self::Internal(e.to_string())
+    }
+}
+
+#[derive(Serialize)]
+struct ErrorBody {
+    code: String,
+    status: u16,
+}
+
+/// Convert `ApiResult<T>` to `worker::Result<Response>`, logging at the appropriate level.
+pub fn into_response<T: Serialize>(result: ApiResult<T>, status: u16) -> worker::Result<Response> {
+    match result {
+        Ok(data) => {
+            tracing::info!("success");
+            Response::from_json(&data).map(|r| r.with_status(status))
+        }
+        Err(ref e) => {
+            match e.log_level() {
+                tracing::Level::ERROR => tracing::error!(error = %e, "failed"),
+                tracing::Level::WARN => tracing::warn!(error = %e, "failed"),
+                _ => tracing::debug!(error = %e, "failed"),
+            }
+            let body = ErrorBody {
+                code: e.code().to_string(),
+                status: e.status_code(),
+            };
+            Response::from_json(&body).map(|r| r.with_status(e.status_code()))
+        }
+    }
+}
+
+/// Shortcut for 200 OK response with logging.
+pub fn ok_response<T: Serialize>(result: ApiResult<T>) -> worker::Result<Response> {
+    into_response(result, 200)
+}
+
+/// Shortcut for 201 Created response with logging.
+pub fn created_response<T: Serialize>(result: ApiResult<T>) -> worker::Result<Response> {
+    into_response(result, 201)
+}
+
+/// Shortcut for 204 No Content response with logging.
+pub fn no_content_response(result: ApiResult<()>) -> worker::Result<Response> {
+    match result {
+        Ok(()) => {
+            tracing::info!("success");
+            Ok(Response::empty()?.with_status(204))
+        }
+        Err(ref e) => {
+            match e.log_level() {
+                tracing::Level::ERROR => tracing::error!(error = %e, "failed"),
+                tracing::Level::WARN => tracing::warn!(error = %e, "failed"),
+                _ => tracing::debug!(error = %e, "failed"),
+            }
+            let body = ErrorBody {
+                code: e.code().to_string(),
+                status: e.status_code(),
+            };
+            Response::from_json(&body).map(|r| r.with_status(e.status_code()))
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Create `crates/logging/src/lib.rs`**
+
+```rust
+pub mod error;
+
+pub use error::{ApiError, ApiResult, created_response, into_response, no_content_response, ok_response};
+
+#[cfg(feature = "cf")]
+pub fn init_cf() {
+    use tracing_subscriber::fmt::format::Pretty;
+    use tracing_subscriber::fmt::time::UtcTime;
+    use tracing_subscriber::prelude::*;
+    use tracing_web::{MakeConsoleWriter, performance_layer};
+
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .json()
+        .with_ansi(false)
+        .with_timer(UtcTime::rfc_3339())
+        .with_writer(MakeConsoleWriter);
+    let perf_layer = performance_layer().with_details_from_fields(Pretty::default());
+    tracing_subscriber::registry()
+        .with(fmt_layer)
+        .with(perf_layer)
+        .init();
+}
+
+#[cfg(feature = "axum")]
+pub fn init_axum() {
+    use tracing_subscriber::fmt::format::FmtSpan;
+    use tracing_subscriber::EnvFilter;
+
+    tracing_subscriber::fmt()
+        .json()
+        .with_env_filter(EnvFilter::from_default_env())
+        .with_target(true)
+        .with_span_events(FmtSpan::CLOSE)
+        .init();
+}
+```
+
+- [ ] **Step 5: Verify it compiles**
+
+Run: `cargo check -p kartoteka-logging`
+Expected: compiles successfully
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/logging/ Cargo.toml
+git commit -m "feat: add kartoteka-logging crate with tracing init and ApiError"
+```
+
+---
+
+## Task 2: Enable Workers Logs in wrangler.toml
+
+**Files:**
+- Modify: `crates/api/wrangler.toml`
+- Modify: `gateway/wrangler.toml`
+
+- [ ] **Step 1: Add observability to API wrangler.toml**
+
+Add at the end of `crates/api/wrangler.toml` (top-level, applies to all envs):
+
+```toml
+[observability]
+enabled = true
+```
+
+- [ ] **Step 2: Add observability to Gateway wrangler.toml**
+
+Read `gateway/wrangler.toml` and add the same `[observability]` section.
+
+```toml
+[observability]
+enabled = true
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/api/wrangler.toml gateway/wrangler.toml
+git commit -m "feat: enable CF Workers Logs observability"
+```
+
+---
+
+## Task 3: Wire tracing init + request span in API worker
+
+**Files:**
+- Modify: `crates/api/Cargo.toml`
+- Modify: `crates/api/src/lib.rs`
+
+- [ ] **Step 1: Add dependencies to `crates/api/Cargo.toml`**
+
+Add these to the `[dependencies]` section:
+
+```toml
+kartoteka-logging = { path = "../logging" }
+tracing = "0.1"
+nanoid = "0.4"
+```
+
+- [ ] **Step 2: Add `#[event(start)]` and request span to `crates/api/src/lib.rs`**
+
+Replace the entire file:
+
+```rust
+use tracing::Instrument;
+use worker::*;
+
+mod auth;
+pub mod error;
+mod handlers;
+pub(crate) mod helpers;
+mod router;
+
+#[event(start)]
+fn start() {
+    kartoteka_logging::init_cf();
+}
+
+#[event(fetch, respond_with_errors)]
+pub async fn main(req: Request, env: Env, ctx: Context) -> Result<Response> {
+    let request_id = req
+        .headers()
+        .get("X-Request-Id")
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| nanoid::nanoid!());
+
+    let user_id = req
+        .headers()
+        .get("X-User-Id")
+        .ok()
+        .flatten()
+        .unwrap_or_default();
+
+    let span = tracing::info_span!("request",
+        request_id = %request_id,
+        method = %req.method(),
+        path = %req.path(),
+        user_id = %user_id,
+    );
+
+    let response = router::handle(req, env).instrument(span.clone()).await;
+
+    match &response {
+        Ok(resp) => {
+            let _enter = span.enter();
+            tracing::info!(status = resp.status_code(), "request completed");
+        }
+        Err(e) => {
+            let _enter = span.enter();
+            tracing::error!(error = %e, "request failed");
+        }
+    }
+
+    response
+}
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cargo check -p kartoteka-api`
+Expected: compiles successfully. Note: this is a WASM target check — if native check fails due to WASM-only deps, try `cargo check -p kartoteka-api --target wasm32-unknown-unknown`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/api/Cargo.toml crates/api/src/lib.rs
+git commit -m "feat: wire tracing init and request span in API worker"
+```
+
+---
+
+## Task 4: Update `error.rs` and migrate one handler module (containers)
+
+This task establishes the handler migration pattern. Subsequent tasks follow it.
+
+**Files:**
+- Modify: `crates/api/src/error.rs`
+- Modify: `crates/api/src/handlers/containers.rs`
+
+- [ ] **Step 1: Update `crates/api/src/error.rs`**
+
+Keep the existing `json_error` function (other handlers still use it) and add the new imports:
+
+```rust
+use kartoteka_shared::ErrorResponse;
+use worker::Response;
+
+pub fn json_error(code: &str, status: u16) -> worker::Result<Response> {
+    let body = ErrorResponse {
+        code: Some(code.to_string()),
+        status,
+    };
+    Response::from_json(&body).map(|r| r.with_status(status))
+}
+```
+
+No changes needed — `json_error` stays for now. Handlers will use `ApiError` from `kartoteka_logging` directly, and the `into_response` / `ok_response` / etc. functions handle error → Response conversion. Once all handlers are migrated, `json_error` can be removed.
+
+- [ ] **Step 2: Add `#[instrument]` to containers handlers**
+
+Add `use tracing::instrument;` at the top of `crates/api/src/handlers/containers.rs`.
+
+For each handler, add `#[instrument(skip_all, fields(action = "..."))]` above the function signature. The `skip_all` is critical — `Request`, `RouteContext`, and D1 types don't implement `Debug` and cannot be logged.
+
+Example for `create`:
+
+```rust
+#[instrument(skip_all, fields(action = "create_container"))]
+pub async fn create(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
+    // ... existing body unchanged ...
+}
+```
+
+Apply to all handlers in `containers.rs`:
+- `list_all` — no action field needed (GET, read-only)
+- `create` — `action = "create_container"`
+- `get_one` — no action field
+- `update` — `action = "update_container"`
+- `delete` — `action = "delete_container"`
+- `get_children` — no action field
+- `move_container` — `action = "move_container"`
+- `toggle_pin` — `action = "toggle_container_pin"`
+- `home` — no action field
+
+For mutating handlers, add `tracing::Span::current().record(...)` after key operations to capture entity IDs. Example in `create`, after the INSERT succeeds:
+
+```rust
+tracing::Span::current().record("container_id", &tracing::field::display(&id));
+```
+
+To use dynamic span fields, the field must be declared in the `#[instrument]` macro with `Empty`:
+
+```rust
+#[instrument(skip_all, fields(action = "create_container", container_id = tracing::field::Empty))]
+pub async fn create(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
+    // ...
+    let id = uuid::Uuid::new_v4().to_string();
+    tracing::Span::current().record("container_id", &tracing::field::display(&id));
+    // ... rest of handler
+}
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cargo check -p kartoteka-api`
+Expected: compiles successfully
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/api/src/error.rs crates/api/src/handlers/containers.rs
+git commit -m "feat: add tracing instrumentation to container handlers"
+```
+
+---
+
+## Task 5: Instrument remaining handler modules
+
+**Files:**
+- Modify: `crates/api/src/handlers/lists.rs`
+- Modify: `crates/api/src/handlers/items.rs`
+- Modify: `crates/api/src/handlers/tags.rs`
+- Modify: `crates/api/src/handlers/preferences.rs`
+- Modify: `crates/api/src/handlers/settings.rs`
+- Modify: `crates/api/src/handlers/admin.rs`
+- Modify: `crates/api/src/handlers/me.rs`
+- Modify: `crates/api/src/handlers/public.rs`
+
+Follow the exact same pattern from Task 4. For each handler file:
+
+1. Add `use tracing::instrument;` at the top
+2. Add `#[instrument(skip_all, fields(action = "..."))]` to mutating handlers
+3. Add `#[instrument(skip_all)]` to read-only handlers (no action field)
+4. Add `Span::current().record()` for key entity IDs in mutating handlers
+
+- [ ] **Step 1: Instrument `lists.rs`**
+
+Action names: `create_list`, `update_list`, `delete_list`, `create_sublist`, `toggle_archive`, `reset_list`, `move_list`, `toggle_list_pin`, `add_list_feature`, `remove_list_feature`.
+
+Dynamic fields: `list_id = tracing::field::Empty` on create/update/delete handlers.
+
+- [ ] **Step 2: Instrument `items.rs`**
+
+Action names: `create_item`, `update_item`, `delete_item`, `move_item`.
+
+Dynamic fields: `item_id = tracing::field::Empty` on create/update/delete.
+
+- [ ] **Step 3: Instrument `tags.rs`**
+
+Action names: `create_tag`, `update_tag`, `delete_tag`, `merge_tags`, `assign_tag_to_item`, `remove_tag_from_item`, `assign_tag_to_list`, `remove_tag_from_list`.
+
+Dynamic fields: `tag_id = tracing::field::Empty` on create/update/delete/merge.
+
+- [ ] **Step 4: Instrument `preferences.rs`**
+
+Action names: `update_preferences` (for PUT). GET has no action.
+
+- [ ] **Step 5: Instrument `settings.rs`**
+
+Action names: `upsert_setting`, `delete_setting`. GET has no action.
+
+Dynamic fields: `setting_key = tracing::field::Empty`.
+
+- [ ] **Step 6: Instrument `admin.rs`**
+
+Action names: `update_instance_setting`, `create_invitation_code`, `delete_invitation_code`. GET has no action.
+
+- [ ] **Step 7: Instrument `me.rs`**
+
+Read-only — `#[instrument(skip_all)]` with no action.
+
+- [ ] **Step 8: Instrument `public.rs`**
+
+Read-only — `#[instrument(skip_all)]` with no action. `validate_invite` gets `action = "validate_invite"`.
+
+- [ ] **Step 9: Verify it compiles**
+
+Run: `cargo check -p kartoteka-api`
+Expected: compiles successfully
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add crates/api/src/handlers/
+git commit -m "feat: add tracing instrumentation to all handler modules"
+```
+
+---
+
+## Task 6: Gateway structured logging + request ID propagation
+
+**Files:**
+- Create: `gateway/src/logger.ts`
+- Modify: `gateway/src/index.ts`
+- Modify: `gateway/src/proxy.ts`
+- Modify: `gateway/src/middleware.ts`
+- Modify: `gateway/package.json`
+
+- [ ] **Step 1: Add `nanoid` dependency**
+
+Run: `cd gateway && npm install nanoid`
+
+- [ ] **Step 2: Create `gateway/src/logger.ts`**
+
+```typescript
+type LogLevel = "DEBUG" | "INFO" | "WARN" | "ERROR";
+
+export function log(level: LogLevel, message: string, fields: Record<string, unknown> = {}) {
+  console.log(JSON.stringify({
+    timestamp: new Date().toISOString(),
+    level,
+    message,
+    ...fields,
+  }));
+}
+```
+
+- [ ] **Step 3: Add request logging middleware to `gateway/src/index.ts`**
+
+Add this middleware right after the CORS middleware (before any routes):
+
+```typescript
+import { nanoid } from "nanoid";
+import { log } from "./logger";
+
+app.use("*", async (c, next) => {
+  const requestId = c.req.header("x-request-id") ?? nanoid();
+  c.set("requestId", requestId);
+  c.header("X-Request-Id", requestId);
+
+  const start = Date.now();
+  await next();
+
+  log("INFO", "request completed", {
+    request_id: requestId,
+    method: c.req.method,
+    path: new URL(c.req.url).pathname,
+    status: c.res.status,
+    duration_ms: Date.now() - start,
+  });
+});
+```
+
+Update the `Variables` interface in `gateway/src/types.ts` to include `requestId`:
+
+```typescript
+export interface Variables {
+  userId: string;
+  userEmail: string;
+  requestId: string;
+}
+```
+
+- [ ] **Step 4: Propagate `X-Request-Id` in `gateway/src/proxy.ts`**
+
+In the `proxy.all("/*", ...)` handler, add after the existing header setup:
+
+```typescript
+const requestId = c.get("requestId");
+if (requestId) headers.set("X-Request-Id", requestId);
+```
+
+This goes right after `if (userEmail) headers.set("X-User-Email", userEmail);`.
+
+- [ ] **Step 5: Add auth event logging to `gateway/src/middleware.ts`**
+
+Add log calls for auth events:
+
+```typescript
+import { log } from "./logger";
+
+// Inside authMiddleware:
+// After successful auth:
+log("INFO", "auth success", {
+  request_id: c.get("requestId"),
+  user_id: session.user.id,
+});
+
+// After auth failure (before returning 401):
+log("WARN", "auth failed", {
+  request_id: c.get("requestId"),
+  path: new URL(c.req.url).pathname,
+});
+```
+
+- [ ] **Step 6: Verify gateway builds**
+
+Run: `cd gateway && npx tsc --noEmit`
+Expected: no type errors
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add gateway/
+git commit -m "feat: add structured logging and request ID propagation to gateway"
+```
+
+---
+
+## Task 7: Smoke test locally
+
+**Files:** none (testing only)
+
+- [ ] **Step 1: Start dev environment**
+
+Run: `just dev`
+
+- [ ] **Step 2: Make API requests and check logs**
+
+Make a few requests to the API:
+```bash
+curl -s http://localhost:8788/api/home | head -c 100
+curl -s -X POST http://localhost:8788/api/lists -H 'Content-Type: application/json' -d '{"name":"test-log"}'
+```
+
+- [ ] **Step 3: Verify JSON log output**
+
+Check the terminal output for both Gateway and API workers. You should see:
+- Gateway: JSON logs with `request_id`, `method`, `path`, `status`, `duration_ms`
+- API worker: JSON logs with `request_id`, `user_id`, `method`, `path`, tracing span fields
+- The same `request_id` appearing in both Gateway and API logs for the same request
+
+- [ ] **Step 4: Verify tracing fields**
+
+Look for business event logs (e.g., from creating a list) containing:
+- `action` field (e.g., `"create_list"`)
+- `list_id` field (the UUID of the created list)
+- `request_id` field matching the Gateway log
+
+- [ ] **Step 5: Clean up test data**
+
+Delete the test list created in step 2.
+
+---
+
+## Task 8: Migrate handlers to `ApiResult<T>` + remove `json_error` (future)
+
+**Files:**
+- Modify: `crates/api/src/error.rs`
+- Modify: all handler files
+- Modify: `crates/api/src/router.rs` (call sites)
+
+This task is a **separate, larger refactor** — it changes every handler's return type from `Result<Response>` to `ApiResult<T>` and wraps call sites in `router.rs` with `ok_response()` / `created_response()` / `no_content_response()`. Tasks 1-7 deliver full structured logging without this refactor. Do this when ready to invest in the handler ergonomics improvement described in the design spec.
+
+- [ ] **Step 1: Audit remaining `json_error` usage**
+
+Run: `grep -rn "json_error" crates/api/src/`
+
+If the list is small, replace each call:
+- `json_error("container_not_found", 404)` → `return Err(ApiError::NotFound("container_not_found".into()))`
+- `json_error("forbidden", 403)` → `return Err(ApiError::Forbidden)`
+- `json_error("bad_request", 400)` → `return Err(ApiError::BadRequest("bad_request".into()))`
+
+- [ ] **Step 2: Remove `json_error` from `error.rs`**
+
+Once no callers remain, delete the function and the `kartoteka_shared::ErrorResponse` import.
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cargo check -p kartoteka-api`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/api/
+git commit -m "refactor: replace json_error with ApiError across all handlers"
+```

--- a/docs/superpowers/specs/2026-03-29-structured-logging-design.md
+++ b/docs/superpowers/specs/2026-03-29-structured-logging-design.md
@@ -1,0 +1,431 @@
+# Structured Logging Design
+
+## Motivation
+
+Kartoteka has zero logging in the Rust API and Gateway. No `console_log!`, no `tracing`, nothing. We need full observability — request tracing, business events, error tracking — with the ability to debug on production.
+
+The system must be Cloudflare-native now (CF Workers Logs + `console.log` JSON indexing) but designed so that migration to Axum/VPS (issue #24) requires changing only the initialization line. Handler code stays untouched.
+
+## Approach
+
+**Unified `tracing` facade** with `tracing-web` + `tracing-subscriber` JSON on CF Workers, swappable to `tracing-subscriber::fmt().json()` on Axum. One new crate: `kartoteka-logging`.
+
+Key insight: Cloudflare's official [workers-rs tracing example](https://github.com/cloudflare/workers-rs/tree/main/examples/tracing) already provides the exact stack we need — no custom Layer required.
+
+## JSON Log Schema
+
+Every log entry (regardless of backend) shares a common core with optional contextual fields:
+
+```json
+{
+  "timestamp": "2026-03-29T14:32:01.123Z",
+  "level": "INFO",
+  "request_id": "a1b2c3d4",
+  "user_id": "uuid-...",
+  "target": "kartoteka_api::handlers::lists",
+  "message": "list created"
+}
+```
+
+### Core fields (always present)
+
+| Field | Source |
+|-------|--------|
+| `timestamp` | `UtcTime::rfc_3339()` (CF) / `tracing-subscriber` (Axum) |
+| `level` | tracing level |
+| `target` | Rust module path (automatic from `tracing`) |
+| `message` | Event message |
+
+### Contextual fields (present when applicable)
+
+| Field | When |
+|-------|------|
+| `request_id` | All request-scoped logs — from `X-Request-Id` header or generated |
+| `user_id` | All authenticated request logs — from `X-User-Id` header |
+| `method`, `path`, `status`, `duration_ms` | Request lifecycle logs (span close) |
+| `action` | Business events (`create_list`, `delete_item`, etc.) |
+| `error` | Error logs |
+| `list_id`, `item_id`, `tag_id` | Entity-specific business events |
+| `mcp_tool`, `mcp_session_id` | MCP tool calls |
+| `mcp_client_id`, `grant_type` | MCP OAuth flow |
+
+Fields not relevant to a given log are omitted (not null, just absent). CF Workers Logs automatically indexes all JSON keys for filtering.
+
+### Log examples by type
+
+**HTTP request completed:**
+```json
+{"timestamp":"...","level":"INFO","request_id":"a1b2","user_id":"uuid","target":"kartoteka_api","message":"request completed","method":"POST","path":"/api/lists","status":201,"duration_ms":12}
+```
+
+**Business event:**
+```json
+{"timestamp":"...","level":"INFO","request_id":"a1b2","user_id":"uuid","target":"kartoteka_api::handlers::lists","message":"list created","action":"create_list","list_id":"uuid","list_name":"Groceries"}
+```
+
+**MCP tool call:**
+```json
+{"timestamp":"...","level":"INFO","request_id":"c3d4","user_id":"uuid","target":"kartoteka_gateway::mcp","message":"mcp tool executed","mcp_tool":"list_items","mcp_session_id":"sess-xyz","duration_ms":45}
+```
+
+**Error:**
+```json
+{"timestamp":"...","level":"ERROR","request_id":"a1b2","user_id":"uuid","target":"kartoteka_api::db","message":"query failed","error":"SQLITE_BUSY: database is locked","action":"create_list"}
+```
+
+## Architecture
+
+### New crate: `kartoteka-logging`
+
+```
+crates/logging/
+  Cargo.toml
+  src/
+    lib.rs           — init_cf(), init_axum(), re-exports (20 LOC)
+    error.rs         — ApiError enum + ApiResult + log_level() (50 LOC)
+    request_id.rs    — extract/generate X-Request-Id, inject into span (30 LOC)
+```
+
+~100 LOC total. Note: `into_response` wrapper lives in `crates/api` (not in logging crate) because it depends on `worker::Response`. The logging crate has no dependency on `worker`.
+
+### Cargo.toml
+
+```toml
+[package]
+name = "kartoteka-logging"
+
+[features]
+default = ["cf"]
+cf = ["tracing-web", "time"]
+axum = []
+
+[dependencies]
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["json", "env-filter", "time"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+anyhow = "1"
+
+# CF-only
+tracing-web = { version = "0.1", optional = true }
+time = { version = "0.3", features = ["wasm-bindgen"], optional = true }
+```
+
+### Dependencies in other crates
+
+```toml
+# crates/api/Cargo.toml
+[dependencies]
+kartoteka-logging = { path = "../logging" }
+tracing = "0.1"  # for #[instrument] and tracing::info!() in handlers
+```
+
+`crates/shared/` — no changes, shared crate does not log.
+
+## Request Flow
+
+### Current (CF Workers)
+
+```
+Client -> Gateway (TS/Hono)
+           | generates request_id (nanoid)
+           | logs: request received (JSON console.log)
+           | sets X-Request-Id header
+           v
+         API Worker (Rust)
+           | extracts X-Request-Id (or generates if missing)
+           | opens tracing span: request_id, user_id, method, path
+           | handlers emit business events inside span
+           | span close -> logs status, duration_ms
+           | tracing-web MakeConsoleWriter -> console.log(JSON)
+           v
+         CF Workers Logs (dashboard, query builder, 7-day retention)
+```
+
+### After migration (Axum)
+
+```
+Client -> Axum binary
+           | tower-http TraceLayer opens span (automatic)
+           | middleware extracts/generates request_id
+           | handlers emit business events (SAME CODE)
+           | tracing-subscriber fmt::json() -> stdout
+           v
+         stdout -> (Loki/Datadog/whatever)
+```
+
+### What changes at migration
+
+| Element | CF (now) | Axum (future) |
+|---------|----------|---------------|
+| Init | `init_cf()` | `init_axum()` |
+| Request span | Custom in main handler | `TraceLayer` from tower-http |
+| Request ID | Custom extraction | Same middleware (ports 1:1) |
+| Business events | `tracing::info!()` | `tracing::info!()` — **no changes** |
+| Output | `console.log` via `MakeConsoleWriter` | stdout |
+| Gateway | Separate TS worker | Gone — MCP in same binary |
+
+## Initialization
+
+### CF Workers
+
+```rust
+// crates/logging/src/lib.rs
+use tracing_subscriber::fmt::format::Pretty;
+use tracing_subscriber::fmt::time::UtcTime;
+use tracing_subscriber::prelude::*;
+use tracing_web::{performance_layer, MakeConsoleWriter};
+
+pub fn init_cf() {
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .json()
+        .with_ansi(false)
+        .with_timer(UtcTime::rfc_3339())
+        .with_writer(MakeConsoleWriter);
+    let perf_layer = performance_layer().with_details_from_fields(Pretty::default());
+    tracing_subscriber::registry()
+        .with(fmt_layer)
+        .with(perf_layer)
+        .init();
+}
+```
+
+In API worker:
+```rust
+#[event(start)]
+fn start() {
+    kartoteka_logging::init_cf();
+}
+```
+
+### Axum (future)
+
+```rust
+pub fn init_axum() {
+    tracing_subscriber::fmt()
+        .json()
+        .with_env_filter(EnvFilter::from_default_env())
+        .with_target(true)
+        .with_span_events(FmtSpan::CLOSE)
+        .init();
+}
+```
+
+### Log level configuration
+
+- **CF Workers**: Compile-time default (`info`). `#[event(start)]` has no access to `Env`. Feature flag `--features debug-logging` for debug builds.
+- **Axum**: Standard `RUST_LOG` env var (`RUST_LOG=info`, `RUST_LOG=kartoteka_api::handlers::lists=debug`).
+- **Dev**: `debug` level by default.
+
+## Typed Handler Pattern
+
+Handlers return `ApiResult<T>` instead of manually building responses and logging. A wrapper handles response conversion and logging automatically.
+
+### ApiError
+
+```rust
+type ApiResult<T> = Result<T, ApiError>;
+
+enum ApiError {
+    NotFound(String),        // -> 404
+    Forbidden,               // -> 403
+    BadRequest(String),      // -> 400
+    Internal(anyhow::Error), // -> 500
+}
+
+impl ApiError {
+    fn status_code(&self) -> u16 {
+        match self {
+            Self::NotFound(_) => 404,
+            Self::Forbidden => 403,
+            Self::BadRequest(_) => 400,
+            Self::Internal(_) => 500,
+        }
+    }
+
+    fn log_level(&self) -> tracing::Level {
+        match self {
+            Self::NotFound(_) | Self::BadRequest(_) => Level::DEBUG,
+            Self::Forbidden => Level::WARN,
+            Self::Internal(_) => Level::ERROR,
+        }
+    }
+}
+```
+
+### Handler pattern
+
+```rust
+#[tracing::instrument(skip(d1), fields(action = "create_list"))]
+async fn create_list(d1: &D1, user_id: &str, body: CreateListRequest) -> ApiResult<List> {
+    let id = Uuid::new_v4();
+    let pos = next_position(d1, "lists", "user_id = ?", &[user_id]).await?;
+    d1.exec("INSERT INTO lists ...", &[&id, &body.name, &user_id]).await?;
+
+    let list = List { id, name: body.name, position: pos, .. };
+    Span::current().record("list_id", &tracing::field::display(&id));
+    Ok(list)
+}
+```
+
+### Response wrapper (lives in `crates/api`, not in logging crate)
+
+```rust
+// crates/api/src/response.rs
+async fn into_response<T: Serialize>(result: ApiResult<T>, status: u16) -> Result<Response> {
+    match result {
+        Ok(data) => {
+            tracing::info!("success");
+            Response::from_json(&data).map(|r| r.with_status(status))
+        }
+        Err(e) => {
+            match e.log_level() {
+                Level::ERROR => tracing::error!(error = %e, "failed"),
+                Level::WARN => tracing::warn!(error = %e, "failed"),
+                _ => tracing::debug!(error = %e, "failed"),
+            }
+            Ok(Response::from_json(&ErrorResponse { error: e.to_string() })?
+                .with_status(e.status_code()))
+        }
+    }
+}
+```
+
+Benefits:
+- Handler LOC drops from ~15-20 to ~5-8
+- Success/error logging is automatic and consistent
+- Error severity mapping is centralized
+- Handlers are testable as pure functions returning `ApiResult<T>`
+- Pattern ports 1:1 to Axum (`IntoResponse` trait impl)
+
+## Span Structure
+
+```
+request{request_id="abc123" method="POST" path="/api/lists" user_id="uuid"}
+  +-- INFO "list created" action="create_list" list_id="uuid" list_name="Groceries"
+  +-- DEBUG "sql query" query="INSERT INTO lists..."
+  +-- CLOSE -> INFO "request completed" status=201 duration_ms=12
+```
+
+One root span per request. `tracing-subscriber` JSON automatically attaches parent span fields to every event.
+
+### Request span (CF Workers)
+
+```rust
+use tracing::Instrument;
+
+pub async fn handle_request(req: Request, env: Env, ctx: Context) -> Result<Response> {
+    let request_id = req.headers().get("X-Request-Id")
+        .unwrap_or_else(|| nanoid::nanoid!());
+    let user_id = req.headers().get("X-User-Id").unwrap_or_default();
+
+    let span = tracing::info_span!("request",
+        request_id = %request_id,
+        method = %req.method(),
+        path = %req.path(),
+        user_id = %user_id,
+    );
+
+    let response = route(req, env, ctx).instrument(span.clone()).await;
+
+    let _enter = span.enter();
+    tracing::info!(status = response.status_code(), "request completed");
+
+    response
+}
+```
+
+## Log Levels
+
+| Level | What we log | Examples |
+|-------|------------|---------|
+| **ERROR** | Something broke, needs attention | DB query failed, panic caught, external service down |
+| **WARN** | Suspicious but handled | Auth failed, rate limit hit, deprecated endpoint called |
+| **INFO** | Normal operations, business events | Request completed, list created, item toggled, MCP tool executed |
+| **DEBUG** | Troubleshooting details | SQL query text, request/response body, session lookup |
+| **TRACE** | Ultra-verbose | Serialization steps, field parsing |
+
+### What we log per layer
+
+**Request lifecycle (automatic from middleware/span):**
+- INFO span close: method, path, status, duration_ms, user_id, request_id
+- WARN: 4xx responses (except 404)
+- ERROR: 5xx responses
+
+**Business events (manually in handlers):**
+- INFO: CRUD operations with context (action, entity id, name)
+- DEBUG: operation details (items moved, old vs new position)
+
+**Auth/session:**
+- INFO: login success, logout
+- WARN: login failed, invalid session, unauthorized access attempt
+
+**MCP (in Gateway):**
+- INFO: tool call executed (tool name, duration, session_id)
+- WARN: tool call failed (validation error)
+- ERROR: tool call crashed
+- INFO: OAuth flow events (authorize, token issued)
+
+**DB:**
+- DEBUG: query text + params (debug level only!)
+- ERROR: query failure with error message
+- WARN: slow query (> 100ms threshold)
+
+### What we DON'T log
+
+- GET requests don't get business events — request span (method, path, status, duration) is enough
+- Request/response bodies at INFO level — DEBUG only
+- PII (email, password, token) — `user_id` is sufficient
+
+### Action naming convention
+
+`verb_noun` consistently: `create_list`, `update_item`, `delete_tag`, `toggle_item`, `reorder_items`, `move_item`, `login_success`, `login_failed`, `mcp_tool_executed`, `mcp_tool_failed`.
+
+## Gateway (TypeScript) Logger
+
+Minimal structured logger with the same JSON schema. Generates and propagates `request_id`.
+
+```typescript
+// gateway/src/logger.ts
+function log(level: string, message: string, fields: Record<string, unknown>) {
+  console.log(JSON.stringify({
+    timestamp: new Date().toISOString(),
+    level,
+    message,
+    ...fields
+  }));
+}
+```
+
+### Gateway request middleware
+
+```typescript
+app.use('*', async (c, next) => {
+  const requestId = c.req.header('x-request-id') ?? nanoid();
+  c.set('requestId', requestId);
+  c.header('X-Request-Id', requestId);
+
+  const start = Date.now();
+  await next();
+
+  console.log(JSON.stringify({
+    timestamp: new Date().toISOString(),
+    level: "INFO",
+    request_id: requestId,
+    method: c.req.method,
+    path: c.req.path,
+    status: c.res.status,
+    duration_ms: Date.now() - start,
+    message: "request completed"
+  }));
+});
+```
+
+MCP tool calls logged here with the same `request_id`.
+
+## Default log levels
+
+- **Production:** `info`
+- **Debug on prod (CF):** rebuild with debug feature flag
+- **Debug on prod (Axum):** `RUST_LOG=kartoteka_api::handlers::lists=debug`
+- **Dev:** `debug`

--- a/gateway/package-lock.json
+++ b/gateway/package-lock.json
@@ -12,7 +12,8 @@
         "@fluent/bundle": "^0.19.1",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "better-auth": "^1.5.0",
-        "hono": "^4.0.0"
+        "hono": "^4.0.0",
+        "nanoid": "^5.1.7"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260329.1",
@@ -2337,6 +2338,24 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.7.tgz",
+      "integrity": "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
     },
     "node_modules/nanostores": {
       "version": "1.2.0",

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -14,7 +14,8 @@
     "@fluent/bundle": "^0.19.1",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "better-auth": "^1.5.0",
-    "hono": "^4.0.0"
+    "hono": "^4.0.0",
+    "nanoid": "^5.1.7"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260329.1",

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -64,6 +64,75 @@ app.get("/auth/api/get-session", async (c, next) => {
   });
 });
 
+// Intercept signup to enforce registration mode and validate invite codes
+app.post("/auth/api/sign-up/email", async (c) => {
+  // Skip in local dev (DEV_AUTH_USER_ID bypasses auth entirely)
+  if (!c.env.DEV_AUTH_USER_ID) {
+    const body = await c.req.json<Record<string, string>>();
+
+    // Call the Rust API to get the current registration mode
+    const apiBase = c.env.DEV_API_URL ?? "http://internal";
+    const modeRes = await (c.env.DEV_API_URL
+      ? fetch(`${apiBase}/api/public/registration-mode`)
+      : c.env.API_WORKER.fetch(new Request(`${apiBase}/api/public/registration-mode`)));
+
+    if (!modeRes.ok) {
+      return c.json({ error: "Failed to check registration mode" }, 500);
+    }
+
+    const { mode } = await modeRes.json<{ mode: string }>();
+
+    if (mode === "closed") {
+      return c.json({ error: "Registration is closed" }, 403);
+    }
+
+    if (mode === "invite") {
+      const inviteCode = body.inviteCode;
+      if (!inviteCode) {
+        return c.json({ error: "Invite code required" }, 403);
+      }
+
+      const validateRes = await (c.env.DEV_API_URL
+        ? fetch(`${apiBase}/api/public/validate-invite`, {
+            method: "POST",
+            body: JSON.stringify({ code: inviteCode, email: body.email }),
+            headers: { "Content-Type": "application/json" },
+          })
+        : c.env.API_WORKER.fetch(
+            new Request(`${apiBase}/api/public/validate-invite`, {
+              method: "POST",
+              body: JSON.stringify({ code: inviteCode, email: body.email }),
+              headers: { "Content-Type": "application/json" },
+            })
+          ));
+
+      if (!validateRes.ok) {
+        return c.json({ error: "Failed to validate invite code" }, 500);
+      }
+
+      const { valid, error } = await validateRes.json<{ valid: boolean; error?: string }>();
+      if (!valid) {
+        return c.json({ error: error ?? "Invalid invite code" }, 403);
+      }
+    }
+
+    // Strip inviteCode before forwarding to Better Auth
+    const { inviteCode: _removed, ...authBody } = body;
+    const auth = getAuth(c.env);
+    return auth.handler(
+      new Request(c.req.raw.url, {
+        method: "POST",
+        body: JSON.stringify(authBody),
+        headers: c.req.raw.headers,
+      })
+    );
+  }
+
+  // Dev mode: forward directly
+  const auth = getAuth(c.env);
+  return auth.handler(c.req.raw);
+});
+
 app.all("/auth/*", async (c) => {
   const auth = getAuth(c.env);
   return auth.handler(c.req.raw);

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -2,11 +2,13 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { getMigrations } from "better-auth/db/migration";
 import { OAuthProvider } from "@cloudflare/workers-oauth-provider";
+import { nanoid } from "nanoid";
 import type { Env, Variables } from "./types";
 import { getAuth } from "./auth";
 import { authMiddleware } from "./middleware";
 import { proxy } from "./proxy";
 import { McpApiHandler } from "./mcp/server";
+import { log } from "./logger";
 
 function escapeHtml(s: string): string {
   return s
@@ -27,6 +29,23 @@ app.use("*", async (c, next) => {
     credentials: true,
   });
   return corsMiddleware(c, next);
+});
+
+app.use("*", async (c, next) => {
+  const requestId = c.req.header("x-request-id") ?? nanoid();
+  c.set("requestId", requestId);
+  c.header("X-Request-Id", requestId);
+
+  const start = Date.now();
+  await next();
+
+  log("INFO", "request completed", {
+    request_id: requestId,
+    method: c.req.method,
+    path: new URL(c.req.url).pathname,
+    status: c.res.status,
+    duration_ms: Date.now() - start,
+  });
 });
 
 app.get("/health", (c) => c.text("ok"));

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -83,23 +83,41 @@ app.get("/auth/api/get-session", async (c, next) => {
   });
 });
 
+async function checkRegistrationMode(env: Env): Promise<{ mode: string } | null> {
+  const apiBase = env.DEV_API_URL ?? "http://internal";
+  const res = await (env.DEV_API_URL
+    ? fetch(`${apiBase}/api/public/registration-mode`)
+    : env.API_WORKER.fetch(new Request(`${apiBase}/api/public/registration-mode`)));
+  if (!res.ok) return null;
+  return res.json<{ mode: string }>();
+}
+
+// Block OAuth social sign-in when registration mode is closed or invite-only
+app.post("/auth/api/sign-in/social", async (c) => {
+  if (!c.env.DEV_AUTH_USER_ID) {
+    const modeData = await checkRegistrationMode(c.env);
+    if (!modeData) return c.json({ error: "Failed to check registration mode" }, 500);
+    if (modeData.mode === "closed") return c.json({ error: "Registration is closed" }, 403);
+    if (modeData.mode === "invite")
+      return c.json({ error: "Invite-only mode does not support social login" }, 403);
+  }
+  const auth = getAuth(c.env);
+  return auth.handler(c.req.raw);
+});
+
 // Intercept signup to enforce registration mode and validate invite codes
 app.post("/auth/api/sign-up/email", async (c) => {
   // Skip in local dev (DEV_AUTH_USER_ID bypasses auth entirely)
   if (!c.env.DEV_AUTH_USER_ID) {
     const body = await c.req.json<Record<string, string>>();
 
-    // Call the Rust API to get the current registration mode
     const apiBase = c.env.DEV_API_URL ?? "http://internal";
-    const modeRes = await (c.env.DEV_API_URL
-      ? fetch(`${apiBase}/api/public/registration-mode`)
-      : c.env.API_WORKER.fetch(new Request(`${apiBase}/api/public/registration-mode`)));
-
-    if (!modeRes.ok) {
+    const modeData = await checkRegistrationMode(c.env);
+    if (!modeData) {
       return c.json({ error: "Failed to check registration mode" }, 500);
     }
 
-    const { mode } = await modeRes.json<{ mode: string }>();
+    const { mode } = modeData;
 
     if (mode === "closed") {
       return c.json({ error: "Registration is closed" }, 403);

--- a/gateway/src/logger.ts
+++ b/gateway/src/logger.ts
@@ -1,10 +1,9 @@
 type LogLevel = "DEBUG" | "INFO" | "WARN" | "ERROR";
 
 export function log(level: LogLevel, message: string, fields: Record<string, unknown> = {}) {
-  console.log(JSON.stringify({
-    timestamp: new Date().toISOString(),
-    level,
-    message,
-    ...fields,
-  }));
+  const entry = JSON.stringify({ timestamp: new Date().toISOString(), level, message, ...fields });
+  if (level === "ERROR") console.error(entry);
+  else if (level === "WARN") console.warn(entry);
+  else if (level === "DEBUG") console.debug(entry);
+  else console.log(entry);
 }

--- a/gateway/src/logger.ts
+++ b/gateway/src/logger.ts
@@ -1,0 +1,10 @@
+type LogLevel = "DEBUG" | "INFO" | "WARN" | "ERROR";
+
+export function log(level: LogLevel, message: string, fields: Record<string, unknown> = {}) {
+  console.log(JSON.stringify({
+    timestamp: new Date().toISOString(),
+    level,
+    message,
+    ...fields,
+  }));
+}

--- a/gateway/src/middleware.ts
+++ b/gateway/src/middleware.ts
@@ -6,6 +6,7 @@ export const authMiddleware = createMiddleware<{ Bindings: Env; Variables: Varia
   async (c, next) => {
     if (c.env.DEV_AUTH_USER_ID) {
       c.set("userId", c.env.DEV_AUTH_USER_ID);
+      c.set("userEmail", "dev@local");
       return next();
     }
 
@@ -17,6 +18,7 @@ export const authMiddleware = createMiddleware<{ Bindings: Env; Variables: Varia
     }
 
     c.set("userId", session.user.id);
+    c.set("userEmail", session.user.email ?? "");
     return next();
   }
 );

--- a/gateway/src/middleware.ts
+++ b/gateway/src/middleware.ts
@@ -1,6 +1,7 @@
 import { createMiddleware } from "hono/factory";
 import type { Env, Variables } from "./types";
 import { getAuth } from "./auth";
+import { log } from "./logger";
 
 export const authMiddleware = createMiddleware<{ Bindings: Env; Variables: Variables }>(
   async (c, next) => {
@@ -14,11 +15,19 @@ export const authMiddleware = createMiddleware<{ Bindings: Env; Variables: Varia
     const session = await auth.api.getSession({ headers: c.req.raw.headers });
 
     if (!session?.user?.id) {
+      log("WARN", "auth failed", {
+        request_id: c.get("requestId") ?? "",
+        path: new URL(c.req.url).pathname,
+      });
       return c.json({ error: "Unauthorized" }, 401);
     }
 
     c.set("userId", session.user.id);
     c.set("userEmail", session.user.email ?? "");
+    log("INFO", "auth success", {
+      request_id: c.get("requestId") ?? "",
+      user_id: session.user.id,
+    });
     return next();
   }
 );

--- a/gateway/src/proxy.ts
+++ b/gateway/src/proxy.ts
@@ -5,8 +5,10 @@ const proxy = new Hono<{ Bindings: Env; Variables: Variables }>();
 
 proxy.all("/*", async (c) => {
   const userId = c.get("userId");
+  const userEmail = c.get("userEmail");
   const headers = new Headers(c.req.raw.headers);
   headers.set("X-User-Id", userId);
+  if (userEmail) headers.set("X-User-Email", userEmail);
 
   if (c.env.DEV_API_URL) {
     // Local dev: rewrite URL to DEV_API_URL

--- a/gateway/src/proxy.ts
+++ b/gateway/src/proxy.ts
@@ -8,7 +8,7 @@ proxy.all("/*", async (c) => {
   const userEmail = c.get("userEmail");
   const headers = new Headers(c.req.raw.headers);
   headers.set("X-User-Id", userId);
-  if (userEmail) headers.set("X-User-Email", userEmail);
+  headers.set("X-User-Email", userEmail || "");
   const requestId = c.get("requestId");
   if (requestId) headers.set("X-Request-Id", requestId);
 

--- a/gateway/src/proxy.ts
+++ b/gateway/src/proxy.ts
@@ -9,6 +9,8 @@ proxy.all("/*", async (c) => {
   const headers = new Headers(c.req.raw.headers);
   headers.set("X-User-Id", userId);
   if (userEmail) headers.set("X-User-Email", userEmail);
+  const requestId = c.get("requestId");
+  if (requestId) headers.set("X-Request-Id", requestId);
 
   if (c.env.DEV_API_URL) {
     // Local dev: rewrite URL to DEV_API_URL

--- a/gateway/src/types.ts
+++ b/gateway/src/types.ts
@@ -18,4 +18,5 @@ export interface Env {
 
 export interface Variables {
   userId: string;
+  userEmail: string;
 }

--- a/gateway/src/types.ts
+++ b/gateway/src/types.ts
@@ -19,4 +19,5 @@ export interface Env {
 export interface Variables {
   userId: string;
   userEmail: string;
+  requestId: string;
 }

--- a/gateway/wrangler.toml
+++ b/gateway/wrangler.toml
@@ -78,3 +78,6 @@ id = "00000000-0000-0000-0000-000000000000"
 [[env.local.services]]
 binding = "API_WORKER"
 service = "kartoteka-api"
+
+[observability]
+enabled = true

--- a/locales/en/admin.ftl
+++ b/locales/en/admin.ftl
@@ -1,0 +1,15 @@
+admin-panel = Admin
+instance-settings = Instance Settings
+registration-mode = Registration Mode
+registration-open = Open
+registration-invite = Invite Only
+registration-closed = Closed
+registration-closed-message = Registration is currently unavailable.
+invitation-codes = Invitation Codes
+invite-code = Invite Code
+invite-code-required = Invite code required
+invite-code-invalid = Invalid or expired invite code
+invite-code-in-use = This code is currently being used, try again shortly
+generate-code = Generate code
+code-active = Active
+code-used = Used

--- a/locales/en/common.ftl
+++ b/locales/en/common.ftl
@@ -9,3 +9,5 @@ common-confirm = Confirm
 common-copied = Copied!
 common-copy = Copy
 common-or = or
+common-status = Status
+common-created = Created

--- a/locales/en/nav.ftl
+++ b/locales/en/nav.ftl
@@ -5,3 +5,4 @@ nav-tags = Tags
 nav-settings = Settings
 nav-logout = Log out
 nav-login = Log in
+nav-admin = Admin

--- a/locales/pl/admin.ftl
+++ b/locales/pl/admin.ftl
@@ -1,0 +1,15 @@
+admin-panel = Panel admina
+instance-settings = Ustawienia instancji
+registration-mode = Tryb rejestracji
+registration-open = Otwarta
+registration-invite = Na zaproszenia
+registration-closed = Zamknięta
+registration-closed-message = Rejestracja jest aktualnie niedostępna.
+invitation-codes = Kody zaproszeń
+invite-code = Kod zaproszenia
+invite-code-required = Wymagany kod zaproszenia
+invite-code-invalid = Nieprawidłowy lub wygasły kod zaproszenia
+invite-code-in-use = Ten kod jest aktualnie używany, spróbuj za chwilę
+generate-code = Generuj kod
+code-active = Aktywny
+code-used = Użyty

--- a/locales/pl/common.ftl
+++ b/locales/pl/common.ftl
@@ -9,3 +9,5 @@ common-confirm = Potwierdź
 common-copied = Skopiowano!
 common-copy = Kopiuj
 common-or = lub
+common-status = Status
+common-created = Utworzono

--- a/locales/pl/nav.ftl
+++ b/locales/pl/nav.ftl
@@ -5,3 +5,4 @@ nav-tags = Tagi
 nav-settings = Ustawienia
 nav-logout = Wyloguj
 nav-login = Zaloguj
+nav-admin = Admin


### PR DESCRIPTION
- [x] Instance settings table (`instance_settings`) with `registration_mode`: `open` / `invite` / `closed`
- [x] Users table syncing Better Auth user IDs with `is_admin` flag
- [x] Invitation codes with 10-min DB reservation to prevent race conditions
- [x] Gateway interceptor enforces registration mode before Better Auth signup
- [x] Admin panel (`/admin`) — change registration mode, generate/list/delete invite codes
- [x] Signup page adapts to registration mode (shows invite field, blocks form when closed)
- [x] Nav shows Admin link for admins
- [x] First user matching `INITIAL_ADMIN_EMAIL` env var auto-promoted to admin
- [x] `kartoteka-logging` crate with tracing init and `ApiError` enum
- [x] Request span tracing in API worker with `request_id`, `user_id`, `method`, `path`, `status`, `duration_ms`
- [x] Gateway TypeScript logger using same JSON schema, `request_id` propagated via `X-Request-Id`
- [x] CI passing on `82bfc82`
- [x] Review fixes: document `INITIAL_ADMIN_EMAIL` in `crates/api/wrangler.toml`; add `INITIAL_ADMIN_EMAIL = "dev@local"` to local env so admin panel works out-of-the-box in local dev; eliminate redundant `get_registration_mode` fetch in signup `on_submit` (use cached `reg_mode` signal instead)

<!-- START COPILOT CODING AGENT TIPS -->
---

✨ Let Copilot coding agent [set things up for you](https://github.com/jpalczewski/kartoteka/issues/new?title=✨+Set+up+Copilot+instructions&body=Configure%20instructions%20for%20this%20repository%20as%20documented%20in%20%5BBest%20practices%20for%20Copilot%20coding%20agent%20in%20your%20repository%5D%28https://gh.io/copilot-coding-agent-tips%29%2E%0A%0A%3COnboard%20this%20repo%3E&assignees=copilot) — coding agent works faster and does higher quality work when set up for your repo.
