### PR TITLE
feat: configurable log level via LOG_LEVEL env var

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ pub async fn create(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
 - `action` — nazwa operacji w formacie `verb_noun` (`create_list`, `delete_item`, `toggle_item`)
 - Entity ID jako `tracing::field::Empty` w atrybucie, uzupełniane przez `Span::current().record(...)` po poznaniu wartości
 - **Bez `&` przed `tracing::field::display`** — clippy `needless_borrows_for_generic_args` blokuje CI
-- Inicjalizacja tracingu: `kartoteka_logging::init_cf()` w `#[event(start)]`
+- Inicjalizacja tracingu: `kartoteka_logging::init_cf(level)` wywoływane na początku `#[event(fetch)]`; level z `env.var("LOG_LEVEL")` (default `"info"`); dev ma `LOG_LEVEL = "debug"` w `wrangler.toml`
 - Gateway: `log()` z `gateway/src/logger.ts` — ten sam schemat JSON, korelacja przez `X-Request-Id`
 
 ## Komendy

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -6,13 +6,10 @@ mod handlers;
 pub(crate) mod helpers;
 mod router;
 
-#[event(start)]
-fn start() {
-    kartoteka_logging::init_cf();
-}
-
 #[event(fetch, respond_with_errors)]
 pub async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
+    let log_level = env.var("LOG_LEVEL").map(|v| v.to_string()).unwrap_or_else(|_| "info".to_string());
+    kartoteka_logging::init_cf(&log_level);
     let request_id = req
         .headers()
         .get("X-Request-Id")

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -8,7 +8,10 @@ mod router;
 
 #[event(fetch, respond_with_errors)]
 pub async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
-    let log_level = env.var("LOG_LEVEL").map(|v| v.to_string()).unwrap_or_else(|_| "info".to_string());
+    let log_level = env
+        .var("LOG_LEVEL")
+        .map(|v| v.to_string())
+        .unwrap_or_else(|_| "info".to_string());
     kartoteka_logging::init_cf(&log_level);
     let request_id = req
         .headers()

--- a/crates/api/wrangler.toml
+++ b/crates/api/wrangler.toml
@@ -35,6 +35,9 @@ migrations_dir = "./migrations"
 name = "kartoteka-api-dev"
 workers_dev = false
 
+[env.dev.vars]
+LOG_LEVEL = "debug"
+
 [[env.dev.d1_databases]]
 binding = "DB"
 database_name = "kartoteka-dev"

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -5,7 +5,7 @@ pub use error::{
 };
 
 #[cfg(feature = "cf")]
-pub fn init_cf() {
+pub fn init_cf(level: &str) {
     use tracing_subscriber::EnvFilter;
     use tracing_subscriber::fmt::format::Pretty;
     use tracing_subscriber::fmt::time::UtcTime;
@@ -19,7 +19,7 @@ pub fn init_cf() {
         .with_writer(MakeConsoleWriter);
     let perf_layer = performance_layer().with_details_from_fields(Pretty::default());
     let _ = tracing_subscriber::registry()
-        .with(EnvFilter::new("info"))
+        .with(EnvFilter::new(level))
         .with(fmt_layer)
         .with(perf_layer)
         .try_init();

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,11 @@
+pre-commit:
+  parallel: true
+  commands:
+    fmt:
+      run: cargo fmt --all -- --check
+      fail_text: "Run `just fmt` to fix formatting"
+    clippy:
+      run: cargo clippy --workspace -- -D warnings
+    tsc:
+      root: gateway/
+      run: npx tsc --noEmit


### PR DESCRIPTION
## Summary

- `init_cf()` now accepts a `level: &str` parameter instead of hardcoding `"info"`
- Level is read from `env.var("LOG_LEVEL")` at request start (safe — `try_init()` is a no-op after first call per isolate)
- Dev environment gets `LOG_LEVEL = "debug"` in `wrangler.toml`
- CLAUDE.md updated to document the configurable level

## Why

Registration bypass bug was discovered on dev — needed debug-level logs to investigate. CF Workers `#[event(start)]` has no access to `Env`, so initialization was moved to the top of `#[event(fetch)]`.

## Test plan

- [ ] `just ci` passes
- [ ] Deploy dev: confirm debug-level SQL queries appear in CF Workers Logs for dev worker
- [ ] Prod worker uses `info` level (no `LOG_LEVEL` var set = default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)