### PR TITLE
Validate item dates and calendar query params

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,61 @@
+# AGENTS.md
+
+## Repo Basics
+
+- Monorepo: `crates/shared`, `crates/api`, `crates/frontend`, `gateway/`
+- API: Cloudflare Workers + D1 (`worker`, `sqlx-d1`)
+- Frontend: Leptos 0.8 CSR
+- Gateway: TypeScript Worker z MCP i proxy do API
+
+## Tracing / Logging
+
+Każdy handler w `crates/api/src/handlers/` musi mieć `#[instrument]`.
+
+Wzorzec:
+
+```rust
+#[instrument(skip_all, fields(action = "create_list", list_id = tracing::field::Empty))]
+pub async fn create(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
+    let id = Uuid::new_v4().to_string();
+    Span::current().record("list_id", tracing::field::display(&id));
+    // ...
+}
+```
+
+- `skip_all` dla `req` i `ctx`
+- `action` w formacie `verb_noun`
+- jeśli handler tworzy lub operuje na konkretnym encji ID, dodaj pole jako `tracing::field::Empty` i uzupełnij je przez `Span::current().record(...)` po poznaniu wartości
+- bez zbędnego `&` przed `tracing::field::display(...)`
+
+## Workers / D1
+
+- D1 zwraca boolean jako `0.0` / `1.0`; używaj istniejących deserializerów z `crates/shared/src/deserializers.rs`
+- D1 bind: `ctx.env.d1("DB")?`
+- parametry SQL przekazuj jako `JsValue`
+- `Response::empty()?.with_status(204)` zwraca `Response`, więc owiń wynik w `Ok(...)`
+- `Headers::new()` nie wymaga `mut`
+
+## Frontend
+
+- W Leptos 0.8 używaj `LocalResource`, nie `Resource`, dla futures opartych o `gloo-net`
+- `LocalResource::get()` zwraca `Option<T>` bezpośrednio; typowy wzorzec to `if let Some(Ok(data)) = resource.get()`
+- HTTP przechodzi przez `HttpClient` z `crates/frontend/src/api/client.rs`
+- przy optymistycznych update'ach używaj snapshot + rollback
+
+## Shared Crate
+
+- `crates/shared` re-eksportuje moduły flat przez `lib.rs`; preferuj importy z `kartoteka_shared::*`
+- DTO są w `crates/shared/src/dto/`, modele w `crates/shared/src/models/`
+- logika dat powinna reuse'ować helpery z `crates/shared/src/date_utils.rs` i `crates/shared/src/validation.rs`
+
+## Validation / Helpers
+
+- przed dodaniem nowych helperów sprawdź istniejące w `crates/api/src/helpers.rs`
+- dla nullable string patchy reuse'uj istniejące konwersje do `JsValue` zamiast dopisywać kolejną lokalną wersję
+- dla ownership/list-item relacji preferuj helpery z `helpers.rs`, nie ad-hoc query w handlerach
+
+## Commands
+
+- lokalny smoke test API/shared: `cargo test -p kartoteka-api` i `cargo test -p kartoteka-shared`
+- gateway: `cd gateway && npm run typecheck`
+- pełniejszy lokalny check: `just ci`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1116,6 +1116,7 @@ dependencies = [
 name = "kartoteka-api"
 version = "0.4.1"
 dependencies = [
+ "chrono",
  "getrandom 0.2.17",
  "kartoteka-i18n",
  "kartoteka-logging",

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -22,6 +22,7 @@ sqlx-d1 = { version = "0.3", features = ["macros"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 uuid = { version = "1", features = ["v4", "js"] }
+chrono = { version = "0.4.44", default-features = false, features = ["alloc"] }
 
 [package.metadata.cargo-machete]
 # getrandom: required for nanoid WASM compat (features = ["js"]), not imported directly;

--- a/crates/api/src/error.rs
+++ b/crates/api/src/error.rs
@@ -1,11 +1,46 @@
 use kartoteka_shared::{ErrorResponse, ValidationFieldError};
 use worker::Response;
 
+fn fallback_message_for_code(code: &str) -> String {
+    let normalized = code.replace('_', " ");
+    let mut chars = normalized.chars();
+    let Some(first) = chars.next() else {
+        return "Request failed.".to_string();
+    };
+    let mut message = first.to_uppercase().collect::<String>();
+    message.push_str(chars.as_str());
+    if !message.ends_with('.') {
+        message.push('.');
+    }
+    message
+}
+
+fn default_message_for_code(code: &str) -> String {
+    match code {
+        "validation_failed" => "Validation failed.".to_string(),
+        "invalid_request_body" => "Invalid request body.".to_string(),
+        "invalid_config" => "Invalid configuration.".to_string(),
+        "invalid_locale" => "Invalid locale.".to_string(),
+        "list_not_found" => "List not found.".to_string(),
+        "item_not_found" => "Item not found.".to_string(),
+        "container_not_found" => "Container not found.".to_string(),
+        "tag_not_found" => "Tag not found.".to_string(),
+        "list_archived" => "List is archived.".to_string(),
+        "feature_required" => "Feature is not enabled.".to_string(),
+        "tag_self_parent" => "Tag cannot be its own parent.".to_string(),
+        "tag_cycle" => "Tag hierarchy would create a cycle.".to_string(),
+        "invalid_container_hierarchy" => "Invalid container hierarchy.".to_string(),
+        "invalid_container_move" => "Invalid container move.".to_string(),
+        "unauthorized" => "Unauthorized.".to_string(),
+        _ => fallback_message_for_code(code),
+    }
+}
+
 pub fn json_error(code: &str, status: u16) -> worker::Result<Response> {
     let body = ErrorResponse {
         code: Some(code.to_string()),
         status,
-        message: None,
+        message: Some(default_message_for_code(code)),
         fields: vec![],
     };
     Response::from_json(&body).map(|r| r.with_status(status))
@@ -22,4 +57,22 @@ pub fn validation_error(
         fields,
     };
     Response::from_json(&body).map(|r| r.with_status(422))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_code_gets_human_message() {
+        assert_eq!(
+            default_message_for_code("list_not_found"),
+            "List not found."
+        );
+    }
+
+    #[test]
+    fn unknown_code_is_humanized() {
+        assert_eq!(default_message_for_code("some_new_code"), "Some new code.");
+    }
 }

--- a/crates/api/src/error.rs
+++ b/crates/api/src/error.rs
@@ -1,10 +1,25 @@
-use kartoteka_shared::ErrorResponse;
+use kartoteka_shared::{ErrorResponse, ValidationFieldError};
 use worker::Response;
 
 pub fn json_error(code: &str, status: u16) -> worker::Result<Response> {
     let body = ErrorResponse {
         code: Some(code.to_string()),
         status,
+        message: None,
+        fields: vec![],
     };
     Response::from_json(&body).map(|r| r.with_status(status))
+}
+
+pub fn validation_error(
+    message: &str,
+    fields: Vec<ValidationFieldError>,
+) -> worker::Result<Response> {
+    let body = ErrorResponse {
+        code: Some("validation_failed".to_string()),
+        status: 422,
+        message: Some(message.to_string()),
+        fields,
+    };
+    Response::from_json(&body).map(|r| r.with_status(422))
 }

--- a/crates/api/src/handlers/containers.rs
+++ b/crates/api/src/handlers/containers.rs
@@ -195,7 +195,10 @@ pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
     tracing::Span::current().record("container_id", tracing::field::display(&id));
-    let body: UpdateContainerRequest = req.json().await?;
+    let body: UpdateContainerRequest = match parse_json_body(&mut req).await {
+        Ok(body) => body,
+        Err(resp) => return Ok(resp),
+    };
     let d1 = ctx.env.d1("DB")?;
 
     if !check_ownership(&d1, "containers", &id, &user_id).await? {
@@ -209,11 +212,11 @@ pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
             .await?;
     }
 
-    if let Some(description) = &body.description {
+    if let Some(desc_val) = nullable_string_patch_to_js(&body.description, true) {
         d1.prepare(
             "UPDATE containers SET description = ?1, updated_at = datetime('now') WHERE id = ?2",
         )
-        .bind(&[description.clone().into(), id.clone().into()])?
+        .bind(&[desc_val, id.clone().into()])?
         .run()
         .await?;
     }

--- a/crates/api/src/handlers/items.rs
+++ b/crates/api/src/handlers/items.rs
@@ -13,6 +13,8 @@ const DATE_ITEM_COLS: &str = "i.id, i.list_id, i.title, i.description, i.complet
     i.quantity, i.actual_quantity, i.unit, i.start_date, i.start_time, i.deadline, i.deadline_time, i.hard_deadline, \
     i.created_at, i.updated_at, l.name as list_name, l.list_type";
 
+const MAX_ITEM_TITLE_LENGTH: usize = 255;
+
 #[derive(Clone, Debug)]
 struct ItemTemporalState {
     start_date: Option<String>,
@@ -53,6 +55,37 @@ impl ItemTemporalState {
 }
 
 #[derive(Clone, Copy, Debug)]
+struct ItemQuantityState {
+    quantity: Option<i32>,
+    actual_quantity: Option<i32>,
+}
+
+impl ItemQuantityState {
+    fn from_create(body: &CreateItemRequest) -> Self {
+        Self {
+            quantity: body.quantity,
+            actual_quantity: body.quantity.map(|_| 0),
+        }
+    }
+
+    fn from_item(item: &Item) -> Self {
+        Self {
+            quantity: item.quantity,
+            actual_quantity: item.actual_quantity,
+        }
+    }
+
+    fn apply_update(&mut self, body: &UpdateItemRequest) {
+        if let Some(quantity) = body.quantity {
+            self.quantity = Some(quantity);
+        }
+        if let Some(actual_quantity) = body.actual_quantity {
+            self.actual_quantity = Some(actual_quantity);
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
 enum DateFieldSelector {
     All,
     One(DateField),
@@ -82,9 +115,35 @@ fn normalize_title(
     if trimmed.is_empty() {
         errors.push(validation_field(field, "required"));
         None
+    } else if trimmed.chars().count() > MAX_ITEM_TITLE_LENGTH {
+        errors.push(validation_field(field, "too_long"));
+        None
     } else {
         Some(trimmed.to_string())
     }
+}
+
+fn validate_item_quantity_state(state: &ItemQuantityState, errors: &mut Vec<ValidationFieldError>) {
+    if state.quantity.is_some_and(|quantity| quantity <= 0) {
+        errors.push(validation_field("quantity", "must_be_positive"));
+    }
+    if state
+        .actual_quantity
+        .is_some_and(|actual_quantity| actual_quantity < 0)
+    {
+        errors.push(validation_field("actual_quantity", "must_be_non_negative"));
+    }
+}
+
+fn derive_completed_from_quantity_state(state: &ItemQuantityState) -> bool {
+    match (state.quantity, state.actual_quantity) {
+        (Some(quantity), Some(actual_quantity)) => actual_quantity >= quantity,
+        _ => false,
+    }
+}
+
+fn list_archived_response() -> worker::Result<Response> {
+    json_error("list_archived", 409)
 }
 
 fn validate_date_field(
@@ -170,6 +229,17 @@ fn parse_date_field_selector(date_field: &str) -> std::result::Result<DateFieldS
         )
         .expect("build 422 response")),
     }
+}
+
+fn query_param_with_alias(url: &Url, primary: &str, alias: Option<&str>) -> Option<String> {
+    if let Some((_, value)) = url.query_pairs().find(|(k, _)| k == primary) {
+        return Some(value.to_string());
+    }
+
+    let alias_key = alias?;
+    url.query_pairs()
+        .find(|(k, _)| k == alias_key)
+        .map(|(_, value)| value.to_string())
 }
 
 fn parse_required_query_date(
@@ -298,7 +368,10 @@ pub async fn get_one(_req: Request, ctx: RouteContext<String>) -> Result<Respons
     let id = require_param(&ctx, "id")?;
     let d1 = ctx.env.d1("DB")?;
 
-    if !check_item_ownership(&d1, &id, &user_id).await? {
+    if get_owned_item_state_in_list(&d1, &id, &list_id, &user_id)
+        .await?
+        .is_none()
+    {
         return json_error("item_not_found", 404);
     }
 
@@ -310,8 +383,10 @@ pub async fn get_one(_req: Request, ctx: RouteContext<String>) -> Result<Respons
         .prepare(&query)
         .bind(&[id.into(), list_id.clone().into()])?
         .first::<Item>(None)
-        .await?
-        .ok_or_else(|| Error::from("Not found"))?;
+        .await?;
+    let Some(item) = item else {
+        return json_error("item_not_found", 404);
+    };
 
     // Fetch list name + features for the combined response (saves a round-trip from the client)
     #[derive(serde::Deserialize)]
@@ -351,8 +426,11 @@ pub async fn create(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
 
     let d1 = ctx.env.d1("DB")?;
 
-    if !check_ownership(&d1, "lists", &list_id, &user_id).await? {
+    let Some(list_state) = get_owned_list_state(&d1, &list_id, &user_id).await? else {
         return json_error("list_not_found", 404);
+    };
+    if list_state.archived {
+        return list_archived_response();
     }
 
     let position = next_position(&d1, "items", "list_id = ?1", &[list_id.clone().into()]).await?;
@@ -373,6 +451,8 @@ pub async fn create(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
 
     let mut validation_errors =
         validate_item_temporal_state(&ItemTemporalState::from_create(&body));
+    let quantity_state = ItemQuantityState::from_create(&body);
+    validate_item_quantity_state(&quantity_state, &mut validation_errors);
     let Some(title) = normalize_title(&body.title, "title", &mut validation_errors) else {
         return validation_error("Invalid item payload.", validation_errors);
     };
@@ -385,9 +465,14 @@ pub async fn create(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
         Some(q) => q.into(),
         None => JsValue::NULL,
     };
-    let actual_quantity_val: JsValue = match body.quantity {
-        Some(_) => 0i32.into(),
+    let actual_quantity_val: JsValue = match quantity_state.actual_quantity {
+        Some(actual_quantity) => actual_quantity.into(),
         None => JsValue::NULL,
+    };
+    let completed_val: i32 = if derive_completed_from_quantity_state(&quantity_state) {
+        1
+    } else {
+        0
     };
     let unit_val = opt_str_to_js(&body.unit);
     let start_date_val = opt_str_to_js(&body.start_date);
@@ -397,14 +482,15 @@ pub async fn create(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
     let hard_deadline_val = opt_str_to_js(&body.hard_deadline);
 
     d1.prepare(
-        "INSERT INTO items (id, list_id, title, description, position, quantity, actual_quantity, unit, start_date, start_time, deadline, deadline_time, hard_deadline) \
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+        "INSERT INTO items (id, list_id, title, description, completed, position, quantity, actual_quantity, unit, start_date, start_time, deadline, deadline_time, hard_deadline) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
     )
     .bind(&[
         id.clone().into(),
         list_id.into(),
         title.into(),
         desc_val,
+        completed_val.into(),
         position.into(),
         quantity_val,
         actual_quantity_val,
@@ -429,16 +515,6 @@ pub async fn create(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
     let mut resp = Response::from_json(&item)?;
     resp = resp.with_status(201);
     Ok(resp)
-}
-
-/// Helper to handle Option<Option<String>> date fields in update:
-/// None = don't change, Some(None) = set NULL, Some(Some(v)) = set value
-fn update_nullable_str(outer: &Option<Option<String>>) -> Option<JsValue> {
-    match outer {
-        None => None, // don't change
-        Some(None) => Some(JsValue::NULL),
-        Some(Some(s)) => Some(JsValue::from(s.as_str())),
-    }
 }
 
 fn check_item_features(
@@ -472,6 +548,7 @@ fn check_item_features(
 #[instrument(skip_all, fields(action = "update_item", item_id = tracing::field::Empty))]
 pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
+    let list_id = require_param(&ctx, "list_id")?;
     let id = require_param(&ctx, "id")?;
     tracing::Span::current().record("item_id", tracing::field::display(&id));
     let body: UpdateItemRequest = match parse_json_body(&mut req).await {
@@ -480,12 +557,15 @@ pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
     };
     let d1 = ctx.env.d1("DB")?;
 
-    let list_id_for_features = match check_item_ownership_with_list(&d1, &id, &user_id).await? {
-        Some(lid) => lid,
+    let item_state = match get_owned_item_state_in_list(&d1, &id, &list_id, &user_id).await? {
+        Some(item_state) => item_state,
         None => return json_error("item_not_found", 404),
     };
+    if item_state.list_archived {
+        return list_archived_response();
+    }
 
-    let feature_names = get_list_features(&d1, &list_id_for_features).await?;
+    let feature_names = get_list_features(&d1, &item_state.list_id).await?;
 
     let has_date_field = matches!(&body.start_date, Some(Some(_)))
         || matches!(&body.deadline, Some(Some(_)))
@@ -509,7 +589,10 @@ pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
 
     let mut next_temporal_state = ItemTemporalState::from_item(&current_item);
     next_temporal_state.apply_update(&body);
+    let mut next_quantity_state = ItemQuantityState::from_item(&current_item);
+    next_quantity_state.apply_update(&body);
     let mut validation_errors = validate_item_temporal_state(&next_temporal_state);
+    validate_item_quantity_state(&next_quantity_state, &mut validation_errors);
     let normalized_title = body
         .title
         .as_deref()
@@ -525,13 +608,7 @@ pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
             .await?;
     }
 
-    if let Some(description) = &body.description {
-        // Empty string is the sentinel for "clear description" (set NULL in DB).
-        let desc_val: JsValue = if description.is_empty() {
-            JsValue::NULL
-        } else {
-            description.clone().into()
-        };
+    if let Some(desc_val) = nullable_string_patch_to_js(&body.description, true) {
         d1.prepare("UPDATE items SET description = ?1, updated_at = datetime('now') WHERE id = ?2")
             .bind(&[desc_val, id.clone().into()])?
             .run()
@@ -553,6 +630,8 @@ pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
             .await?;
     }
 
+    let quantity_changed = body.quantity.is_some() || body.actual_quantity.is_some();
+
     if let Some(quantity) = body.quantity {
         d1.prepare("UPDATE items SET quantity = ?1, updated_at = datetime('now') WHERE id = ?2")
             .bind(&[JsValue::from(quantity), id.clone().into()])?
@@ -567,29 +646,11 @@ pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
         .bind(&[JsValue::from(actual), id.clone().into()])?
         .run()
         .await?;
-
-        // Auto-complete: check if actual >= target
-        let row = d1
-            .prepare("SELECT quantity FROM items WHERE id = ?1")
-            .bind(&[id.clone().into()])?
-            .first::<serde_json::Value>(None)
-            .await?;
-        if let Some(row) = row {
-            if let Some(target) = row.get("quantity").and_then(|v| v.as_i64()) {
-                let completed_val: i32 = if (actual as i64) >= target { 1 } else { 0 };
-                d1.prepare(
-                    "UPDATE items SET completed = ?1, updated_at = datetime('now') WHERE id = ?2",
-                )
-                .bind(&[JsValue::from(completed_val), id.clone().into()])?
-                .run()
-                .await?;
-            }
-        }
     }
 
-    if let Some(unit) = &body.unit {
+    if let Some(unit_val) = nullable_string_patch_to_js(&body.unit, false) {
         d1.prepare("UPDATE items SET unit = ?1, updated_at = datetime('now') WHERE id = ?2")
-            .bind(&[JsValue::from(unit.as_str()), id.clone().into()])?
+            .bind(&[unit_val, id.clone().into()])?
             .run()
             .await?;
     }
@@ -604,7 +665,7 @@ pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
     ];
 
     for (col, field) in &date_updates {
-        if let Some(js_val) = update_nullable_str(field) {
+        if let Some(js_val) = nullable_string_patch_to_js(field, false) {
             let sql = format!(
                 "UPDATE items SET {} = ?1, updated_at = datetime('now') WHERE id = ?2",
                 col
@@ -614,6 +675,18 @@ pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
                 .run()
                 .await?;
         }
+    }
+
+    if quantity_changed {
+        let completed_val: i32 = if derive_completed_from_quantity_state(&next_quantity_state) {
+            1
+        } else {
+            0
+        };
+        d1.prepare("UPDATE items SET completed = ?1, updated_at = datetime('now') WHERE id = ?2")
+            .bind(&[completed_val.into(), id.clone().into()])?
+            .run()
+            .await?;
     }
 
     let select_query = format!("SELECT {} FROM items WHERE id = ?1", ITEM_COLS);
@@ -630,12 +703,17 @@ pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
 #[instrument(skip_all, fields(action = "delete_item", item_id = tracing::field::Empty))]
 pub async fn delete(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
+    let list_id = require_param(&ctx, "list_id")?;
     let id = require_param(&ctx, "id")?;
     tracing::Span::current().record("item_id", tracing::field::display(&id));
     let d1 = ctx.env.d1("DB")?;
 
-    if !check_item_ownership(&d1, &id, &user_id).await? {
-        return json_error("item_not_found", 404);
+    let item_state = match get_owned_item_state_in_list(&d1, &id, &list_id, &user_id).await? {
+        Some(item_state) => item_state,
+        None => return json_error("item_not_found", 404),
+    };
+    if item_state.list_archived {
+        return list_archived_response();
     }
 
     d1.prepare("DELETE FROM items WHERE id = ?1")
@@ -647,23 +725,35 @@ pub async fn delete(_req: Request, ctx: RouteContext<String>) -> Result<Response
 
 #[instrument(skip_all, fields(action = "move_item", item_id = tracing::field::Empty))]
 pub async fn move_item(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
+    #[derive(serde::Deserialize)]
+    struct MoveItemRequest {
+        target_list_id: String,
+    }
+
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
     tracing::Span::current().record("item_id", tracing::field::display(&id));
-    let body: serde_json::Value = req.json().await?;
-    let target_list_id = body
-        .get("target_list_id")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| Error::from("Missing target_list_id"))?
-        .to_string();
+    let body: MoveItemRequest = match parse_json_body(&mut req).await {
+        Ok(body) => body,
+        Err(resp) => return Ok(resp),
+    };
+    let target_list_id = body.target_list_id;
     let d1 = ctx.env.d1("DB")?;
 
-    if !check_item_ownership(&d1, &id, &user_id).await? {
-        return json_error("item_not_found", 404);
+    let source_item_state = match get_owned_item_state(&d1, &id, &user_id).await? {
+        Some(item_state) => item_state,
+        None => return json_error("item_not_found", 404),
+    };
+    if source_item_state.list_archived {
+        return list_archived_response();
     }
 
-    if !check_ownership(&d1, "lists", &target_list_id, &user_id).await? {
+    let Some(target_list_state) = get_owned_list_state(&d1, &target_list_id, &user_id).await?
+    else {
         return json_error("list_not_found", 404);
+    };
+    if target_list_state.archived {
+        return list_archived_response();
     }
 
     let position = next_position(
@@ -698,12 +788,7 @@ pub async fn by_date(req: Request, ctx: RouteContext<String>) -> Result<Response
     let user_id = ctx.data.clone();
     let url = req.url()?;
 
-    let date = match parse_required_query_date(
-        "date",
-        url.query_pairs()
-            .find(|(k, _)| k == "date")
-            .map(|(_, v)| v.to_string()),
-    ) {
+    let date = match parse_required_query_date("date", query_param_with_alias(&url, "date", None)) {
         Ok(date) => date,
         Err(resp) => return Ok(resp),
     };
@@ -714,10 +799,7 @@ pub async fn by_date(req: Request, ctx: RouteContext<String>) -> Result<Response
         .map(|(_, v)| v != "false")
         .unwrap_or(true);
 
-    let date_field_raw = url
-        .query_pairs()
-        .find(|(k, _)| k == "date_field")
-        .map(|(_, v)| v.to_string())
+    let date_field_raw = query_param_with_alias(&url, "date_field", Some("field"))
         .unwrap_or_else(|| "deadline".to_string());
     let selector = match parse_date_field_selector(&date_field_raw) {
         Ok(selector) => selector,
@@ -730,19 +812,21 @@ pub async fn by_date(req: Request, ctx: RouteContext<String>) -> Result<Response
     if matches!(selector, DateFieldSelector::All) {
         // UNION ALL across all three date fields
         let sql = format!(
-            "SELECT {cols}, 'start' as date_type \
-             FROM items i JOIN lists l ON l.id = i.list_id \
-             WHERE l.user_id = ?1 AND l.archived = 0 AND i.start_date = ?2 \
-             UNION ALL \
-             SELECT {cols}, 'deadline' as date_type \
-             FROM items i JOIN lists l ON l.id = i.list_id \
-             WHERE l.user_id = ?1 AND l.archived = 0 \
-             AND (i.deadline = ?2{overdue}) \
-             UNION ALL \
-             SELECT {cols}, 'hard_deadline' as date_type \
-             FROM items i JOIN lists l ON l.id = i.list_id \
-             WHERE l.user_id = ?1 AND l.archived = 0 AND i.hard_deadline = ?2 \
-             ORDER BY completed ASC, list_name ASC, deadline_time ASC, position ASC",
+            "SELECT * FROM ( \
+                SELECT {cols}, 'start_date' as date_type, i.completed as sort_completed, l.name as sort_list_name, COALESCE(i.start_time, '') as sort_time, i.position as sort_position \
+                FROM items i JOIN lists l ON l.id = i.list_id \
+                WHERE l.user_id = ?1 AND l.archived = 0 AND i.start_date = ?2 \
+                UNION ALL \
+                SELECT {cols}, 'deadline' as date_type, i.completed as sort_completed, l.name as sort_list_name, COALESCE(i.deadline_time, '') as sort_time, i.position as sort_position \
+                FROM items i JOIN lists l ON l.id = i.list_id \
+                WHERE l.user_id = ?1 AND l.archived = 0 \
+                AND (i.deadline = ?2{overdue}) \
+                UNION ALL \
+                SELECT {cols}, 'hard_deadline' as date_type, i.completed as sort_completed, l.name as sort_list_name, '' as sort_time, i.position as sort_position \
+                FROM items i JOIN lists l ON l.id = i.list_id \
+                WHERE l.user_id = ?1 AND l.archived = 0 AND i.hard_deadline = ?2 \
+             ) \
+             ORDER BY sort_completed ASC, sort_list_name ASC, sort_time ASC, sort_position ASC",
             cols = DATE_ITEM_COLS,
             overdue = if include_overdue {
                 " OR (i.deadline < ?2 AND i.completed = 0)"
@@ -763,29 +847,32 @@ pub async fn by_date(req: Request, ctx: RouteContext<String>) -> Result<Response
         Response::from_json(&items)
     } else {
         // Single date field query
-        let col = match selector {
-            DateFieldSelector::One(field) => field.column_name(),
+        let field = match selector {
+            DateFieldSelector::One(field) => field,
             DateFieldSelector::All => unreachable!("handled above"),
         };
+        let col = field.column_name();
 
         let sql = if include_overdue {
             format!(
-                "SELECT {cols}, NULL as date_type \
+                "SELECT {cols}, '{label}' as date_type \
                  FROM items i JOIN lists l ON l.id = i.list_id \
                  WHERE l.user_id = ?1 AND l.archived = 0 \
                  AND ({col} = ?2 OR ({col} < ?2 AND i.completed = 0)) \
                  ORDER BY i.completed ASC, {col} ASC, l.name ASC, i.deadline_time ASC, i.position ASC",
                 cols = DATE_ITEM_COLS,
                 col = col,
+                label = field.label(),
             )
         } else {
             format!(
-                "SELECT {cols}, NULL as date_type \
+                "SELECT {cols}, '{label}' as date_type \
                  FROM items i JOIN lists l ON l.id = i.list_id \
                  WHERE l.user_id = ?1 AND l.archived = 0 AND {col} = ?2 \
                  ORDER BY i.completed ASC, l.name ASC, i.deadline_time ASC, i.position ASC",
                 cols = DATE_ITEM_COLS,
                 col = col,
+                label = field.label(),
             )
         };
 
@@ -809,22 +896,12 @@ pub async fn calendar(req: Request, ctx: RouteContext<String>) -> Result<Respons
     let user_id = ctx.data.clone();
     let url = req.url()?;
 
-    let from = match parse_required_query_date(
-        "from",
-        url.query_pairs()
-            .find(|(k, _)| k == "from")
-            .map(|(_, v)| v.to_string()),
-    ) {
+    let from = match parse_required_query_date("from", query_param_with_alias(&url, "from", None)) {
         Ok(from) => from,
         Err(resp) => return Ok(resp),
     };
 
-    let to = match parse_required_query_date(
-        "to",
-        url.query_pairs()
-            .find(|(k, _)| k == "to")
-            .map(|(_, v)| v.to_string()),
-    ) {
+    let to = match parse_required_query_date("to", query_param_with_alias(&url, "to", None)) {
         Ok(to) => to,
         Err(resp) => return Ok(resp),
     };
@@ -835,10 +912,7 @@ pub async fn calendar(req: Request, ctx: RouteContext<String>) -> Result<Respons
         );
     }
 
-    let detail = url
-        .query_pairs()
-        .find(|(k, _)| k == "detail")
-        .map(|(_, v)| v.to_string())
+    let detail = query_param_with_alias(&url, "detail", Some("mode"))
         .unwrap_or_else(|| "counts".to_string());
     if detail != "counts" && detail != "full" {
         return validation_error(
@@ -847,10 +921,7 @@ pub async fn calendar(req: Request, ctx: RouteContext<String>) -> Result<Respons
         );
     }
 
-    let date_field_raw = url
-        .query_pairs()
-        .find(|(k, _)| k == "date_field")
-        .map(|(_, v)| v.to_string())
+    let date_field_raw = query_param_with_alias(&url, "date_field", Some("field"))
         .unwrap_or_else(|| "deadline".to_string());
     let selector = match parse_date_field_selector(&date_field_raw) {
         Ok(selector) => selector,
@@ -864,18 +935,20 @@ pub async fn calendar(req: Request, ctx: RouteContext<String>) -> Result<Respons
     if detail == "full" {
         if matches!(selector, DateFieldSelector::All) {
             let sql = format!(
-                "SELECT {cols}, 'start' as date_type \
-                 FROM items i JOIN lists l ON l.id = i.list_id \
-                 WHERE l.user_id = ?1 AND l.archived = 0 AND i.start_date >= ?2 AND i.start_date <= ?3 \
-                 UNION ALL \
-                 SELECT {cols}, 'deadline' as date_type \
-                 FROM items i JOIN lists l ON l.id = i.list_id \
-                 WHERE l.user_id = ?1 AND l.archived = 0 AND i.deadline >= ?2 AND i.deadline <= ?3 \
-                 UNION ALL \
-                 SELECT {cols}, 'hard_deadline' as date_type \
-                 FROM items i JOIN lists l ON l.id = i.list_id \
-                 WHERE l.user_id = ?1 AND l.archived = 0 AND i.hard_deadline >= ?2 AND i.hard_deadline <= ?3 \
-                 ORDER BY completed ASC, list_name ASC, deadline_time ASC, position ASC",
+                "SELECT * FROM ( \
+                    SELECT {cols}, 'start_date' as date_type, i.start_date as sort_date, i.completed as sort_completed, l.name as sort_list_name, COALESCE(i.start_time, '') as sort_time, i.position as sort_position \
+                    FROM items i JOIN lists l ON l.id = i.list_id \
+                    WHERE l.user_id = ?1 AND l.archived = 0 AND i.start_date >= ?2 AND i.start_date <= ?3 \
+                    UNION ALL \
+                    SELECT {cols}, 'deadline' as date_type, i.deadline as sort_date, i.completed as sort_completed, l.name as sort_list_name, COALESCE(i.deadline_time, '') as sort_time, i.position as sort_position \
+                    FROM items i JOIN lists l ON l.id = i.list_id \
+                    WHERE l.user_id = ?1 AND l.archived = 0 AND i.deadline >= ?2 AND i.deadline <= ?3 \
+                    UNION ALL \
+                    SELECT {cols}, 'hard_deadline' as date_type, i.hard_deadline as sort_date, i.completed as sort_completed, l.name as sort_list_name, '' as sort_time, i.position as sort_position \
+                    FROM items i JOIN lists l ON l.id = i.list_id \
+                    WHERE l.user_id = ?1 AND l.archived = 0 AND i.hard_deadline >= ?2 AND i.hard_deadline <= ?3 \
+                 ) \
+                 ORDER BY sort_date ASC, sort_completed ASC, sort_list_name ASC, sort_time ASC, sort_position ASC",
                 cols = DATE_ITEM_COLS,
             );
             let result = d1
@@ -904,18 +977,20 @@ pub async fn calendar(req: Request, ctx: RouteContext<String>) -> Result<Respons
 
             Response::from_json(&day_items)
         } else {
-            let col = match selector {
-                DateFieldSelector::One(field) => field.column_name(),
+            let field = match selector {
+                DateFieldSelector::One(field) => field,
                 DateFieldSelector::All => unreachable!("handled above"),
             };
+            let col = field.column_name();
             let sql = format!(
-                "SELECT {cols}, NULL as date_type \
+                "SELECT {cols}, '{label}' as date_type \
                  FROM items i JOIN lists l ON l.id = i.list_id \
                  WHERE l.user_id = ?1 AND l.archived = 0 \
                  AND {col} >= ?2 AND {col} <= ?3 \
                  ORDER BY {col} ASC, i.completed ASC, l.name ASC, i.deadline_time ASC, i.position ASC",
                 cols = DATE_ITEM_COLS,
                 col = col,
+                label = field.label(),
             );
             let result = d1
                 .prepare(&sql)
@@ -989,5 +1064,56 @@ pub async fn calendar(req: Request, ctx: RouteContext<String>) -> Result<Respons
             let summaries = filter_day_summaries(result.results::<DaySummary>()?, from, to);
             Response::from_json(&summaries)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_title_rejects_titles_longer_than_255_chars() {
+        let title = "a".repeat(MAX_ITEM_TITLE_LENGTH + 1);
+        let mut errors = Vec::new();
+
+        let normalized = normalize_title(&title, "title", &mut errors);
+
+        assert!(normalized.is_none());
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].field, "title");
+        assert_eq!(errors[0].code, "too_long");
+    }
+
+    #[test]
+    fn quantity_validation_rejects_non_positive_quantity_and_negative_actual() {
+        let state = ItemQuantityState {
+            quantity: Some(0),
+            actual_quantity: Some(-1),
+        };
+        let mut errors = Vec::new();
+
+        validate_item_quantity_state(&state, &mut errors);
+
+        assert_eq!(errors.len(), 2);
+        assert_eq!(errors[0].field, "quantity");
+        assert_eq!(errors[0].code, "must_be_positive");
+        assert_eq!(errors[1].field, "actual_quantity");
+        assert_eq!(errors[1].code, "must_be_non_negative");
+    }
+
+    #[test]
+    fn derived_completion_uses_quantity_and_actual_quantity() {
+        assert!(!derive_completed_from_quantity_state(&ItemQuantityState {
+            quantity: Some(3),
+            actual_quantity: Some(2),
+        }));
+        assert!(derive_completed_from_quantity_state(&ItemQuantityState {
+            quantity: Some(3),
+            actual_quantity: Some(3),
+        }));
+        assert!(!derive_completed_from_quantity_state(&ItemQuantityState {
+            quantity: None,
+            actual_quantity: None,
+        }));
     }
 }

--- a/crates/api/src/handlers/items.rs
+++ b/crates/api/src/handlers/items.rs
@@ -1,4 +1,4 @@
-use crate::error::json_error;
+use crate::error::{json_error, validation_error};
 use crate::helpers::*;
 use kartoteka_shared::*;
 use tracing::instrument;
@@ -12,6 +12,265 @@ const ITEM_COLS: &str = "id, list_id, title, description, completed, position, q
 const DATE_ITEM_COLS: &str = "i.id, i.list_id, i.title, i.description, i.completed, i.position, \
     i.quantity, i.actual_quantity, i.unit, i.start_date, i.start_time, i.deadline, i.deadline_time, i.hard_deadline, \
     i.created_at, i.updated_at, l.name as list_name, l.list_type";
+
+#[derive(Clone, Debug)]
+struct ItemTemporalState {
+    start_date: Option<String>,
+    start_time: Option<String>,
+    deadline: Option<String>,
+    deadline_time: Option<String>,
+    hard_deadline: Option<String>,
+}
+
+impl ItemTemporalState {
+    fn from_create(body: &CreateItemRequest) -> Self {
+        Self {
+            start_date: body.start_date.clone(),
+            start_time: body.start_time.clone(),
+            deadline: body.deadline.clone(),
+            deadline_time: body.deadline_time.clone(),
+            hard_deadline: body.hard_deadline.clone(),
+        }
+    }
+
+    fn from_item(item: &Item) -> Self {
+        Self {
+            start_date: item.start_date.clone(),
+            start_time: item.start_time.clone(),
+            deadline: item.deadline.clone(),
+            deadline_time: item.deadline_time.clone(),
+            hard_deadline: item.hard_deadline.clone(),
+        }
+    }
+
+    fn apply_update(&mut self, body: &UpdateItemRequest) {
+        apply_patch_field(&mut self.start_date, &body.start_date);
+        apply_patch_field(&mut self.start_time, &body.start_time);
+        apply_patch_field(&mut self.deadline, &body.deadline);
+        apply_patch_field(&mut self.deadline_time, &body.deadline_time);
+        apply_patch_field(&mut self.hard_deadline, &body.hard_deadline);
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum DateFieldSelector {
+    All,
+    One(DateField),
+}
+
+fn apply_patch_field(target: &mut Option<String>, patch: &Option<Option<String>>) {
+    match patch {
+        Some(Some(value)) => *target = Some(value.clone()),
+        Some(None) => *target = None,
+        None => {}
+    }
+}
+
+fn validation_field(field: &str, code: &str) -> ValidationFieldError {
+    ValidationFieldError {
+        field: field.to_string(),
+        code: code.to_string(),
+    }
+}
+
+fn normalize_title(
+    title: &str,
+    field: &str,
+    errors: &mut Vec<ValidationFieldError>,
+) -> Option<String> {
+    let trimmed = title.trim();
+    if trimmed.is_empty() {
+        errors.push(validation_field(field, "required"));
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn validate_date_field(
+    field: &str,
+    value: Option<&str>,
+    errors: &mut Vec<ValidationFieldError>,
+) -> Option<chrono::NaiveDate> {
+    let value = value?;
+    match validate_business_date(value) {
+        Ok(date) => Some(date),
+        Err(DateValidationError::Invalid) => {
+            errors.push(validation_field(field, "invalid_date"));
+            None
+        }
+        Err(DateValidationError::OutOfRange) => {
+            errors.push(validation_field(field, "date_out_of_range"));
+            None
+        }
+    }
+}
+
+fn validate_time_field(
+    field: &str,
+    value: Option<&str>,
+    errors: &mut Vec<ValidationFieldError>,
+) -> bool {
+    let Some(value) = value else {
+        return true;
+    };
+    if validate_hhmm_time(value).is_ok() {
+        true
+    } else {
+        errors.push(validation_field(field, "invalid_time"));
+        false
+    }
+}
+
+fn validate_item_temporal_state(state: &ItemTemporalState) -> Vec<ValidationFieldError> {
+    let mut errors = Vec::new();
+    let start_date = validate_date_field("start_date", state.start_date.as_deref(), &mut errors);
+    let deadline = validate_date_field("deadline", state.deadline.as_deref(), &mut errors);
+    let hard_deadline =
+        validate_date_field("hard_deadline", state.hard_deadline.as_deref(), &mut errors);
+
+    let start_has_valid_time =
+        validate_time_field("start_time", state.start_time.as_deref(), &mut errors);
+    let deadline_has_valid_time =
+        validate_time_field("deadline_time", state.deadline_time.as_deref(), &mut errors);
+
+    if state.start_time.is_some() && state.start_date.is_none() && start_has_valid_time {
+        errors.push(validation_field("start_time", "time_requires_date"));
+    }
+    if state.deadline_time.is_some() && state.deadline.is_none() && deadline_has_valid_time {
+        errors.push(validation_field("deadline_time", "time_requires_date"));
+    }
+
+    if let (Some(start_date), Some(deadline)) = (start_date, deadline)
+        && start_date > deadline
+    {
+        errors.push(validation_field("start_date", "start_after_deadline"));
+    }
+    if let (Some(deadline), Some(hard_deadline)) = (deadline, hard_deadline)
+        && deadline > hard_deadline
+    {
+        errors.push(validation_field(
+            "hard_deadline",
+            "hard_deadline_before_deadline",
+        ));
+    }
+
+    errors
+}
+
+fn parse_date_field_selector(date_field: &str) -> std::result::Result<DateFieldSelector, Response> {
+    match date_field {
+        "all" => Ok(DateFieldSelector::All),
+        "start_date" => Ok(DateFieldSelector::One(DateField::StartDate)),
+        "deadline" => Ok(DateFieldSelector::One(DateField::Deadline)),
+        "hard_deadline" => Ok(DateFieldSelector::One(DateField::HardDeadline)),
+        _ => Err(validation_error(
+            "Invalid query parameters.",
+            vec![validation_field("date_field", "invalid_date_field")],
+        )
+        .expect("build 422 response")),
+    }
+}
+
+fn parse_required_query_date(
+    field: &str,
+    value: Option<String>,
+) -> std::result::Result<chrono::NaiveDate, Response> {
+    let Some(value) = value else {
+        return Err(validation_error(
+            "Invalid query parameters.",
+            vec![validation_field(field, "required")],
+        )
+        .expect("build 422 response"));
+    };
+
+    match validate_business_date(&value) {
+        Ok(date) => Ok(date),
+        Err(DateValidationError::Invalid) => Err(validation_error(
+            "Invalid query parameters.",
+            vec![validation_field(field, "invalid_date")],
+        )
+        .expect("build 422 response")),
+        Err(DateValidationError::OutOfRange) => Err(validation_error(
+            "Invalid query parameters.",
+            vec![validation_field(field, "date_out_of_range")],
+        )
+        .expect("build 422 response")),
+    }
+}
+
+fn relevant_date_for_item(item: &DateItem, selector: DateFieldSelector) -> Option<&str> {
+    match selector {
+        DateFieldSelector::All => match item.date_type.as_deref() {
+            Some("start") => item.start_date.as_deref(),
+            Some("hard_deadline") => item.hard_deadline.as_deref(),
+            Some("deadline") => item.deadline.as_deref(),
+            _ => None,
+        },
+        DateFieldSelector::One(DateField::StartDate) => item.start_date.as_deref(),
+        DateFieldSelector::One(DateField::Deadline) => item.deadline.as_deref(),
+        DateFieldSelector::One(DateField::HardDeadline) => item.hard_deadline.as_deref(),
+    }
+}
+
+fn keep_item_for_day(
+    item: &DateItem,
+    selector: DateFieldSelector,
+    target: chrono::NaiveDate,
+    include_overdue: bool,
+) -> bool {
+    let Some(date_value) = relevant_date_for_item(item, selector) else {
+        return false;
+    };
+    let Ok(item_date) = validate_business_date(date_value) else {
+        return false;
+    };
+
+    match selector {
+        DateFieldSelector::All => match item.date_type.as_deref() {
+            Some("deadline") => {
+                item_date == target || (include_overdue && item_date < target && !item.completed)
+            }
+            Some("start") | Some("hard_deadline") => item_date == target,
+            _ => false,
+        },
+        DateFieldSelector::One(_) => {
+            item_date == target || (include_overdue && item_date < target && !item.completed)
+        }
+    }
+}
+
+fn date_key_in_range(
+    item: &DateItem,
+    selector: DateFieldSelector,
+    from: chrono::NaiveDate,
+    to: chrono::NaiveDate,
+) -> Option<String> {
+    let date_value = relevant_date_for_item(item, selector)?;
+    let item_date = validate_business_date(date_value).ok()?;
+    if item_date < from || item_date > to {
+        return None;
+    }
+    Some(format_date(&item_date))
+}
+
+fn filter_day_summaries(
+    summaries: Vec<DaySummary>,
+    from: chrono::NaiveDate,
+    to: chrono::NaiveDate,
+) -> Vec<DaySummary> {
+    summaries
+        .into_iter()
+        .filter_map(|mut summary| {
+            let parsed = validate_business_date(&summary.date).ok()?;
+            if parsed < from || parsed > to {
+                return None;
+            }
+            summary.date = format_date(&parsed);
+            Some(summary)
+        })
+        .collect()
+}
 
 #[instrument(skip_all)]
 pub async fn list_all(_req: Request, ctx: RouteContext<String>) -> Result<Response> {
@@ -83,7 +342,10 @@ pub async fn get_one(_req: Request, ctx: RouteContext<String>) -> Result<Respons
 pub async fn create(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let list_id = require_param(&ctx, "list_id")?;
-    let body: CreateItemRequest = req.json().await?;
+    let body: CreateItemRequest = match parse_json_body(&mut req).await {
+        Ok(body) => body,
+        Err(resp) => return Ok(resp),
+    };
     let id = uuid::Uuid::new_v4().to_string();
     tracing::Span::current().record("item_id", tracing::field::display(&id));
 
@@ -109,6 +371,15 @@ pub async fn create(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
         return Ok(err_resp);
     }
 
+    let mut validation_errors =
+        validate_item_temporal_state(&ItemTemporalState::from_create(&body));
+    let Some(title) = normalize_title(&body.title, "title", &mut validation_errors) else {
+        return validation_error("Invalid item payload.", validation_errors);
+    };
+    if !validation_errors.is_empty() {
+        return validation_error("Invalid item payload.", validation_errors);
+    }
+
     let desc_val = opt_str_to_js(&body.description);
     let quantity_val: JsValue = match body.quantity {
         Some(q) => q.into(),
@@ -132,7 +403,7 @@ pub async fn create(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
     .bind(&[
         id.clone().into(),
         list_id.into(),
-        body.title.into(),
+        title.into(),
         desc_val,
         position.into(),
         quantity_val,
@@ -203,7 +474,10 @@ pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
     tracing::Span::current().record("item_id", tracing::field::display(&id));
-    let body: UpdateItemRequest = req.json().await?;
+    let body: UpdateItemRequest = match parse_json_body(&mut req).await {
+        Ok(body) => body,
+        Err(resp) => return Ok(resp),
+    };
     let d1 = ctx.env.d1("DB")?;
 
     let list_id_for_features = match check_item_ownership_with_list(&d1, &id, &user_id).await? {
@@ -226,9 +500,27 @@ pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
         return Ok(err_resp);
     }
 
-    if let Some(title) = &body.title {
+    let current_item = d1
+        .prepare(format!("SELECT {} FROM items WHERE id = ?1", ITEM_COLS))
+        .bind(&[id.clone().into()])?
+        .first::<Item>(None)
+        .await?
+        .ok_or_else(|| Error::from("Not found"))?;
+
+    let mut next_temporal_state = ItemTemporalState::from_item(&current_item);
+    next_temporal_state.apply_update(&body);
+    let mut validation_errors = validate_item_temporal_state(&next_temporal_state);
+    let normalized_title = body
+        .title
+        .as_deref()
+        .and_then(|title| normalize_title(title, "title", &mut validation_errors));
+    if !validation_errors.is_empty() {
+        return validation_error("Invalid item payload.", validation_errors);
+    }
+
+    if let Some(title) = normalized_title {
         d1.prepare("UPDATE items SET title = ?1, updated_at = datetime('now') WHERE id = ?2")
-            .bind(&[title.clone().into(), id.clone().into()])?
+            .bind(&[title.into(), id.clone().into()])?
             .run()
             .await?;
     }
@@ -406,11 +698,15 @@ pub async fn by_date(req: Request, ctx: RouteContext<String>) -> Result<Response
     let user_id = ctx.data.clone();
     let url = req.url()?;
 
-    let date = url
-        .query_pairs()
-        .find(|(k, _)| k == "date")
-        .map(|(_, v)| v.to_string())
-        .ok_or_else(|| Error::from("Missing date parameter"))?;
+    let date = match parse_required_query_date(
+        "date",
+        url.query_pairs()
+            .find(|(k, _)| k == "date")
+            .map(|(_, v)| v.to_string()),
+    ) {
+        Ok(date) => date,
+        Err(resp) => return Ok(resp),
+    };
 
     let include_overdue = url
         .query_pairs()
@@ -418,15 +714,20 @@ pub async fn by_date(req: Request, ctx: RouteContext<String>) -> Result<Response
         .map(|(_, v)| v != "false")
         .unwrap_or(true);
 
-    let date_field = url
+    let date_field_raw = url
         .query_pairs()
         .find(|(k, _)| k == "date_field")
         .map(|(_, v)| v.to_string())
         .unwrap_or_else(|| "deadline".to_string());
+    let selector = match parse_date_field_selector(&date_field_raw) {
+        Ok(selector) => selector,
+        Err(resp) => return Ok(resp),
+    };
 
     let d1 = ctx.env.d1("DB")?;
+    let date_str = format_date(&date);
 
-    if date_field == "all" {
+    if matches!(selector, DateFieldSelector::All) {
         // UNION ALL across all three date fields
         let sql = format!(
             "SELECT {cols}, 'start' as date_type \
@@ -451,17 +752,20 @@ pub async fn by_date(req: Request, ctx: RouteContext<String>) -> Result<Response
         );
         let result = d1
             .prepare(&sql)
-            .bind(&[user_id.into(), date.into()])?
+            .bind(&[user_id.into(), date_str.clone().into()])?
             .all()
             .await?;
-        let items = result.results::<DateItem>()?;
+        let items = result
+            .results::<DateItem>()?
+            .into_iter()
+            .filter(|item| keep_item_for_day(item, selector, date, include_overdue))
+            .collect::<Vec<_>>();
         Response::from_json(&items)
     } else {
         // Single date field query
-        let col = match date_field.as_str() {
-            "start_date" => "i.start_date",
-            "hard_deadline" => "i.hard_deadline",
-            _ => "i.deadline",
+        let col = match selector {
+            DateFieldSelector::One(field) => field.column_name(),
+            DateFieldSelector::All => unreachable!("handled above"),
         };
 
         let sql = if include_overdue {
@@ -487,10 +791,14 @@ pub async fn by_date(req: Request, ctx: RouteContext<String>) -> Result<Response
 
         let result = d1
             .prepare(&sql)
-            .bind(&[user_id.into(), date.into()])?
+            .bind(&[user_id.into(), date_str.into()])?
             .all()
             .await?;
-        let items = result.results::<DateItem>()?;
+        let items = result
+            .results::<DateItem>()?
+            .into_iter()
+            .filter(|item| keep_item_for_day(item, selector, date, include_overdue))
+            .collect::<Vec<_>>();
         Response::from_json(&items)
     }
 }
@@ -501,34 +809,60 @@ pub async fn calendar(req: Request, ctx: RouteContext<String>) -> Result<Respons
     let user_id = ctx.data.clone();
     let url = req.url()?;
 
-    let from = url
-        .query_pairs()
-        .find(|(k, _)| k == "from")
-        .map(|(_, v)| v.to_string())
-        .ok_or_else(|| Error::from("Missing from parameter"))?;
+    let from = match parse_required_query_date(
+        "from",
+        url.query_pairs()
+            .find(|(k, _)| k == "from")
+            .map(|(_, v)| v.to_string()),
+    ) {
+        Ok(from) => from,
+        Err(resp) => return Ok(resp),
+    };
 
-    let to = url
-        .query_pairs()
-        .find(|(k, _)| k == "to")
-        .map(|(_, v)| v.to_string())
-        .ok_or_else(|| Error::from("Missing to parameter"))?;
+    let to = match parse_required_query_date(
+        "to",
+        url.query_pairs()
+            .find(|(k, _)| k == "to")
+            .map(|(_, v)| v.to_string()),
+    ) {
+        Ok(to) => to,
+        Err(resp) => return Ok(resp),
+    };
+    if from > to {
+        return validation_error(
+            "Invalid query parameters.",
+            vec![validation_field("from", "range_start_after_end")],
+        );
+    }
 
     let detail = url
         .query_pairs()
         .find(|(k, _)| k == "detail")
         .map(|(_, v)| v.to_string())
         .unwrap_or_else(|| "counts".to_string());
+    if detail != "counts" && detail != "full" {
+        return validation_error(
+            "Invalid query parameters.",
+            vec![validation_field("detail", "invalid_detail")],
+        );
+    }
 
-    let date_field = url
+    let date_field_raw = url
         .query_pairs()
         .find(|(k, _)| k == "date_field")
         .map(|(_, v)| v.to_string())
         .unwrap_or_else(|| "deadline".to_string());
+    let selector = match parse_date_field_selector(&date_field_raw) {
+        Ok(selector) => selector,
+        Err(resp) => return Ok(resp),
+    };
 
     let d1 = ctx.env.d1("DB")?;
+    let from_str = format_date(&from);
+    let to_str = format_date(&to);
 
     if detail == "full" {
-        if date_field == "all" {
+        if matches!(selector, DateFieldSelector::All) {
             let sql = format!(
                 "SELECT {cols}, 'start' as date_type \
                  FROM items i JOIN lists l ON l.id = i.list_id \
@@ -546,7 +880,11 @@ pub async fn calendar(req: Request, ctx: RouteContext<String>) -> Result<Respons
             );
             let result = d1
                 .prepare(&sql)
-                .bind(&[user_id.into(), from.into(), to.into()])?
+                .bind(&[
+                    user_id.into(),
+                    from_str.clone().into(),
+                    to_str.clone().into(),
+                ])?
                 .all()
                 .await?;
             let items = result.results::<DateItem>()?;
@@ -555,12 +893,9 @@ pub async fn calendar(req: Request, ctx: RouteContext<String>) -> Result<Respons
             let mut day_map: std::collections::BTreeMap<String, Vec<DateItem>> =
                 std::collections::BTreeMap::new();
             for item in items {
-                let date = match item.date_type.as_deref() {
-                    Some("start") => item.start_date.clone().unwrap_or_default(),
-                    Some("hard_deadline") => item.hard_deadline.clone().unwrap_or_default(),
-                    _ => item.deadline.clone().unwrap_or_default(),
-                };
-                day_map.entry(date).or_default().push(item);
+                if let Some(date_key) = date_key_in_range(&item, selector, from, to) {
+                    day_map.entry(date_key).or_default().push(item);
+                }
             }
             let day_items: Vec<DayItems> = day_map
                 .into_iter()
@@ -569,10 +904,9 @@ pub async fn calendar(req: Request, ctx: RouteContext<String>) -> Result<Respons
 
             Response::from_json(&day_items)
         } else {
-            let col = match date_field.as_str() {
-                "start_date" => "i.start_date",
-                "hard_deadline" => "i.hard_deadline",
-                _ => "i.deadline",
+            let col = match selector {
+                DateFieldSelector::One(field) => field.column_name(),
+                DateFieldSelector::All => unreachable!("handled above"),
             };
             let sql = format!(
                 "SELECT {cols}, NULL as date_type \
@@ -585,7 +919,11 @@ pub async fn calendar(req: Request, ctx: RouteContext<String>) -> Result<Respons
             );
             let result = d1
                 .prepare(&sql)
-                .bind(&[user_id.into(), from.into(), to.into()])?
+                .bind(&[
+                    user_id.into(),
+                    from_str.clone().into(),
+                    to_str.clone().into(),
+                ])?
                 .all()
                 .await?;
             let items = result.results::<DateItem>()?;
@@ -593,12 +931,9 @@ pub async fn calendar(req: Request, ctx: RouteContext<String>) -> Result<Respons
             let mut day_map: std::collections::BTreeMap<String, Vec<DateItem>> =
                 std::collections::BTreeMap::new();
             for item in items {
-                let date = match date_field.as_str() {
-                    "start_date" => item.start_date.clone().unwrap_or_default(),
-                    "hard_deadline" => item.hard_deadline.clone().unwrap_or_default(),
-                    _ => item.deadline.clone().unwrap_or_default(),
-                };
-                day_map.entry(date).or_default().push(item);
+                if let Some(date_key) = date_key_in_range(&item, selector, from, to) {
+                    day_map.entry(date_key).or_default().push(item);
+                }
             }
             let day_items: Vec<DayItems> = day_map
                 .into_iter()
@@ -609,7 +944,7 @@ pub async fn calendar(req: Request, ctx: RouteContext<String>) -> Result<Respons
         }
     } else {
         // Counts mode
-        if date_field == "all" {
+        if matches!(selector, DateFieldSelector::All) {
             let sql = "SELECT date, COUNT(DISTINCT id) as total, \
                  CAST(SUM(CASE WHEN completed = 1 THEN 1 ELSE 0 END) AS INTEGER) as completed \
                  FROM ( \
@@ -624,16 +959,15 @@ pub async fn calendar(req: Request, ctx: RouteContext<String>) -> Result<Respons
                  ) GROUP BY date ORDER BY date ASC";
             let result = d1
                 .prepare(sql)
-                .bind(&[user_id.into(), from.into(), to.into()])?
+                .bind(&[user_id.into(), from_str.into(), to_str.into()])?
                 .all()
                 .await?;
-            let summaries = result.results::<DaySummary>()?;
+            let summaries = filter_day_summaries(result.results::<DaySummary>()?, from, to);
             Response::from_json(&summaries)
         } else {
-            let col = match date_field.as_str() {
-                "start_date" => "i.start_date",
-                "hard_deadline" => "i.hard_deadline",
-                _ => "i.deadline",
+            let col = match selector {
+                DateFieldSelector::One(field) => field.column_name(),
+                DateFieldSelector::All => unreachable!("handled above"),
             };
             let sql = format!(
                 "SELECT {col} as date, \
@@ -649,10 +983,10 @@ pub async fn calendar(req: Request, ctx: RouteContext<String>) -> Result<Respons
             );
             let result = d1
                 .prepare(&sql)
-                .bind(&[user_id.into(), from.into(), to.into()])?
+                .bind(&[user_id.into(), from_str.into(), to_str.into()])?
                 .all()
                 .await?;
-            let summaries = result.results::<DaySummary>()?;
+            let summaries = filter_day_summaries(result.results::<DaySummary>()?, from, to);
             Response::from_json(&summaries)
         }
     }

--- a/crates/api/src/handlers/items.rs
+++ b/crates/api/src/handlers/items.rs
@@ -783,7 +783,7 @@ pub async fn move_item(mut req: Request, ctx: RouteContext<String>) -> Result<Re
 }
 
 /// GET /api/items/by-date?date=YYYY-MM-DD&date_field=deadline&include_overdue=true
-#[instrument(skip_all)]
+#[instrument(skip_all, fields(action = "list_items_by_date"))]
 pub async fn by_date(req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let url = req.url()?;
@@ -891,7 +891,7 @@ pub async fn by_date(req: Request, ctx: RouteContext<String>) -> Result<Response
 }
 
 /// GET /api/items/calendar?from=YYYY-MM-DD&to=YYYY-MM-DD&date_field=deadline&detail=counts|full
-#[instrument(skip_all)]
+#[instrument(skip_all, fields(action = "list_calendar"))]
 pub async fn calendar(req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
     let url = req.url()?;

--- a/crates/api/src/handlers/items.rs
+++ b/crates/api/src/handlers/items.rs
@@ -272,7 +272,7 @@ fn parse_required_query_date(
 fn relevant_date_for_item(item: &DateItem, selector: DateFieldSelector) -> Option<&str> {
     match selector {
         DateFieldSelector::All => match item.date_type.as_deref() {
-            Some("start") => item.start_date.as_deref(),
+            Some("start_date") => item.start_date.as_deref(),
             Some("hard_deadline") => item.hard_deadline.as_deref(),
             Some("deadline") => item.deadline.as_deref(),
             _ => None,
@@ -301,7 +301,7 @@ fn keep_item_for_day(
             Some("deadline") => {
                 item_date == target || (include_overdue && item_date < target && !item.completed)
             }
-            Some("start") | Some("hard_deadline") => item_date == target,
+            Some("start_date") | Some("hard_deadline") => item_date == target,
             _ => false,
         },
         DateFieldSelector::One(_) => {
@@ -1115,5 +1115,41 @@ mod tests {
             quantity: None,
             actual_quantity: None,
         }));
+    }
+
+    #[test]
+    fn all_selector_uses_start_date_date_type() {
+        let item = DateItem {
+            id: "item-1".into(),
+            list_id: "list-1".into(),
+            title: "Start item".into(),
+            description: None,
+            completed: false,
+            position: 0,
+            quantity: None,
+            actual_quantity: None,
+            unit: None,
+            start_date: Some("2026-04-12".into()),
+            start_time: Some("09:00".into()),
+            deadline: None,
+            deadline_time: None,
+            hard_deadline: None,
+            created_at: "2026-04-01T00:00:00Z".into(),
+            updated_at: "2026-04-01T00:00:00Z".into(),
+            list_name: "List".into(),
+            list_type: ListType::Checklist,
+            date_type: Some("start_date".into()),
+        };
+
+        assert_eq!(
+            relevant_date_for_item(&item, DateFieldSelector::All),
+            Some("2026-04-12")
+        );
+        assert!(keep_item_for_day(
+            &item,
+            DateFieldSelector::All,
+            chrono::NaiveDate::from_ymd_opt(2026, 4, 12).unwrap(),
+            true,
+        ));
     }
 }

--- a/crates/api/src/handlers/lists.rs
+++ b/crates/api/src/handlers/lists.rs
@@ -50,6 +50,14 @@ async fn list_has_sublists(d1: &D1Database, list_id: &str) -> Result<bool> {
         .is_some())
 }
 
+async fn touch_list_updated_at(d1: &D1Database, list_id: &str) -> Result<()> {
+    d1.prepare("UPDATE lists SET updated_at = datetime('now') WHERE id = ?1")
+        .bind(&[list_id.into()])?
+        .run()
+        .await?;
+    Ok(())
+}
+
 async fn fetch_lists_by_ids(
     d1: &D1Database,
     user_id: &str,
@@ -256,7 +264,10 @@ pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
     tracing::Span::current().record("list_id", tracing::field::display(&id));
-    let body: UpdateListRequest = req.json().await?;
+    let body: UpdateListRequest = match parse_json_body(&mut req).await {
+        Ok(body) => body,
+        Err(resp) => return Ok(resp),
+    };
     let d1 = ctx.env.d1("DB")?;
 
     if !check_ownership(&d1, "lists", &id, &user_id).await? {
@@ -270,9 +281,9 @@ pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
             .await?;
     }
 
-    if let Some(description) = &body.description {
+    if let Some(desc_val) = nullable_string_patch_to_js(&body.description, true) {
         d1.prepare("UPDATE lists SET description = ?1, updated_at = datetime('now') WHERE id = ?2")
-            .bind(&[description.clone().into(), id.clone().into()])?
+            .bind(&[desc_val, id.clone().into()])?
             .run()
             .await?;
     }
@@ -469,6 +480,7 @@ pub async fn add_feature(mut req: Request, ctx: RouteContext<String>) -> Result<
     ])?
     .run()
     .await?;
+    touch_list_updated_at(&d1, &list_id).await?;
 
     // Return updated list
     let list = d1
@@ -498,6 +510,7 @@ pub async fn remove_feature(_req: Request, ctx: RouteContext<String>) -> Result<
         .bind(&[list_id.clone().into(), feature_name.into()])?
         .run()
         .await?;
+    touch_list_updated_at(&d1, &list_id).await?;
 
     // Return updated list
     let list = d1

--- a/crates/api/src/handlers/tags.rs
+++ b/crates/api/src/handlers/tags.rs
@@ -5,6 +5,10 @@ use tracing::instrument;
 use wasm_bindgen::JsValue;
 use worker::*;
 
+const TAG_ITEM_COLS: &str = "i.id, i.list_id, i.title, i.description, i.completed, i.position, \
+    i.quantity, i.actual_quantity, i.unit, i.start_date, i.start_time, i.deadline, i.deadline_time, i.hard_deadline, \
+    i.created_at, i.updated_at, l.name as list_name, l.list_type";
+
 async fn apply_tag_links(
     d1: &D1Database,
     user_id: &str,
@@ -156,6 +160,7 @@ pub async fn create(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
     tracing::Span::current().record("tag_id", tracing::field::display(&id));
 
     let parent_val = opt_str_to_js(&body.parent_tag_id);
+    let color = body.color.unwrap_or_else(random_hex_color);
 
     let d1 = ctx.env.d1("DB")?;
     d1.prepare(
@@ -165,7 +170,7 @@ pub async fn create(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
         id.clone().into(),
         user_id.clone().into(),
         body.name.into(),
-        body.color.into(),
+        color.into(),
         parent_val,
     ])?
     .run()
@@ -476,40 +481,40 @@ pub async fn tag_items(req: Request, ctx: RouteContext<String>) -> Result<Respon
         .unwrap_or(true);
 
     let rows = if recursive {
-        d1.prepare(
+        let sql = format!(
             "WITH RECURSIVE tag_tree AS ( \
              SELECT id FROM tags WHERE id = ?1 AND user_id = ?2 \
              UNION ALL \
              SELECT t.id FROM tags t JOIN tag_tree tt ON t.parent_tag_id = tt.id WHERE t.user_id = ?2 \
              ) \
-             SELECT DISTINCT i.id, i.list_id, i.title, i.description, i.completed, i.position, \
-             i.quantity, i.actual_quantity, i.unit, i.start_date, i.start_time, i.deadline, i.deadline_time, i.hard_deadline, \
-             i.created_at, i.updated_at, l.name as list_name \
+             SELECT DISTINCT {cols}, NULL as date_type \
              FROM items i \
              JOIN item_tags it ON it.item_id = i.id \
              JOIN tag_tree tt ON it.tag_id = tt.id \
              JOIN lists l ON l.id = i.list_id \
-             ORDER BY l.name, i.position"
-        )
-        .bind(&[tag_id.into(), user_id.into()])?
-        .all()
-        .await?
-        .results::<serde_json::Value>()?
+             ORDER BY l.name, i.position",
+            cols = TAG_ITEM_COLS,
+        );
+        d1.prepare(&sql)
+            .bind(&[tag_id.into(), user_id.into()])?
+            .all()
+            .await?
+            .results::<DateItem>()?
     } else {
-        d1.prepare(
-            "SELECT i.id, i.list_id, i.title, i.description, i.completed, i.position, \
-             i.quantity, i.actual_quantity, i.unit, i.start_date, i.start_time, i.deadline, i.deadline_time, i.hard_deadline, \
-             i.created_at, i.updated_at, l.name as list_name \
+        let sql = format!(
+            "SELECT {cols}, NULL as date_type \
              FROM items i \
              JOIN item_tags it ON it.item_id = i.id \
              JOIN lists l ON l.id = i.list_id \
              WHERE it.tag_id = ?1 AND l.user_id = ?2 \
              ORDER BY l.name, i.position",
-        )
-        .bind(&[tag_id.into(), user_id.into()])?
-        .all()
-        .await?
-        .results::<serde_json::Value>()?
+            cols = TAG_ITEM_COLS,
+        );
+        d1.prepare(&sql)
+            .bind(&[tag_id.into(), user_id.into()])?
+            .all()
+            .await?
+            .results::<DateItem>()?
     };
 
     Response::from_json(&rows)

--- a/crates/api/src/handlers/tags.rs
+++ b/crates/api/src/handlers/tags.rs
@@ -148,7 +148,10 @@ pub async fn list_all(_req: Request, ctx: RouteContext<String>) -> Result<Respon
 #[instrument(skip_all, fields(action = "create_tag", tag_id = tracing::field::Empty))]
 pub async fn create(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
-    let body: CreateTagRequest = req.json().await?;
+    let body: CreateTagRequest = match parse_json_body(&mut req).await {
+        Ok(body) => body,
+        Err(resp) => return Ok(resp),
+    };
     let id = uuid::Uuid::new_v4().to_string();
     tracing::Span::current().record("tag_id", tracing::field::display(&id));
 
@@ -186,7 +189,10 @@ pub async fn update(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
     let user_id = ctx.data.clone();
     let id = require_param(&ctx, "id")?;
     tracing::Span::current().record("tag_id", tracing::field::display(&id));
-    let body: UpdateTagRequest = req.json().await?;
+    let body: UpdateTagRequest = match parse_json_body(&mut req).await {
+        Ok(body) => body,
+        Err(resp) => return Ok(resp),
+    };
     let d1 = ctx.env.d1("DB")?;
 
     if !check_ownership(&d1, "tags", &id, &user_id).await? {
@@ -417,7 +423,10 @@ pub async fn remove_from_list(_req: Request, ctx: RouteContext<String>) -> Resul
 )]
 pub async fn set_links(mut req: Request, ctx: RouteContext<String>) -> Result<Response> {
     let user_id = ctx.data.clone();
-    let body: SetTagLinksRequest = req.json().await?;
+    let body: SetTagLinksRequest = match parse_json_body(&mut req).await {
+        Ok(body) => body,
+        Err(resp) => return Ok(resp),
+    };
     tracing::Span::current().record("tag_count", body.tag_ids.len());
     tracing::Span::current().record(
         "target_count",

--- a/crates/api/src/helpers.rs
+++ b/crates/api/src/helpers.rs
@@ -1,3 +1,5 @@
+use crate::error::json_error;
+use serde::de::DeserializeOwned;
 use wasm_bindgen::JsValue;
 use worker::*;
 
@@ -178,6 +180,17 @@ pub fn require_param(ctx: &RouteContext<String>, name: &str) -> Result<String> {
     ctx.param(name)
         .ok_or_else(|| Error::from(format!("Missing {name}")))
         .map(|s| s.to_string())
+}
+
+pub async fn parse_json_body<T: DeserializeOwned>(
+    req: &mut Request,
+) -> std::result::Result<T, Response> {
+    let body = req
+        .text()
+        .await
+        .map_err(|_| json_error("invalid_request_body", 400).expect("build 400 response"))?;
+    serde_json::from_str::<T>(&body)
+        .map_err(|_| json_error("invalid_request_body", 400).expect("build 400 response"))
 }
 
 /// Fetch list feature names for a given list_id.

--- a/crates/api/src/helpers.rs
+++ b/crates/api/src/helpers.rs
@@ -3,6 +3,19 @@ use serde::de::DeserializeOwned;
 use wasm_bindgen::JsValue;
 use worker::*;
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OwnedListState {
+    pub id: String,
+    pub archived: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OwnedItemState {
+    pub id: String,
+    pub list_id: String,
+    pub list_archived: bool,
+}
+
 pub fn dedupe_ids(ids: &[String]) -> Vec<String> {
     let mut seen = std::collections::HashSet::new();
     ids.iter()
@@ -78,6 +91,28 @@ pub async fn check_ownership(
     Ok(check.is_some())
 }
 
+pub async fn get_owned_list_state(
+    d1: &D1Database,
+    list_id: &str,
+    user_id: &str,
+) -> Result<Option<OwnedListState>> {
+    let row = d1
+        .prepare("SELECT id, archived FROM lists WHERE id = ?1 AND user_id = ?2")
+        .bind(&[list_id.into(), user_id.into()])?
+        .first::<serde_json::Value>(None)
+        .await?;
+
+    Ok(row.and_then(|value| {
+        let id = value.get("id")?.as_str()?.to_string();
+        let archived = value
+            .get("archived")
+            .and_then(|v| v.as_f64())
+            .map(|f| f != 0.0)
+            .unwrap_or(false);
+        Some(OwnedListState { id, archived })
+    }))
+}
+
 /// Check if an item belongs to the user (via list join). Returns `true` if owned.
 pub async fn check_item_ownership(d1: &D1Database, item_id: &str, user_id: &str) -> Result<bool> {
     let check = d1
@@ -92,22 +127,46 @@ pub async fn check_item_ownership(d1: &D1Database, item_id: &str, user_id: &str)
     Ok(check.is_some())
 }
 
-/// Check item ownership and return its list_id. Returns `None` if not owned.
-pub async fn check_item_ownership_with_list(
+/// Check item ownership and return list metadata. Returns `None` if not owned.
+pub async fn get_owned_item_state(
     d1: &D1Database,
     item_id: &str,
     user_id: &str,
-) -> Result<Option<String>> {
+) -> Result<Option<OwnedItemState>> {
     let check = d1
         .prepare(
-            "SELECT items.id, items.list_id FROM items \
+            "SELECT items.id, items.list_id, lists.archived FROM items \
              JOIN lists ON lists.id = items.list_id \
              WHERE items.id = ?1 AND lists.user_id = ?2",
         )
         .bind(&[item_id.into(), user_id.into()])?
         .first::<serde_json::Value>(None)
         .await?;
-    Ok(check.and_then(|v| v.get("list_id")?.as_str().map(String::from)))
+    Ok(check.and_then(|v| {
+        let id = v.get("id")?.as_str()?.to_string();
+        let list_id = v.get("list_id")?.as_str()?.to_string();
+        let list_archived = v
+            .get("archived")
+            .and_then(|value| value.as_f64())
+            .map(|value| value != 0.0)
+            .unwrap_or(false);
+        Some(OwnedItemState {
+            id,
+            list_id,
+            list_archived,
+        })
+    }))
+}
+
+pub async fn get_owned_item_state_in_list(
+    d1: &D1Database,
+    item_id: &str,
+    list_id: &str,
+    user_id: &str,
+) -> Result<Option<OwnedItemState>> {
+    Ok(get_owned_item_state(d1, item_id, user_id)
+        .await?
+        .filter(|item| item.list_id == list_id))
 }
 
 /// Toggle a boolean field (D1 stores bools as 0/1 floats).
@@ -173,6 +232,26 @@ pub fn opt_str_to_js(opt: &Option<String>) -> JsValue {
         Some(s) => JsValue::from(s.as_str()),
         None => JsValue::NULL,
     }
+}
+
+/// Convert a tri-state nullable string patch into a DB value.
+/// None = don't change, Some(None) = set NULL, Some(Some(v)) = set value.
+/// When `empty_string_clears` is true, Some(Some("")) also maps to NULL.
+pub fn nullable_string_patch_to_js(
+    patch: &Option<Option<String>>,
+    empty_string_clears: bool,
+) -> Option<JsValue> {
+    match patch {
+        None => None,
+        Some(None) => Some(JsValue::NULL),
+        Some(Some(value)) if empty_string_clears && value.is_empty() => Some(JsValue::NULL),
+        Some(Some(value)) => Some(JsValue::from(value.as_str())),
+    }
+}
+
+pub fn random_hex_color() -> String {
+    let seed = uuid::Uuid::new_v4().simple().to_string();
+    format!("#{}", &seed[..6])
 }
 
 /// Extract a required route parameter or return an error.

--- a/crates/frontend/src/api/tags.rs
+++ b/crates/frontend/src/api/tags.rs
@@ -37,7 +37,7 @@ pub async fn fetch_tag_items(
     client: &impl super::HttpClient,
     tag_id: &str,
     recursive: bool,
-) -> Result<Vec<serde_json::Value>, super::ApiError> {
+) -> Result<Vec<DateItem>, super::ApiError> {
     let url = format!(
         "{}/tags/{tag_id}/items?recursive={recursive}",
         super::API_BASE

--- a/crates/frontend/src/components/items/item_actions.rs
+++ b/crates/frontend/src/components/items/item_actions.rs
@@ -100,7 +100,11 @@ pub fn create_item_actions(
         let client = client_desc.clone();
         leptos::task::spawn_local(async move {
             let req = UpdateItemRequest {
-                description: Some(new_desc), // empty string = clear (sentinel)
+                description: Some(if new_desc.is_empty() {
+                    None
+                } else {
+                    Some(new_desc)
+                }),
                 ..Default::default()
             };
             if api::update_item(&client, &lid, &item_id, &req)

--- a/crates/frontend/src/components/tags/tag_tree.rs
+++ b/crates/frontend/src/components/tags/tag_tree.rs
@@ -183,7 +183,7 @@ pub fn TagTreeRow(
                         leptos::task::spawn_local(async move {
                             let req = CreateTagRequest {
                                 name,
-                                color,
+                                color: Some(color),
                                 parent_tag_id: Some(parent_id),
                             };
                             if let Ok(tag) = api::create_tag(&client_c, &req).await {

--- a/crates/frontend/src/pages/container.rs
+++ b/crates/frontend/src/pages/container.rs
@@ -209,7 +209,7 @@ pub fn ContainerPage() -> impl IntoView {
                                     leptos::task::spawn_local(async move {
                                         let req = UpdateContainerRequest {
                                             name: None,
-                                            description: desc,
+                                            description: Some(desc),
                                             status: None,
                                         };
                                         let _ = api::update_container(&client, &cid, &req).await;

--- a/crates/frontend/src/pages/item_detail.rs
+++ b/crates/frontend/src/pages/item_detail.rs
@@ -157,7 +157,7 @@ pub fn ItemDetailPage() -> impl IntoView {
                                 />
                             </div>
 
-                            // Description — empty string is the sentinel for "clear"
+                            // Description — send explicit null to clear, keep string when set
                             <EditableDescription
                                 value=item.description.clone()
                                 on_save=Callback::new(move |new_desc: Option<String>| {
@@ -167,7 +167,7 @@ pub fn ItemDetailPage() -> impl IntoView {
                                         item_id(),
                                         toast.clone(),
                                         UpdateItemRequest {
-                                            description: Some(new_desc.unwrap_or_default()),
+                                            description: Some(new_desc),
                                             ..Default::default()
                                         },
                                     );

--- a/crates/frontend/src/pages/list/mod.rs
+++ b/crates/frontend/src/pages/list/mod.rs
@@ -329,7 +329,7 @@ pub fn ListPage() -> impl IntoView {
                         leptos::task::spawn_local(async move {
                             let req = UpdateListRequest {
                                 name: None,
-                                description: new_desc,
+                                description: Some(new_desc),
                                 list_type: None,
                                 archived: None,
                             };

--- a/crates/frontend/src/pages/tags/detail.rs
+++ b/crates/frontend/src/pages/tags/detail.rs
@@ -6,7 +6,7 @@ use crate::components::editable_title::EditableTitle;
 use crate::components::tag_tree::{
     TagTreeRow, build_breadcrumb, build_subtree, get_descendant_ids,
 };
-use kartoteka_shared::{Tag, UpdateTagRequest};
+use kartoteka_shared::{DateItem, Tag, UpdateTagRequest};
 use leptos::prelude::*;
 use leptos_fluent::move_tr;
 use leptos_router::components::A;
@@ -28,7 +28,7 @@ pub fn TagDetailPage() -> impl IntoView {
 
     let all_tags = RwSignal::new(Vec::<Tag>::new());
     let tag = RwSignal::new(Option::<Tag>::None);
-    let items = RwSignal::new(Vec::<serde_json::Value>::new());
+    let items = RwSignal::new(Vec::<DateItem>::new());
     let (loading, set_loading) = signal(true);
     let (recursive, set_recursive) = signal(true);
     let active_action = RwSignal::new(Option::<DetailAction>::None);
@@ -78,16 +78,14 @@ pub fn TagDetailPage() -> impl IntoView {
 
                         // Group items by list_name
                         let no_list_label = move_tr!("tags-no-list").get();
-                        let mut groups: BTreeMap<(String, String), Vec<serde_json::Value>> = BTreeMap::new();
+                        let mut groups: BTreeMap<(String, String), Vec<DateItem>> = BTreeMap::new();
                         for item in all_items {
-                            let list_name = item.get("list_name")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or(&no_list_label)
-                                .to_string();
-                            let list_id = item.get("list_id")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("")
-                                .to_string();
+                            let list_name = if item.list_name.is_empty() {
+                                no_list_label.clone()
+                            } else {
+                                item.list_name.clone()
+                            };
+                            let list_id = item.list_id.clone();
                             groups.entry((list_id, list_name)).or_default().push(item);
                         }
 
@@ -363,13 +361,8 @@ pub fn TagDetailPage() -> impl IntoView {
                                                             </A>
                                                         </h4>
                                                         {group_items.into_iter().map(|item| {
-                                                            let title = item.get("title")
-                                                                .and_then(|v| v.as_str())
-                                                                .unwrap_or("")
-                                                                .to_string();
-                                                            let completed = item.get("completed")
-                                                                .map(|v| v.as_f64().unwrap_or(0.0) != 0.0 || v.as_bool().unwrap_or(false))
-                                                                .unwrap_or(false);
+                                                            let title = item.title.clone();
+                                                            let completed = item.completed;
                                                             view! {
                                                                 <div class="flex items-center gap-2 py-1 pl-2">
                                                                     <span class=if completed { "text-base-content/40" } else { "" }>

--- a/crates/frontend/src/pages/tags/mod.rs
+++ b/crates/frontend/src/pages/tags/mod.rs
@@ -34,7 +34,7 @@ pub fn TagsPage() -> impl IntoView {
             leptos::task::spawn_local(async move {
                 let req = CreateTagRequest {
                     name,
-                    color,
+                    color: Some(color),
                     parent_tag_id: None,
                 };
                 if let Ok(tag) = api::create_tag(&client, &req).await {

--- a/crates/shared/src/deserializers.rs
+++ b/crates/shared/src/deserializers.rs
@@ -32,3 +32,11 @@ pub(crate) fn features_from_json<'de, D: Deserializer<'de>>(
 pub(crate) fn default_config() -> serde_json::Value {
     serde_json::json!({})
 }
+
+pub(crate) fn double_option<'de, T, D>(d: D) -> Result<Option<Option<T>>, D::Error>
+where
+    T: Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    Ok(Some(Option::<T>::deserialize(d)?))
+}

--- a/crates/shared/src/dto/requests.rs
+++ b/crates/shared/src/dto/requests.rs
@@ -1,4 +1,4 @@
-use crate::deserializers::default_config;
+use crate::deserializers::{default_config, double_option};
 use crate::models::{ContainerStatus, ListFeature, ListType};
 use serde::{Deserialize, Serialize};
 
@@ -13,6 +13,7 @@ pub struct CreateContainerRequest {
 pub struct UpdateContainerRequest {
     pub name: Option<String>,
     pub description: Option<String>,
+    #[serde(default, deserialize_with = "double_option")]
     pub status: Option<Option<ContainerStatus>>,
 }
 
@@ -99,10 +100,15 @@ pub struct UpdateItemRequest {
     pub quantity: Option<i32>,
     pub actual_quantity: Option<i32>,
     pub unit: Option<String>,
+    #[serde(default, deserialize_with = "double_option")]
     pub start_date: Option<Option<String>>,
+    #[serde(default, deserialize_with = "double_option")]
     pub start_time: Option<Option<String>>,
+    #[serde(default, deserialize_with = "double_option")]
     pub deadline: Option<Option<String>>,
+    #[serde(default, deserialize_with = "double_option")]
     pub deadline_time: Option<Option<String>>,
+    #[serde(default, deserialize_with = "double_option")]
     pub hard_deadline: Option<Option<String>>,
 }
 
@@ -117,6 +123,7 @@ pub struct CreateTagRequest {
 pub struct UpdateTagRequest {
     pub name: Option<String>,
     pub color: Option<String>,
+    #[serde(default, deserialize_with = "double_option")]
     pub parent_tag_id: Option<Option<String>>,
 }
 

--- a/crates/shared/src/dto/requests.rs
+++ b/crates/shared/src/dto/requests.rs
@@ -12,7 +12,8 @@ pub struct CreateContainerRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UpdateContainerRequest {
     pub name: Option<String>,
-    pub description: Option<String>,
+    #[serde(default, deserialize_with = "double_option")]
+    pub description: Option<Option<String>>,
     #[serde(default, deserialize_with = "double_option")]
     pub status: Option<Option<ContainerStatus>>,
 }
@@ -67,7 +68,8 @@ impl CreateListRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UpdateListRequest {
     pub name: Option<String>,
-    pub description: Option<String>,
+    #[serde(default, deserialize_with = "double_option")]
+    pub description: Option<Option<String>>,
     pub list_type: Option<ListType>,
     pub archived: Option<bool>,
 }
@@ -94,12 +96,14 @@ pub struct CreateItemRequest {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct UpdateItemRequest {
     pub title: Option<String>,
-    pub description: Option<String>,
+    #[serde(default, deserialize_with = "double_option")]
+    pub description: Option<Option<String>>,
     pub completed: Option<bool>,
     pub position: Option<i32>,
     pub quantity: Option<i32>,
     pub actual_quantity: Option<i32>,
-    pub unit: Option<String>,
+    #[serde(default, deserialize_with = "double_option")]
+    pub unit: Option<Option<String>>,
     #[serde(default, deserialize_with = "double_option")]
     pub start_date: Option<Option<String>>,
     #[serde(default, deserialize_with = "double_option")]
@@ -115,7 +119,7 @@ pub struct UpdateItemRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateTagRequest {
     pub name: String,
-    pub color: String,
+    pub color: Option<String>,
     pub parent_tag_id: Option<String>,
 }
 

--- a/crates/shared/src/dto/responses.rs
+++ b/crates/shared/src/dto/responses.rs
@@ -1,6 +1,12 @@
 use crate::models::{Container, Item, List, ListFeature};
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidationFieldError {
+    pub field: String,
+    pub code: String,
+}
+
 /// Response from GET /api/me
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MeResponse {
@@ -55,6 +61,10 @@ pub struct ErrorResponse {
     pub code: Option<String>,
     #[serde(default)]
     pub status: u16,
+    #[serde(default)]
+    pub message: Option<String>,
+    #[serde(default)]
+    pub fields: Vec<ValidationFieldError>,
 }
 
 /// Response from GET /api/home — matches actual API shape

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -3,12 +3,14 @@ pub mod date_utils;
 pub(crate) mod deserializers;
 pub mod dto;
 pub mod models;
+pub mod validation;
 
 // Flat re-exports for backward compatibility (no churn in crates/api imports)
 pub use constants::*;
 pub use date_utils::*;
 pub use dto::*;
 pub use models::*;
+pub use validation::*;
 
 #[cfg(test)]
 mod tests;

--- a/crates/shared/src/models/list.rs
+++ b/crates/shared/src/models/list.rs
@@ -62,7 +62,7 @@ impl DateField {
 
     pub fn label(&self) -> &'static str {
         match self {
-            Self::StartDate => "start",
+            Self::StartDate => "start_date",
             Self::Deadline => "deadline",
             Self::HardDeadline => "hard_deadline",
         }

--- a/crates/shared/src/models/list.rs
+++ b/crates/shared/src/models/list.rs
@@ -35,7 +35,7 @@ impl ListType {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum DateField {
     StartDate,

--- a/crates/shared/src/tests/containers.rs
+++ b/crates/shared/src/tests/containers.rs
@@ -18,3 +18,15 @@ fn container_status_serde() {
     let cs: ContainerStatus = serde_json::from_str(r#""paused""#).unwrap();
     assert_eq!(cs, ContainerStatus::Paused);
 }
+
+#[test]
+fn update_container_description_null_clears_field() {
+    let req: UpdateContainerRequest = serde_json::from_str(r#"{"description": null}"#).unwrap();
+    assert!(matches!(req.description, Some(None)));
+}
+
+#[test]
+fn update_container_description_value_is_some_some() {
+    let req: UpdateContainerRequest = serde_json::from_str(r#"{"description": "opis"}"#).unwrap();
+    assert!(matches!(req.description, Some(Some(ref d)) if d == "opis"));
+}

--- a/crates/shared/src/tests/items.rs
+++ b/crates/shared/src/tests/items.rs
@@ -11,11 +11,8 @@ fn update_item_absent_field_is_none() {
 
 #[test]
 fn update_item_null_field_is_none() {
-    // serde flattens Option<Option<String>> — null becomes None, same as absent.
-    // To distinguish "clear field" from "don't touch", the frontend must omit
-    // the key (don't touch) vs send null (currently also treated as don't touch).
     let req: UpdateItemRequest = serde_json::from_str(r#"{"deadline": null}"#).unwrap();
-    assert!(req.deadline.is_none());
+    assert!(matches!(req.deadline, Some(None)));
 }
 
 #[test]
@@ -35,8 +32,8 @@ fn update_item_description_absent_is_none() {
 
 #[test]
 fn update_item_description_empty_string_is_clear_sentinel() {
-    // Some("") = clear description (set NULL in DB). Empty string is the sentinel
-    // because serde cannot distinguish Option<Option<T>> null from absent.
+    // Some("") = clear description (set NULL in DB). This is kept for
+    // description even though date fields use explicit JSON null semantics.
     let req: UpdateItemRequest = serde_json::from_str(r#"{"description": ""}"#).unwrap();
     assert!(matches!(req.description, Some(ref d) if d.is_empty()));
 }
@@ -112,4 +109,42 @@ fn day_summary_deserialize() {
     let ds: DaySummary = serde_json::from_str(json).unwrap();
     assert_eq!(ds.total, 5);
     assert_eq!(ds.completed, 3);
+}
+
+#[test]
+fn validate_business_date_accepts_valid_date() {
+    let parsed = validate_business_date("2026-03-31").unwrap();
+    assert_eq!(format_date(&parsed), "2026-03-31");
+}
+
+#[test]
+fn validate_business_date_rejects_invalid_date() {
+    assert_eq!(
+        validate_business_date("2026-02-30"),
+        Err(DateValidationError::Invalid)
+    );
+}
+
+#[test]
+fn validate_business_date_rejects_out_of_range_year() {
+    assert_eq!(
+        validate_business_date("1900-01-01"),
+        Err(DateValidationError::OutOfRange)
+    );
+}
+
+#[test]
+fn validate_hhmm_time_rejects_seconds() {
+    assert_eq!(
+        validate_hhmm_time("14:30:00"),
+        Err(TimeValidationError::Invalid)
+    );
+}
+
+#[test]
+fn validate_hhmm_time_rejects_invalid_hour() {
+    assert_eq!(
+        validate_hhmm_time("25:61"),
+        Err(TimeValidationError::Invalid)
+    );
 }

--- a/crates/shared/src/tests/items.rs
+++ b/crates/shared/src/tests/items.rs
@@ -31,17 +31,39 @@ fn update_item_description_absent_is_none() {
 }
 
 #[test]
-fn update_item_description_empty_string_is_clear_sentinel() {
-    // Some("") = clear description (set NULL in DB). This is kept for
-    // description even though date fields use explicit JSON null semantics.
-    let req: UpdateItemRequest = serde_json::from_str(r#"{"description": ""}"#).unwrap();
-    assert!(matches!(req.description, Some(ref d) if d.is_empty()));
+fn update_item_description_null_clears_field() {
+    let req: UpdateItemRequest = serde_json::from_str(r#"{"description": null}"#).unwrap();
+    assert!(matches!(req.description, Some(None)));
 }
 
 #[test]
 fn update_item_description_value_is_some_string() {
     let req: UpdateItemRequest = serde_json::from_str(r#"{"description": "hello"}"#).unwrap();
-    assert!(matches!(req.description, Some(ref d) if d == "hello"));
+    assert!(matches!(req.description, Some(Some(ref d)) if d == "hello"));
+}
+
+#[test]
+fn update_item_description_empty_string_is_preserved() {
+    let req: UpdateItemRequest = serde_json::from_str(r#"{"description": ""}"#).unwrap();
+    assert!(matches!(req.description, Some(Some(ref d)) if d.is_empty()));
+}
+
+#[test]
+fn update_item_unit_absent_is_none() {
+    let req: UpdateItemRequest = serde_json::from_str(r#"{}"#).unwrap();
+    assert!(req.unit.is_none());
+}
+
+#[test]
+fn update_item_unit_null_clears_field() {
+    let req: UpdateItemRequest = serde_json::from_str(r#"{"unit": null}"#).unwrap();
+    assert!(matches!(req.unit, Some(None)));
+}
+
+#[test]
+fn update_item_unit_value_is_some_some() {
+    let req: UpdateItemRequest = serde_json::from_str(r#"{"unit": "kg"}"#).unwrap();
+    assert!(matches!(req.unit, Some(Some(ref unit)) if unit == "kg"));
 }
 
 // --- DateItem -> Item conversion ---
@@ -112,6 +134,33 @@ fn day_summary_deserialize() {
 }
 
 #[test]
+fn date_item_deserializes_numeric_completed_and_missing_date_type() {
+    let json = r#"{
+        "id": "abc",
+        "list_id": "l1",
+        "title": "Test",
+        "description": null,
+        "completed": 1,
+        "position": 0,
+        "quantity": null,
+        "actual_quantity": null,
+        "unit": null,
+        "start_date": null,
+        "start_time": null,
+        "deadline": null,
+        "deadline_time": null,
+        "hard_deadline": null,
+        "created_at": "2024-01-01",
+        "updated_at": "2024-01-01",
+        "list_name": "Lista",
+        "list_type": "checklist"
+    }"#;
+    let item: DateItem = serde_json::from_str(json).unwrap();
+    assert!(item.completed);
+    assert!(item.date_type.is_none());
+}
+
+#[test]
 fn validate_business_date_accepts_valid_date() {
     let parsed = validate_business_date("2026-03-31").unwrap();
     assert_eq!(format_date(&parsed), "2026-03-31");
@@ -147,4 +196,14 @@ fn validate_hhmm_time_rejects_invalid_hour() {
         validate_hhmm_time("25:61"),
         Err(TimeValidationError::Invalid)
     );
+}
+
+#[test]
+fn validate_hhmm_time_rejects_missing_zero_padding() {
+    assert_eq!(validate_hhmm_time("9:5"), Err(TimeValidationError::Invalid));
+}
+
+#[test]
+fn validate_hhmm_time_accepts_zero_padded_time() {
+    assert!(validate_hhmm_time("09:05").is_ok());
 }

--- a/crates/shared/src/tests/lists.rs
+++ b/crates/shared/src/tests/lists.rs
@@ -110,6 +110,18 @@ fn move_list_request_remove_from_container() {
 }
 
 #[test]
+fn update_list_description_null_clears_field() {
+    let req: UpdateListRequest = serde_json::from_str(r#"{"description": null}"#).unwrap();
+    assert!(matches!(req.description, Some(None)));
+}
+
+#[test]
+fn update_list_description_value_is_some_some() {
+    let req: UpdateListRequest = serde_json::from_str(r#"{"description": "opis"}"#).unwrap();
+    assert!(matches!(req.description, Some(Some(ref d)) if d == "opis"));
+}
+
+#[test]
 fn set_list_placement_request_validates_non_empty_ids() {
     let req = SetListPlacementRequest {
         list_ids: vec![],
@@ -226,7 +238,7 @@ fn date_field_time_columns() {
 
 #[test]
 fn date_field_labels() {
-    assert_eq!(DateField::StartDate.label(), "start");
+    assert_eq!(DateField::StartDate.label(), "start_date");
     assert_eq!(DateField::Deadline.label(), "deadline");
     assert_eq!(DateField::HardDeadline.label(), "hard_deadline");
 }

--- a/crates/shared/src/tests/mod.rs
+++ b/crates/shared/src/tests/mod.rs
@@ -2,3 +2,4 @@ mod containers;
 mod deserializers;
 mod items;
 mod lists;
+mod tags;

--- a/crates/shared/src/tests/tags.rs
+++ b/crates/shared/src/tests/tags.rs
@@ -1,0 +1,15 @@
+use crate::*;
+
+#[test]
+fn create_tag_request_accepts_missing_color() {
+    let req: CreateTagRequest = serde_json::from_str(r#"{"name": "Pilne"}"#).unwrap();
+    assert_eq!(req.name, "Pilne");
+    assert!(req.color.is_none());
+}
+
+#[test]
+fn create_tag_request_preserves_explicit_color() {
+    let req: CreateTagRequest =
+        serde_json::from_str(r##"{"name": "Pilne", "color": "#ff0000"}"##).unwrap();
+    assert_eq!(req.color.as_deref(), Some("#ff0000"));
+}

--- a/crates/shared/src/validation.rs
+++ b/crates/shared/src/validation.rs
@@ -1,0 +1,28 @@
+use chrono::{Datelike, NaiveDate, NaiveTime};
+
+pub const BUSINESS_DATE_MIN_YEAR: i32 = 2000;
+pub const BUSINESS_DATE_MAX_YEAR: i32 = 2100;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DateValidationError {
+    Invalid,
+    OutOfRange,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TimeValidationError {
+    Invalid,
+}
+
+pub fn validate_business_date(date_str: &str) -> Result<NaiveDate, DateValidationError> {
+    let date = NaiveDate::parse_from_str(date_str, "%Y-%m-%d")
+        .map_err(|_| DateValidationError::Invalid)?;
+    if !(BUSINESS_DATE_MIN_YEAR..=BUSINESS_DATE_MAX_YEAR).contains(&date.year()) {
+        return Err(DateValidationError::OutOfRange);
+    }
+    Ok(date)
+}
+
+pub fn validate_hhmm_time(time_str: &str) -> Result<NaiveTime, TimeValidationError> {
+    NaiveTime::parse_from_str(time_str, "%H:%M").map_err(|_| TimeValidationError::Invalid)
+}

--- a/crates/shared/src/validation.rs
+++ b/crates/shared/src/validation.rs
@@ -24,5 +24,15 @@ pub fn validate_business_date(date_str: &str) -> Result<NaiveDate, DateValidatio
 }
 
 pub fn validate_hhmm_time(time_str: &str) -> Result<NaiveTime, TimeValidationError> {
+    let bytes = time_str.as_bytes();
+    if bytes.len() != 5
+        || bytes[2] != b':'
+        || !bytes[0].is_ascii_digit()
+        || !bytes[1].is_ascii_digit()
+        || !bytes[3].is_ascii_digit()
+        || !bytes[4].is_ascii_digit()
+    {
+        return Err(TimeValidationError::Invalid);
+    }
     NaiveTime::parse_from_str(time_str, "%H:%M").map_err(|_| TimeValidationError::Invalid)
 }

--- a/gateway/src/mcp/tools/calendar.ts
+++ b/gateway/src/mcp/tools/calendar.ts
@@ -4,6 +4,13 @@ import type { ApiContext } from "../api";
 import { callTool } from "../api";
 import { tr } from "../i18n";
 
+function applyDateFieldParam(
+  params: URLSearchParams,
+  field?: "start_date" | "deadline" | "hard_deadline"
+): void {
+  params.set("date_field", field ?? "all");
+}
+
 export function registerCalendarTools(server: McpServer, api: ApiContext, locale: string): void {
   server.registerTool("get_calendar", {
     description: tr("tool-get-calendar", locale),
@@ -14,8 +21,8 @@ export function registerCalendarTools(server: McpServer, api: ApiContext, locale
       mode: z.enum(["counts", "full"]).default("full").describe("'counts' = day summaries, 'full' = complete items"),
     },
   }, ({ from, to, field, mode }) => {
-    const params = new URLSearchParams({ from, to, mode });
-    if (field) params.set("field", field);
+    const params = new URLSearchParams({ from, to, detail: mode });
+    applyDateFieldParam(params, field);
     return callTool(api, "GET", `/api/items/calendar?${params.toString()}`);
   });
 
@@ -28,7 +35,7 @@ export function registerCalendarTools(server: McpServer, api: ApiContext, locale
     },
   }, ({ date, field, include_overdue }) => {
     const params = new URLSearchParams({ date });
-    if (field) params.set("field", field);
+    applyDateFieldParam(params, field);
     if (include_overdue !== undefined) params.set("include_overdue", String(include_overdue));
     return callTool(api, "GET", `/api/items/by-date?${params.toString()}`);
   });

--- a/gateway/src/mcp/tools/items.ts
+++ b/gateway/src/mcp/tools/items.ts
@@ -4,6 +4,10 @@ import type { ApiContext } from "../api";
 import { callTool, apiCall, errorResult, jsonResult } from "../api";
 import { tr } from "../i18n";
 
+const itemTitleSchema = z.string().trim().min(1).max(255);
+const quantitySchema = z.number().int().positive();
+const actualQuantitySchema = z.number().int().nonnegative();
+
 export function registerItemTools(server: McpServer, api: ApiContext, locale: string): void {
   server.registerTool("get_list_items", {
     description: tr("tool-get-items", locale),
@@ -16,9 +20,9 @@ export function registerItemTools(server: McpServer, api: ApiContext, locale: st
     description: tr("tool-add-item", locale),
     inputSchema: {
       list_id: z.string().describe("The list ID"),
-      title: z.string().describe("Item title"),
+      title: itemTitleSchema.describe("Item title"),
       description: z.string().optional().describe("Item description"),
-      quantity: z.number().optional().describe("Target quantity"),
+      quantity: quantitySchema.optional().describe("Target quantity"),
       unit: z.string().optional().describe("Unit of measurement"),
       start_date: z.string().optional().describe("Start date YYYY-MM-DD"),
       start_time: z.string().optional().describe("Start time HH:MM"),
@@ -37,11 +41,11 @@ export function registerItemTools(server: McpServer, api: ApiContext, locale: st
     inputSchema: {
       list_id: z.string().describe("The list ID"),
       item_id: z.string().describe("The item ID"),
-      title: z.string().optional().describe("New title"),
+      title: itemTitleSchema.optional().describe("New title"),
       description: z.string().nullable().optional().describe("New description (null to clear)"),
       completed: z.boolean().optional().describe("Completion state"),
-      quantity: z.number().optional().describe("Target quantity"),
-      actual_quantity: z.number().optional().describe("Actual quantity (auto-completes when >= quantity)"),
+      quantity: quantitySchema.optional().describe("Target quantity"),
+      actual_quantity: actualQuantitySchema.optional().describe("Actual quantity (auto-completes when >= quantity)"),
       unit: z.string().nullable().optional().describe("Unit (null to clear)"),
       start_date: z.string().nullable().optional().describe("Start date YYYY-MM-DD (null to clear)"),
       start_time: z.string().nullable().optional().describe("Start time HH:MM (null to clear)"),
@@ -82,9 +86,10 @@ export function registerItemTools(server: McpServer, api: ApiContext, locale: st
   ): Promise<{ content: { type: "text"; text: string }[]; isError?: boolean }> {
     const res = await apiFn(fields);
     if (!res.ok) {
+      const raw = await res.text();
       if (res.status === 422) {
         let body: { error?: string; feature?: string; message?: string } = {};
-        try { body = await res.json(); } catch { /* ignore */ }
+        try { body = JSON.parse(raw) as typeof body; } catch { /* ignore */ }
 
         if (body.error === "feature_required" && body.feature) {
           let autoEnable = false;
@@ -117,7 +122,7 @@ export function registerItemTools(server: McpServer, api: ApiContext, locale: st
           );
         }
       }
-      return errorResult(`API error ${res.status}: ${await res.text()}`);
+      return errorResult(`API error ${res.status}: ${raw}`);
     }
     try {
       return jsonResult(await res.json());

--- a/gateway/src/mcp/tools/tags.ts
+++ b/gateway/src/mcp/tools/tags.ts
@@ -79,7 +79,7 @@ export function registerTagTools(server: McpServer, api: ApiContext, locale: str
       recursive: z.boolean().default(false).describe("Include items from child tags"),
     },
   }, ({ tag_id, recursive }) => {
-    const params = recursive ? "?recursive=true" : "";
+    const params = `?recursive=${recursive ? "true" : "false"}`;
     return callTool(api, "GET", `/api/tags/${tag_id}/items${params}`);
   });
 


### PR DESCRIPTION
## Summary
- add shared validation for business dates and strict HH:MM times, plus field-aware 422 responses
- validate item create/update payloads for real dates, temporal ordering, orphaned times, empty/too-long titles, and invalid quantity values
- fix nullable patch handling for item/list/container fields and tighten tag payload handling/results consistency
- fix calendar and by-date query handling, including alias support, stable `date_type` values, and `all`-field behavior for full item responses
- block item writes against archived lists, enforce list-scoped item access, and return human-readable API error messages

## Testing
- cargo test -p kartoteka-shared
- cargo test -p kartoteka-api
- cd gateway && npm run typecheck

## Follow-up
- Closes #93