### PR TITLE
fix: make GlooClient Copy, fix admin panel save (wasm32 compile error)

### DIFF
--- a/crates/frontend/src/api/client.rs
+++ b/crates/frontend/src/api/client.rs
@@ -26,7 +26,7 @@ pub trait HttpClient {
 
 /// Production HTTP client using gloo-net. Sends credentials with every request.
 /// On non-wasm targets the impl panics — only ever instantiated in WASM context.
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct GlooClient;
 
 #[cfg(target_arch = "wasm32")]

--- a/crates/frontend/src/pages/admin/mod.rs
+++ b/crates/frontend/src/pages/admin/mod.rs
@@ -41,30 +41,23 @@ fn InstanceSettingsSection() -> impl IntoView {
     let client = use_context::<GlooClient>().expect("GlooClient not provided");
 
     #[cfg(target_arch = "wasm32")]
-    let _settings_res = {
-        LocalResource::new(move || {
-            let client = client.clone();
-            async move {
-                if let Ok(settings) = crate::api::admin::list_instance_settings(&client).await {
-                    for s in settings {
-                        if s.key == kartoteka_shared::INSTANCE_SETTING_REGISTRATION_MODE {
-                            if let Some(m) = s.value.as_str() {
-                                reg_mode.set(m.to_string());
-                            }
-                        }
+    let _settings_res = LocalResource::new(move || async move {
+        if let Ok(settings) = crate::api::admin::list_instance_settings(&client).await {
+            for s in settings {
+                if s.key == kartoteka_shared::INSTANCE_SETTING_REGISTRATION_MODE {
+                    if let Some(m) = s.value.as_str() {
+                        reg_mode.set(m.to_string());
                     }
                 }
             }
-        })
-    };
+        }
+    });
 
     let on_save = move |_| {
         saving.set(true);
         save_error.set(None);
         #[cfg(target_arch = "wasm32")]
         let mode = reg_mode.get_untracked();
-        #[cfg(target_arch = "wasm32")]
-        let client = client.clone();
         leptos::task::spawn_local(async move {
             #[cfg(target_arch = "wasm32")]
             {
@@ -127,21 +120,14 @@ fn InvitationCodesSection() -> impl IntoView {
     let client = use_context::<GlooClient>().expect("GlooClient not provided");
 
     #[cfg(target_arch = "wasm32")]
-    let _codes_res = {
-        LocalResource::new(move || {
-            let client = client.clone();
-            async move {
-                if let Ok(list) = crate::api::admin::list_invitation_codes(&client).await {
-                    codes.set(list);
-                }
-            }
-        })
-    };
+    let _codes_res = LocalResource::new(move || async move {
+        if let Ok(list) = crate::api::admin::list_invitation_codes(&client).await {
+            codes.set(list);
+        }
+    });
 
     let on_generate = move |_| {
         generating.set(true);
-        #[cfg(target_arch = "wasm32")]
-        let client = client.clone();
         leptos::task::spawn_local(async move {
             #[cfg(target_arch = "wasm32")]
             {
@@ -181,12 +167,9 @@ fn InvitationCodesSection() -> impl IntoView {
                             {move || codes.get().into_iter().map(|c| {
                                 let id_del = c.id.clone();
                                 let dimmed = c.used_by.is_some();
-                                // Inline delete callback — Fn-compatible (codes is Copy RwSignal)
                                 let delete_this = move |_: web_sys::MouseEvent| {
                                     #[allow(unused_variables)]
                                     let id = id_del.clone();
-                                    #[cfg(target_arch = "wasm32")]
-                                    let client = client.clone();
                                     leptos::task::spawn_local(async move {
                                         #[cfg(target_arch = "wasm32")]
                                         {


### PR DESCRIPTION
## Summary
- `GlooClient` is a zero-size unit struct — adding `Copy` eliminates all clone-before-move boilerplate
- Previous fix (PR #75) still had wasm32 compile error: non-Copy value moved into `async move` inside `Fn` closure (`FnOnce` instead of `FnMut`)
- `Copy` GlooClient means captures in `LocalResource` and `spawn_local` closures work without explicit cloning
- Verified with `cargo check --target wasm32-unknown-unknown`

## Root cause
Admin panel PUT/POST/DELETE requests were never sent: `use_context::<GlooClient>()` was called inside `spawn_local` (outside reactive owner → `None` → `.expect()` panic).

## Test plan
- [ ] Open admin panel → change registration mode → Save → verify persists on reload
- [ ] Generate / delete invitation codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)