### PR TITLE
fix(ci): release-please auto-merges develop to main on release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,12 +25,18 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+      - uses: actions/checkout@v4
+        if: ${{ steps.release.outputs.release_created }}
+        with:
+          ref: develop
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Merge develop into main
         if: ${{ steps.release.outputs.release_created }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin
           git checkout main
           git merge origin/develop --ff-only
           git push origin main

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,8 +18,19 @@ jobs:
       cancel-in-progress: false
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           release-type: simple
-          target-branch: main
+          target-branch: develop
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Merge develop into main
+        if: ${{ steps.release.outputs.release_created }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin
+          git checkout main
+          git merge origin/develop --ff-only
+          git push origin main

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,6 +20,6 @@ jobs:
       - uses: googleapis/release-please-action@v4
         with:
           release-type: simple
-          target-branch: develop
+          target-branch: main
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/gateway/src/auth.ts
+++ b/gateway/src/auth.ts
@@ -20,7 +20,7 @@ export function createAuth(env: Env) {
       crossSubDomainCookies: { enabled: false },
       cookies: {
         session_token: {
-          attributes: { sameSite: "none", secure: true, path: "/" },
+          attributes: { sameSite: "none", secure: true, path: "/", partitioned: true },
         },
       },
     },


### PR DESCRIPTION
## Summary

- Reverts `target-branch` back to `develop` (previously broken: targeting `main` caused release-please to find 0 commits and skip)
- After release PR is merged to develop, workflow auto fast-forwards `main` to `develop`, triggering the production deploy

## Root cause

`target-branch: main` made release-please search for conventional commits on `main`. Since commits flow through `develop`, it found 0 and created no PR.

## Test plan

- [ ] Merge a conventional commit to `develop`
- [ ] Verify release-please creates/updates release PR targeting `develop`
- [ ] Merge release PR → verify `main` is automatically updated and deploy-prod triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)