### PR TITLE
fix(ci): set release-please target-branch back to develop

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,7 +21,7 @@ jobs:
         id: release
         with:
           release-type: simple
-          target-branch: main
+          target-branch: develop
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
## Summary

- Fixes `target-branch: develop` — previous PRs accidentally left it as `main`
- With `target-branch: main` release-please searches commits on `main` and finds 0, so no release PR is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)