### PR TITLE
fix: restore calendar item detail navigation and week layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,3 +59,7 @@ pub async fn create(mut req: Request, ctx: RouteContext<String>) -> Result<Respo
 - lokalny smoke test API/shared: `cargo test -p kartoteka-api` i `cargo test -p kartoteka-shared`
 - gateway: `cd gateway && npm run typecheck`
 - pełniejszy lokalny check: `just ci`
+
+## Git / Commits
+
+- każdy commit musi używać formatu Conventional Commits, np. `feat: ...`, `fix: ...`, `chore: ...`

--- a/crates/frontend/src/app.rs
+++ b/crates/frontend/src/app.rs
@@ -12,11 +12,11 @@ use crate::components::pwa_runtime::PwaRuntime;
 use crate::components::sync_locale::SyncLocale;
 use crate::components::toast_container::ToastContainer;
 use crate::pages::{
-    admin::AdminPage, calendar::CalendarPage, calendar::day::CalendarDayPage,
-    container::ContainerPage, home::HomePage, item_detail::ItemDetailPage, list::ListPage,
-    login::LoginPage, oauth_consent::OAuthConsentPage, settings::McpRedirect,
-    settings::SettingsPage, signup::SignupPage, tags::TagsPage, tags::detail::TagDetailPage,
-    today::TodayPage,
+    admin::AdminPage, calendar::CalendarPage, calendar::CalendarRootRedirect,
+    calendar::day::CalendarLegacyDayRedirect, container::ContainerPage, home::HomePage,
+    item_detail::ItemDetailPage, list::ListPage, login::LoginPage, oauth_consent::OAuthConsentPage,
+    settings::McpRedirect, settings::SettingsPage, signup::SignupPage, tags::TagsPage,
+    tags::detail::TagDetailPage, today::TodayPage,
 };
 use crate::state::AdminContext;
 
@@ -133,8 +133,9 @@ pub fn App() -> impl IntoView {
                         <Route path=path!("/settings") view=SettingsPage/>
                         <Route path=path!("/mcp") view=McpRedirect/>
                         <Route path=path!("/oauth/consent") view=OAuthConsentPage/>
-                        <Route path=path!("/calendar") view=CalendarPage/>
-                        <Route path=path!("/calendar/:date") view=CalendarDayPage/>
+                        <Route path=path!("/calendar") view=CalendarRootRedirect/>
+                        <Route path=path!("/calendar/:date") view=CalendarLegacyDayRedirect/>
+                        <Route path=path!("/calendar/:year/:month/:day") view=CalendarPage/>
                         <Route path=path!("/tags") view=TagsPage/>
                         <Route path=path!("/tags/:id") view=TagDetailPage/>
                         <Route path=path!("/lists/:list_id/items/:id") view=ItemDetailPage/>

--- a/crates/frontend/src/components/calendar/calendar_nav.rs
+++ b/crates/frontend/src/components/calendar/calendar_nav.rs
@@ -4,18 +4,20 @@ use leptos_fluent::move_tr;
 
 use super::ViewMode;
 use crate::components::common::date_utils::{
-    format_date_short, get_today_string, parse_date, polish_month_name, week_range,
+    format_date_short, parse_date, polish_month_name, week_range,
 };
 
 #[component]
 pub fn CalendarNav(
-    current_date: RwSignal<String>,
+    anchor_date: RwSignal<String>,
     view_mode: RwSignal<ViewMode>,
     on_prev: Callback<()>,
     on_next: Callback<()>,
+    on_view_mode_change: Callback<ViewMode>,
+    on_today: Callback<()>,
 ) -> impl IntoView {
     let title = move || {
-        let date = current_date.get();
+        let date = anchor_date.get();
         match view_mode.get() {
             ViewMode::Month => {
                 if let Some(d) = parse_date(&date) {
@@ -46,31 +48,27 @@ pub fn CalendarNav(
             <div class="flex items-center gap-2">
                 <button
                     class="btn btn-sm btn-outline"
-                    on:click=move |_| current_date.set(get_today_string())
+                    on:click=move |_| on_today.run(())
                 >
                     {move_tr!("nav-today")}
                 </button>
                 <div class="join">
-                    <button
-                        class=move || if view_mode.get() == ViewMode::Month {
-                            "join-item btn btn-sm btn-active"
-                        } else {
-                            "join-item btn btn-sm"
-                        }
-                        on:click=move |_| view_mode.set(ViewMode::Month)
-                    >
-                        "Miesiąc"
-                    </button>
-                    <button
-                        class=move || if view_mode.get() == ViewMode::Week {
-                            "join-item btn btn-sm btn-active"
-                        } else {
-                            "join-item btn btn-sm"
-                        }
-                        on:click=move |_| view_mode.set(ViewMode::Week)
-                    >
-                        "Tydzień"
-                    </button>
+                    <input
+                        class="join-item btn btn-sm"
+                        type="radio"
+                        name="calendar-view-mode"
+                        aria-label="Miesiąc"
+                        prop:checked=move || view_mode.get() == ViewMode::Month
+                        on:change=move |_| on_view_mode_change.run(ViewMode::Month)
+                    />
+                    <input
+                        class="join-item btn btn-sm"
+                        type="radio"
+                        name="calendar-view-mode"
+                        aria-label="Tydzień"
+                        prop:checked=move || view_mode.get() == ViewMode::Week
+                        on:change=move |_| on_view_mode_change.run(ViewMode::Week)
+                    />
                 </div>
             </div>
         </div>

--- a/crates/frontend/src/components/calendar/mod.rs
+++ b/crates/frontend/src/components/calendar/mod.rs
@@ -2,8 +2,4 @@ pub mod calendar_nav;
 pub mod month_grid;
 pub mod week_view;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum ViewMode {
-    Month,
-    Week,
-}
+pub use crate::state::calendar_route::ViewMode;

--- a/crates/frontend/src/components/calendar/month_grid.rs
+++ b/crates/frontend/src/components/calendar/month_grid.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 
 use leptos::prelude::*;
-use leptos_router::hooks::use_navigate;
 
 use crate::components::common::date_utils::{
     add_days, day_of_week, days_in_month, polish_day_of_week,
@@ -9,9 +8,14 @@ use crate::components::common::date_utils::{
 use kartoteka_shared::DaySummary;
 
 #[component]
-pub fn MonthGrid(counts: Vec<DaySummary>, year: i32, month: u32, today: String) -> impl IntoView {
-    let navigate = use_navigate();
-
+pub fn MonthGrid(
+    counts: Vec<DaySummary>,
+    year: i32,
+    month: u32,
+    today: String,
+    selected_date: String,
+    on_select: Callback<String>,
+) -> impl IntoView {
     // Build lookup: date -> (total, completed)
     let count_map: HashMap<String, (u32, u32)> = counts
         .into_iter()
@@ -60,20 +64,22 @@ pub fn MonthGrid(counts: Vec<DaySummary>, year: i32, month: u32, today: String) 
                 {dates.into_iter().map(|date| {
                     let is_current_month = date.starts_with(&month_prefix);
                     let is_today = date == today_for_cells;
+                    let is_selected = date == selected_date;
                     let day_num: u32 = date.split('-').nth(2).and_then(|d| d.parse().ok()).unwrap_or(0);
                     let counts = count_map.get(&date).copied();
                     let today_cmp = today_for_cells.clone();
                     let date_cmp = date.clone();
-
-                    let navigate = navigate.clone();
                     let date_for_click = date.clone();
+                    let on_select = on_select.clone();
 
                     let cell_class = move || {
-                        let mut cls = "flex flex-col items-center justify-center p-1 min-h-12 rounded-lg cursor-pointer hover:bg-base-200 transition-colors".to_string();
+                        let mut cls = "flex min-h-12 cursor-pointer flex-col items-center justify-center rounded-lg p-1 transition-colors hover:bg-base-200".to_string();
                         if !is_current_month {
                             cls.push_str(" opacity-30");
                         }
-                        if is_today {
+                        if is_selected {
+                            cls.push_str(" bg-primary text-primary-content shadow-sm");
+                        } else if is_today {
                             cls.push_str(" ring-2 ring-primary");
                         }
                         cls
@@ -105,10 +111,7 @@ pub fn MonthGrid(counts: Vec<DaySummary>, year: i32, month: u32, today: String) 
                     view! {
                         <div
                             class=cell_class
-                            on:click=move |_| {
-                                let nav = navigate.clone();
-                                nav(&format!("/calendar/{}", date_for_click), Default::default());
-                            }
+                            on:click=move |_| on_select.run(date_for_click.clone())
                         >
                             <span class="text-sm">{day_num}</span>
                             {indicator}

--- a/crates/frontend/src/components/calendar/week_view.rs
+++ b/crates/frontend/src/components/calendar/week_view.rs
@@ -27,11 +27,12 @@ pub fn WeekView(
 
     // Build 7 days starting from monday
     let week_dates: Vec<String> = (0..7).map(|i| add_days(&monday, i)).collect();
+    let highlight_today = selected_date == today;
 
     view! {
         <div class="grid grid-cols-1 md:grid-cols-7 gap-2">
             {week_dates.into_iter().enumerate().map(|(dow, date)| {
-                let is_today = date == today;
+                let is_today = highlight_today && date == today;
                 let is_selected = date == selected_date;
                 let day_items: Vec<DateItem> = days.iter()
                     .find(|d| d.date == date)
@@ -162,6 +163,7 @@ pub fn WeekView(
                                 view! {
                                     <DateItemRow
                                         item=item
+                                        compact=true
                                         on_toggle=on_toggle
                                         on_delete=on_delete
                                         all_tags=tags.clone()

--- a/crates/frontend/src/components/calendar/week_view.rs
+++ b/crates/frontend/src/components/calendar/week_view.rs
@@ -18,6 +18,8 @@ pub fn WeekView(
     item_tag_links: Vec<ItemTagLink>,
     items_signal: RwSignal<Vec<DayItems>>,
     start_date: String,
+    selected_date: String,
+    on_select: Callback<String>,
 ) -> impl IntoView {
     let client = use_context::<GlooClient>().expect("GlooClient not provided");
     let toast = use_context::<ToastContext>().expect("ToastContext missing");
@@ -30,12 +32,15 @@ pub fn WeekView(
         <div class="grid grid-cols-1 md:grid-cols-7 gap-2">
             {week_dates.into_iter().enumerate().map(|(dow, date)| {
                 let is_today = date == today;
+                let is_selected = date == selected_date;
                 let day_items: Vec<DateItem> = days.iter()
                     .find(|d| d.date == date)
                     .map(|d| d.items.clone())
                     .unwrap_or_default();
 
-                let col_class = if is_today {
+                let col_class = if is_selected {
+                    "border border-primary rounded-lg p-2 bg-primary/10 shadow-sm"
+                } else if is_today {
                     "border border-primary rounded-lg p-2 bg-primary/5"
                 } else {
                     "border border-base-300 rounded-lg p-2"
@@ -43,13 +48,18 @@ pub fn WeekView(
 
                 let tags = all_tags.clone();
                 let links = item_tag_links.clone();
+                let on_select = on_select.clone();
+                let date_for_click = date.clone();
 
                 view! {
                     <div class=col_class>
-                        <div class="text-xs font-semibold text-center mb-2 text-base-content/60">
+                        <button
+                            class="mb-2 w-full rounded-md px-2 py-1 text-center text-xs font-semibold text-base-content/60 hover:bg-base-200"
+                            on:click=move |_| on_select.run(date_for_click.clone())
+                        >
                             <div>{polish_day_of_week(dow as u32)}</div>
                             <div>{format_date_short(&date)}</div>
-                        </div>
+                        </button>
 
                         {if day_items.is_empty() {
                             view! {

--- a/crates/frontend/src/components/common/date_utils.rs
+++ b/crates/frontend/src/components/common/date_utils.rs
@@ -3,8 +3,8 @@ use kartoteka_shared::Item;
 
 // Re-export shared date_utils for backward compatibility
 pub use kartoteka_shared::date_utils::{
-    add_days, days_between, days_in_month, is_overdue_for_date_type, month_grid_range, next_month,
-    parse_date, prev_month, sort_by_deadline, week_range,
+    add_days, days_between, days_in_month, is_overdue_for_date_type, month_grid_range, parse_date,
+    sort_by_deadline, week_range,
 };
 
 /// Get today's date as "YYYY-MM-DD" using JS Date

--- a/crates/frontend/src/components/filters/filter_chips.rs
+++ b/crates/frontend/src/components/filters/filter_chips.rs
@@ -8,9 +8,12 @@ use crate::components::tags::tag_tree::TagFilterOption;
 pub fn FilterChips(
     unique_lists: Vec<(String, String)>,
     relevant_tags: Vec<TagFilterOption>,
-    hidden_lists: RwSignal<HashSet<String>>,
-    hidden_tags: RwSignal<HashSet<String>>,
-    show_completed: RwSignal<bool>,
+    hidden_lists: HashSet<String>,
+    hidden_tags: HashSet<String>,
+    show_completed: bool,
+    on_toggle_list: Callback<String>,
+    on_toggle_tag: Callback<String>,
+    on_toggle_show_completed: Callback<()>,
 ) -> impl IntoView {
     view! {
         <div>
@@ -20,7 +23,8 @@ pub fn FilterChips(
                     let lid = list_id.clone();
                     let is_hidden = {
                         let lid = lid.clone();
-                        move || hidden_lists.get().contains(&lid)
+                        let hidden_lists = hidden_lists.clone();
+                        move || hidden_lists.contains(&lid)
                     };
                     view! {
                         <button
@@ -29,13 +33,7 @@ pub fn FilterChips(
                             } else {
                                 "btn btn-xs btn-outline btn-primary"
                             }
-                            on:click=move |_| {
-                                hidden_lists.update(|s| {
-                                    if !s.remove(&list_id) {
-                                        s.insert(list_id.clone());
-                                    }
-                                });
-                            }
+                            on:click=move |_| on_toggle_list.run(list_id.clone())
                         >
                             {list_name}
                         </button>
@@ -53,7 +51,8 @@ pub fn FilterChips(
                             let tag_color = tag.color.clone();
                             let is_hidden = {
                                 let tid = tid.clone();
-                                move || hidden_tags.get().contains(&tid)
+                                let hidden_tags = hidden_tags.clone();
+                                move || hidden_tags.contains(&tid)
                             };
                             view! {
                                 <button
@@ -63,13 +62,7 @@ pub fn FilterChips(
                                         "badge badge-sm h-auto whitespace-normal py-1 text-left cursor-pointer"
                                     }
                                     style=format!("background-color: {}; color: white;", tag_color)
-                                    on:click=move |_| {
-                                        hidden_tags.update(|s| {
-                                            if !s.remove(&tid) {
-                                                s.insert(tid.clone());
-                                            }
-                                        });
-                                    }
+                                    on:click=move |_| on_toggle_tag.run(tid.clone())
                                 >
                                     {tag_name}
                                 </button>
@@ -86,8 +79,8 @@ pub fn FilterChips(
                 <input
                     type="checkbox"
                     class="toggle toggle-sm toggle-primary"
-                    prop:checked=move || show_completed.get()
-                    on:change=move |_| show_completed.update(|v| *v = !*v)
+                    prop:checked=show_completed
+                    on:change=move |_| on_toggle_show_completed.run(())
                 />
                 <span class="text-sm text-base-content/60">"Ukończone"</span>
             </label>

--- a/crates/frontend/src/components/items/date_item_row.rs
+++ b/crates/frontend/src/components/items/date_item_row.rs
@@ -1,5 +1,6 @@
 use kartoteka_shared::{Item, Tag};
 use leptos::prelude::*;
+use leptos_router::components::A;
 
 use crate::components::common::date_utils::{
     format_date_short, get_today_string, is_overdue, item_date_badges, relative_date,
@@ -91,12 +92,12 @@ pub fn DateItemRow(
                     checked=completed
                     on:change=move |_| on_toggle.run(id_toggle.clone())
                 />
-                <a
+                <A
                     href=item_href
-                    class=format!("{title_class} hover:text-primary transition-colors no-underline")
+                    attr:class=format!("{title_class} text-left hover:text-primary transition-colors no-underline")
                 >
                     {item_title}
-                </a>
+                </A>
 
                 // Primary date (clickable for editing)
                 {if on_date_save.is_some() {

--- a/crates/frontend/src/components/items/date_item_row.rs
+++ b/crates/frontend/src/components/items/date_item_row.rs
@@ -19,6 +19,7 @@ pub fn DateItemRow(
     #[prop(default = vec![])] item_tag_ids: Vec<String>,
     #[prop(optional)] on_tag_toggle: Option<Callback<String>>,
     #[prop(optional)] date_type: Option<String>,
+    #[prop(default = false)] compact: bool,
     /// (item_id, date_type, date_value, time_value)
     #[prop(optional)]
     on_date_save: Option<Callback<(String, String, String, Option<String>)>>,
@@ -34,17 +35,17 @@ pub fn DateItemRow(
     let overdue = is_overdue(&item, &today);
 
     let row_class = if completed {
-        "flex items-center gap-3 py-2 opacity-50"
+        "flex flex-wrap items-start gap-2 py-2 opacity-50"
     } else if overdue {
-        "flex items-center gap-3 py-2 text-error"
+        "flex flex-wrap items-start gap-2 py-2 text-error"
     } else {
-        "flex items-center gap-3 py-2"
+        "flex flex-wrap items-start gap-2 py-2"
     };
 
     let title_class = if completed {
-        "flex-1 min-w-0 line-through text-base-content/50"
+        "block min-w-0 break-words line-through text-base-content/50"
     } else {
-        "flex-1 min-w-0"
+        "block min-w-0 break-words"
     };
 
     let primary_dt = date_type.as_deref().unwrap_or("deadline");
@@ -58,12 +59,18 @@ pub fn DateItemRow(
     let relative = display_date.as_ref().map(|d| relative_date(d, &today));
     let time_display = display_time;
 
-    let date_color = if completed {
-        "text-right text-sm text-base-content/40 shrink-0"
+    let date_color = if compact && completed {
+        "pt-1 text-left text-xs leading-tight text-base-content/40"
+    } else if compact && overdue {
+        "pt-1 text-left text-xs leading-tight text-error"
+    } else if compact {
+        "pt-1 text-left text-xs leading-tight text-base-content/60"
+    } else if completed {
+        "ml-auto shrink-0 text-right text-sm text-base-content/40"
     } else if overdue {
-        "text-right text-sm text-error shrink-0"
+        "ml-auto shrink-0 text-right text-sm text-error"
     } else {
-        "text-right text-sm text-base-content/60 shrink-0"
+        "ml-auto shrink-0 text-right text-sm text-base-content/60"
     };
 
     let primary_icon = match primary_dt {
@@ -85,61 +92,128 @@ pub fn DateItemRow(
     view! {
         <div class="border-b border-base-300">
             // Row 1: checkbox + title + primary date + delete
-            <div class=row_class>
-                <input
-                    type="checkbox"
-                    class="checkbox checkbox-secondary"
-                    checked=completed
-                    on:change=move |_| on_toggle.run(id_toggle.clone())
-                />
-                <A
-                    href=item_href
-                    attr:class=format!("{title_class} text-left hover:text-primary transition-colors no-underline")
-                >
-                    {item_title}
-                </A>
-
-                // Primary date (clickable for editing)
-                {if on_date_save.is_some() {
-                    let pdt = primary_dt_str.clone();
-                    view! {
-                        <button type="button" class=format!("{date_color} cursor-pointer hover:opacity-80")
-                            on:click=move |_| {
-                                let current = editing_date.get();
-                                if current.as_deref() == Some(pdt.as_str()) {
-                                    editing_date.set(None);
-                                } else {
-                                    editing_date.set(Some(pdt.clone()));
-                                }
-                            }
-                        >
-                            {date_display.as_ref().map(|d| view! {
-                                <div class="flex items-center gap-1 justify-end">
-                                    <span class="opacity-60">{primary_icon}</span>
-                                    <span class="font-medium">{d.clone()}</span>
-                                </div>
-                            })}
-                            {relative.as_ref().map(|r| view! { <div class="text-xs">{r.clone()}</div> })}
-                            {time_display.as_ref().map(|t| view! { <div class="text-xs">{t.clone()}</div> })}
-                        </button>
-                    }.into_any()
-                } else {
-                    view! {
-                        <div class=date_color>
-                            {date_display.map(|d| view! {
-                                <div class="flex items-center gap-1 justify-end">
-                                    <span class="opacity-60">{primary_icon}</span>
-                                    <span class="font-medium">{d}</span>
-                                </div>
-                            })}
-                            {relative.map(|r| view! { <div class="text-xs">{r}</div> })}
-                            {time_display.map(|t| view! { <div class="text-xs">{t}</div> })}
+            {if compact {
+                view! {
+                    <div class="py-2">
+                        <div class="flex items-start gap-2">
+                            <input
+                                type="checkbox"
+                                class="checkbox checkbox-secondary checkbox-sm mt-1 shrink-0"
+                                checked=completed
+                                on:change=move |_| on_toggle.run(id_toggle.clone())
+                            />
+                            <A
+                                href=item_href
+                                attr:class=format!("{title_class} flex-1 text-left hover:text-primary transition-colors no-underline")
+                            >
+                                {item_title.clone()}
+                            </A>
+                            <div class="shrink-0 self-start">
+                                <InlineConfirmButton on_confirm=Callback::new(move |()| on_delete.run(id_delete.clone())) />
+                            </div>
                         </div>
-                    }.into_any()
-                }}
 
-                <InlineConfirmButton on_confirm=Callback::new(move |()| on_delete.run(id_delete.clone())) />
-            </div>
+                        {if on_date_save.is_some() {
+                            let pdt = primary_dt_str.clone();
+                            view! {
+                                <button
+                                    type="button"
+                                    class=format!("ml-10 {date_color} cursor-pointer hover:opacity-80")
+                                    on:click=move |_| {
+                                        let current = editing_date.get();
+                                        if current.as_deref() == Some(pdt.as_str()) {
+                                            editing_date.set(None);
+                                        } else {
+                                            editing_date.set(Some(pdt.clone()));
+                                        }
+                                    }
+                                >
+                                    {date_display.as_ref().map(|d| view! {
+                                        <div class="flex items-center gap-1 justify-start">
+                                            <span class="opacity-60">{primary_icon}</span>
+                                            <span class="font-medium">{d.clone()}</span>
+                                        </div>
+                                    })}
+                                    {relative.as_ref().map(|r| view! { <div class="text-xs">{r.clone()}</div> })}
+                                    {time_display.as_ref().map(|t| view! { <div class="text-xs">{t.clone()}</div> })}
+                                </button>
+                            }.into_any()
+                        } else {
+                            view! {
+                                <div class=format!("ml-10 {date_color}")>
+                                    {date_display.map(|d| view! {
+                                        <div class="flex items-center gap-1 justify-start">
+                                            <span class="opacity-60">{primary_icon}</span>
+                                            <span class="font-medium">{d}</span>
+                                        </div>
+                                    })}
+                                    {relative.map(|r| view! { <div class="text-xs">{r}</div> })}
+                                    {time_display.map(|t| view! { <div class="text-xs">{t}</div> })}
+                                </div>
+                            }.into_any()
+                        }}
+                    </div>
+                }.into_any()
+            } else {
+                view! {
+                    <div class=row_class>
+                        <input
+                            type="checkbox"
+                            class="checkbox checkbox-secondary checkbox-sm mt-1"
+                            checked=completed
+                            on:change=move |_| on_toggle.run(id_toggle.clone())
+                        />
+                        <A
+                            href=item_href
+                            attr:class=format!(
+                                "{title_class} flex-1 text-left hover:text-primary transition-colors no-underline"
+                            )
+                        >
+                            {item_title}
+                        </A>
+
+                        {if on_date_save.is_some() {
+                            let pdt = primary_dt_str.clone();
+                            view! {
+                                <button type="button" class=format!("{date_color} cursor-pointer hover:opacity-80")
+                                    on:click=move |_| {
+                                        let current = editing_date.get();
+                                        if current.as_deref() == Some(pdt.as_str()) {
+                                            editing_date.set(None);
+                                        } else {
+                                            editing_date.set(Some(pdt.clone()));
+                                        }
+                                    }
+                                >
+                                    {date_display.as_ref().map(|d| view! {
+                                        <div class="flex items-center gap-1 justify-end">
+                                            <span class="opacity-60">{primary_icon}</span>
+                                            <span class="font-medium">{d.clone()}</span>
+                                        </div>
+                                    })}
+                                    {relative.as_ref().map(|r| view! { <div class="text-xs">{r.clone()}</div> })}
+                                    {time_display.as_ref().map(|t| view! { <div class="text-xs">{t.clone()}</div> })}
+                                </button>
+                            }.into_any()
+                        } else {
+                            view! {
+                                <div class=date_color>
+                                    {date_display.map(|d| view! {
+                                        <div class="flex items-center gap-1 justify-end">
+                                            <span class="opacity-60">{primary_icon}</span>
+                                            <span class="font-medium">{d}</span>
+                                        </div>
+                                    })}
+                                    {relative.map(|r| view! { <div class="text-xs">{r}</div> })}
+                                    {time_display.map(|t| view! { <div class="text-xs">{t}</div> })}
+                                </div>
+                            }.into_any()
+                        }}
+
+                        <InlineConfirmButton on_confirm=Callback::new(move |()| on_delete.run(id_delete.clone())) />
+                    </div>
+                }.into_any()
+            }}
 
             // Row 2: tags + secondary date badges (clickable)
             {if has_secondary {

--- a/crates/frontend/src/pages/calendar/day.rs
+++ b/crates/frontend/src/pages/calendar/day.rs
@@ -1,139 +1,200 @@
 use std::collections::{BTreeMap, HashSet};
+use std::future::Future;
 
 use leptos::prelude::*;
 use leptos_fluent::move_tr;
 use leptos_router::components::A;
-use leptos_router::hooks::use_params_map;
+use leptos_router::hooks::{use_navigate, use_params_map, use_query_map};
 
 use crate::api;
+use crate::api::ApiError;
 use crate::api::client::GlooClient;
 use crate::app::{ToastContext, ToastKind};
 use crate::components::common::date_utils::{
-    add_days, day_of_week, format_polish_date, polish_day_of_week_full,
+    add_days, day_of_week, format_polish_date, parse_date, polish_day_of_week_full,
 };
 use crate::components::common::loading::LoadingSpinner;
-use crate::components::filters::filter_chips::FilterChips;
 use crate::components::items::date_item_row::DateItemRow;
-use crate::components::tags::tag_tree::build_tag_filter_options;
+use crate::state::calendar_route::{CalendarRouteState, calendar_href};
 use crate::state::item_mutations::{
-    ItemDateField, apply_date_change_to_date_items, build_date_update_request,
-    run_optimistic_mutation,
+    ItemDateField, apply_date_change_to_date_items, apply_date_change_to_day_items,
+    build_date_update_request, run_optimistic_mutation,
 };
 use kartoteka_shared::*;
 
-#[component]
-pub fn CalendarDayPage() -> impl IntoView {
-    let params = use_params_map();
-    let date = move || params.read().get("date").unwrap_or_default();
+fn run_dual_optimistic_mutation<T, U, MutateFirst, MutateSecond, Request, RequestFuture, OnError>(
+    first: RwSignal<T>,
+    second: RwSignal<U>,
+    mutate_first: MutateFirst,
+    mutate_second: MutateSecond,
+    request: Request,
+    on_error: OnError,
+) where
+    T: Clone + Send + Sync + 'static,
+    U: Clone + Send + Sync + 'static,
+    MutateFirst: FnOnce(&mut T) -> bool + 'static,
+    MutateSecond: FnOnce(&mut U) + 'static,
+    Request: FnOnce() -> RequestFuture + 'static,
+    RequestFuture: Future<Output = Result<(), ApiError>> + 'static,
+    OnError: FnOnce(ApiError) + 'static,
+{
+    let previous_first = first.get_untracked();
+    let previous_second = second.get_untracked();
 
+    let mut next_first = previous_first.clone();
+    if !mutate_first(&mut next_first) {
+        return;
+    }
+
+    let mut next_second = previous_second.clone();
+    mutate_second(&mut next_second);
+
+    first.set(next_first);
+    second.set(next_second);
+
+    leptos::task::spawn_local(async move {
+        if let Err(error) = request().await {
+            first.set(previous_first);
+            second.set(previous_second);
+            on_error(error);
+        }
+    });
+}
+
+#[component]
+pub fn CalendarLegacyDayRedirect() -> impl IntoView {
+    let params = use_params_map();
+    let query = use_query_map();
+    let navigate = use_navigate();
+    let today = crate::components::common::date_utils::get_today_string();
+
+    Effect::new(move |_| {
+        let legacy_date = params.read().get("date").unwrap_or_default();
+        let selected_date = parse_date(&legacy_date)
+            .map(|date| date.format("%Y-%m-%d").to_string())
+            .unwrap_or_else(|| today.clone());
+        let query = query.read();
+        let state = CalendarRouteState {
+            selected_date,
+            view_mode: crate::components::calendar::ViewMode::parse(
+                query.get_str("view").unwrap_or("month"),
+            ),
+            hidden_lists: query
+                .get_str("hidden_lists")
+                .unwrap_or_default()
+                .split(',')
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned)
+                .collect(),
+            hidden_tags: query
+                .get_str("hidden_tags")
+                .unwrap_or_default()
+                .split(',')
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned)
+                .collect(),
+            show_completed: query.get_str("show_completed").unwrap_or("1") != "0",
+        };
+
+        navigate(&calendar_href(&state), Default::default());
+    });
+
+    view! { <LoadingSpinner/> }
+}
+
+#[component]
+pub fn CalendarDayPanel(
+    selected_date: RwSignal<String>,
+    items: RwSignal<Vec<DateItem>>,
+    loading: ReadSignal<bool>,
+    all_tags: RwSignal<Vec<Tag>>,
+    item_tag_links: RwSignal<Vec<ItemTagLink>>,
+    hidden_lists: RwSignal<HashSet<String>>,
+    hidden_tags: RwSignal<HashSet<String>>,
+    show_completed: RwSignal<bool>,
+    on_select_date: Callback<String>,
+    week_items: RwSignal<Vec<DayItems>>,
+    sync_week: Signal<bool>,
+) -> impl IntoView {
     let toast = use_context::<ToastContext>().expect("ToastContext missing");
     let client = use_context::<GlooClient>().expect("GlooClient not provided");
-    let items = RwSignal::new(Vec::<DateItem>::new());
-    let all_tags = RwSignal::new(Vec::<Tag>::new());
-    let item_tag_links = RwSignal::new(Vec::<ItemTagLink>::new());
-    let (loading, set_loading) = signal(true);
-    let hidden_lists = RwSignal::new(HashSet::<String>::new());
-    let hidden_tags = RwSignal::new(HashSet::<String>::new());
-    let show_completed = RwSignal::new(true);
-
-    let _resource = {
-        let client = client.clone();
-        LocalResource::new(move || {
-            let d = date();
-            let client = client.clone();
-            async move {
-                set_loading.set(true);
-                match api::fetch_items_by_date(&client, &d, false, "all").await {
-                    Ok(fetched) => items.set(fetched),
-                    Err(e) => toast.push(format!("Błąd: {e}"), ToastKind::Error),
-                }
-                if let Ok(tags) = api::fetch_tags(&client).await {
-                    all_tags.set(tags);
-                }
-                if let Ok(links) = api::fetch_item_tag_links(&client).await {
-                    item_tag_links.set(links);
-                }
-                set_loading.set(false);
-            }
-        })
-    };
 
     view! {
-        <div class="container mx-auto max-w-2xl p-4">
-            // Header with date + navigation
+        <div class="mt-6 rounded-xl border border-base-300 bg-base-100 p-4">
             {move || {
-                let d = date();
-                let prev = add_days(&d, -1);
-                let next = add_days(&d, 1);
-                let dow = day_of_week(&d);
+                let date = selected_date.get();
+                let prev = add_days(&date, -1);
+                let next = add_days(&date, 1);
+                let dow = day_of_week(&date);
                 let dow_name = polish_day_of_week_full(dow);
-                let formatted = format_polish_date(&d);
+                let formatted = format_polish_date(&date);
 
                 view! {
-                    <div class="flex items-center justify-between mb-4">
-                        <A href=format!("/calendar/{prev}") attr:class="btn btn-sm btn-ghost">"‹"</A>
+                    <div class="mb-4 flex items-center justify-between gap-2">
+                        <button
+                            class="btn btn-sm btn-ghost"
+                            on:click={
+                                let on_select_date = on_select_date.clone();
+                                move |_| on_select_date.run(prev.clone())
+                            }
+                        >
+                            "‹"
+                        </button>
                         <div class="text-center">
-                            <h1 class="text-2xl font-bold">{formatted}</h1>
+                            <h3 class="text-xl font-bold">{formatted}</h3>
                             <span class="text-base-content/50 capitalize">{dow_name}</span>
                         </div>
-                        <A href=format!("/calendar/{next}") attr:class="btn btn-sm btn-ghost">"›"</A>
-                    </div>
-                    <div class="text-center mb-4">
-                        <A href="/calendar" attr:class="btn btn-sm btn-outline btn-ghost">{move_tr!("calendar-back-to-calendar")}</A>
+                        <button
+                            class="btn btn-sm btn-ghost"
+                            on:click=move |_| on_select_date.run(next.clone())
+                        >
+                            "›"
+                        </button>
                     </div>
                 }
             }}
 
             {move || {
-                if loading.get() {
+                let all_items = items.get();
+
+                if loading.get() && all_items.is_empty() {
                     return view! { <LoadingSpinner/> }.into_any();
                 }
-
-                let all_items = items.get();
                 let tags = all_tags.get();
                 let links = item_tag_links.get();
 
                 if all_items.is_empty() {
                     return view! {
-                        <p class="text-center text-base-content/50 py-12">
+                        <p class="py-12 text-center text-base-content/50">
                             {move_tr!("calendar-empty-day")}
                         </p>
-                    }.into_any();
-                }
-
-                // Collect unique lists
-                let mut unique_lists: Vec<(String, String)> = Vec::new();
-                let mut seen = HashSet::new();
-                for item in &all_items {
-                    if seen.insert(item.list_id.clone()) {
-                        unique_lists.push((item.list_id.clone(), item.list_name.clone()));
                     }
+                    .into_any();
                 }
 
-                // Collect relevant tags
-                let item_ids: HashSet<String> = all_items.iter().map(|i| i.id.clone()).collect();
-                let relevant_tag_ids: HashSet<String> = links.iter()
-                    .filter(|l| item_ids.contains(&l.item_id))
-                    .map(|l| l.tag_id.clone())
-                    .collect();
-                let relevant_tag_ids: Vec<String> = relevant_tag_ids.into_iter().collect();
-                let relevant_tags = build_tag_filter_options(&tags, &relevant_tag_ids);
+                let hidden_lists_value = hidden_lists.get();
+                let hidden_tags_value = hidden_tags.get();
+                let show_completed_value = show_completed.get();
 
-                // Filter
-                let hl = hidden_lists.get();
-                let ht = hidden_tags.get();
-                let sc = show_completed.get();
-
-                let filtered: Vec<DateItem> = all_items.into_iter()
+                let filtered: Vec<DateItem> = all_items
+                    .into_iter()
                     .filter(|item| {
-                        if hl.contains(&item.list_id) { return false; }
-                        if !sc && item.completed { return false; }
-                        if !ht.is_empty() {
-                            let item_tags: HashSet<String> = links.iter()
-                                .filter(|l| l.item_id == item.id)
-                                .map(|l| l.tag_id.clone())
+                        if hidden_lists_value.contains(&item.list_id) {
+                            return false;
+                        }
+                        if !show_completed_value && item.completed {
+                            return false;
+                        }
+                        if !hidden_tags_value.is_empty() {
+                            let item_tags: HashSet<String> = links
+                                .iter()
+                                .filter(|link| link.item_id == item.id)
+                                .map(|link| link.tag_id.clone())
                                 .collect();
-                            if ht.iter().any(|t| item_tags.contains(t)) {
+                            if hidden_tags_value
+                                .iter()
+                                .any(|tag_id| item_tags.contains(tag_id))
+                            {
                                 return false;
                             }
                         }
@@ -141,32 +202,32 @@ pub fn CalendarDayPage() -> impl IntoView {
                     })
                     .collect();
 
-                // Group by list
                 let mut groups: BTreeMap<(String, String), Vec<DateItem>> = BTreeMap::new();
                 for item in filtered {
                     let key = (item.list_id.clone(), item.list_name.clone());
                     groups.entry(key).or_default().push(item);
                 }
 
-                let client_render = use_context::<GlooClient>().expect("GlooClient not provided");
-
                 view! {
-                    <div>
-                        <FilterChips
-                            unique_lists=unique_lists
-                            relevant_tags=relevant_tags
-                            hidden_lists=hidden_lists
-                            hidden_tags=hidden_tags
-                            show_completed=show_completed
-                        />
-
+                    <div class="relative">
+                        {move || {
+                            if loading.get() {
+                                view! {
+                                    <div class="pointer-events-none absolute inset-x-0 top-0 z-10 mx-auto w-fit rounded-full bg-base-200/90 px-3 py-1 text-xs text-base-content/70 shadow-sm">
+                                        "Odświeżanie…"
+                                    </div>
+                                }.into_any()
+                            } else {
+                                view! { <></> }.into_any()
+                            }
+                        }}
                         {groups.into_iter().map(|((list_id, list_name), group_items)| {
                             let tags = tags.clone();
                             let links = links.clone();
-                            let client = client_render.clone();
+                            let client = client.clone();
                             view! {
                                 <div class="mb-4">
-                                    <h4 class="text-sm font-semibold uppercase tracking-wide mb-1 text-base-content/70">
+                                    <h4 class="mb-1 text-sm font-semibold uppercase tracking-wide text-base-content/70">
                                         <A href=format!("/lists/{list_id}") attr:class="link link-hover">
                                             {list_name}
                                         </A>
@@ -177,20 +238,25 @@ pub fn CalendarDayPage() -> impl IntoView {
                                         let date_type = date_item.date_type.clone();
                                         let item: Item = date_item.into();
 
-                                        let item_tag_ids: Vec<String> = links.iter()
-                                            .filter(|l| l.item_id == item_id)
-                                            .map(|l| l.tag_id.clone())
+                                        let item_tag_ids: Vec<String> = links
+                                            .iter()
+                                            .filter(|link| link.item_id == item_id)
+                                            .map(|link| link.tag_id.clone())
                                             .collect();
 
                                         let toggle_list_id = item_list_id.clone();
                                         let toggle_item_id = item_id.clone();
                                         let client_toggle = client.clone();
                                         let toast_toggle = toast.clone();
+                                        let sync_week_toggle = sync_week;
+                                        let selected_date_toggle = selected_date;
+                                        let week_items_toggle = week_items;
+                                        let items_toggle = items;
                                         let on_toggle = Callback::new(move |_id: String| {
                                             let lid = toggle_list_id.clone();
                                             let iid = toggle_item_id.clone();
                                             let client_t = client_toggle.clone();
-                                            let current = items
+                                            let current = items_toggle
                                                 .get_untracked()
                                                 .iter()
                                                 .find(|item| item.id == iid)
@@ -198,84 +264,203 @@ pub fn CalendarDayPage() -> impl IntoView {
                                             let Some(next_completed) = current else { return };
                                             let iid_for_mutation = iid.clone();
                                             let iid_for_request = iid.clone();
-                                            run_optimistic_mutation(
-                                                items,
-                                                move |items| {
-                                                    let Some(item) = items
-                                                        .iter_mut()
-                                                        .find(|item| item.id == iid_for_mutation)
-                                                    else {
-                                                        return false;
-                                                    };
-                                                    item.completed = next_completed;
-                                                    true
-                                                },
-                                                move || async move {
-                                                    let req = UpdateItemRequest {
-                                                        completed: Some(next_completed),
-                                                        ..Default::default()
-                                                    };
-                                                    api::update_item(&client_t, &lid, &iid_for_request, &req)
-                                                        .await
-                                                        .map(|_| ())
-                                                },
-                                                move |e| toast_toggle.push(format!("Błąd: {e}"), ToastKind::Error),
-                                            );
+
+                                            if sync_week_toggle.get_untracked() {
+                                                let date_for_week = selected_date_toggle.get_untracked();
+                                                let iid_for_week = iid.clone();
+                                                run_dual_optimistic_mutation(
+                                                    items_toggle,
+                                                    week_items_toggle,
+                                                    move |items| {
+                                                        let Some(item) = items
+                                                            .iter_mut()
+                                                            .find(|item| item.id == iid_for_mutation)
+                                                        else {
+                                                            return false;
+                                                        };
+                                                        item.completed = next_completed;
+                                                        true
+                                                    },
+                                                    move |days| {
+                                                        if let Some(day) = days
+                                                            .iter_mut()
+                                                            .find(|day| day.date == date_for_week)
+                                                        {
+                                                            if let Some(item) = day
+                                                                .items
+                                                                .iter_mut()
+                                                                .find(|item| item.id == iid_for_week)
+                                                            {
+                                                                item.completed = next_completed;
+                                                            }
+                                                        }
+                                                    },
+                                                    move || async move {
+                                                        let req = UpdateItemRequest {
+                                                            completed: Some(next_completed),
+                                                            ..Default::default()
+                                                        };
+                                                        api::update_item(&client_t, &lid, &iid_for_request, &req)
+                                                            .await
+                                                            .map(|_| ())
+                                                    },
+                                                    move |e| toast_toggle.push(format!("Błąd: {e}"), ToastKind::Error),
+                                                );
+                                            } else {
+                                                run_optimistic_mutation(
+                                                    items_toggle,
+                                                    move |items| {
+                                                        let Some(item) = items
+                                                            .iter_mut()
+                                                            .find(|item| item.id == iid_for_mutation)
+                                                        else {
+                                                            return false;
+                                                        };
+                                                        item.completed = next_completed;
+                                                        true
+                                                    },
+                                                    move || async move {
+                                                        let req = UpdateItemRequest {
+                                                            completed: Some(next_completed),
+                                                            ..Default::default()
+                                                        };
+                                                        api::update_item(&client_t, &lid, &iid_for_request, &req)
+                                                            .await
+                                                            .map(|_| ())
+                                                    },
+                                                    move |e| toast_toggle.push(format!("Błąd: {e}"), ToastKind::Error),
+                                                );
+                                            }
                                         });
 
                                         let delete_list_id = item_list_id.clone();
                                         let delete_item_id = item_id.clone();
                                         let client_delete = client.clone();
                                         let toast_delete = toast.clone();
+                                        let sync_week_delete = sync_week;
+                                        let selected_date_delete = selected_date;
+                                        let week_items_delete = week_items;
+                                        let items_delete = items;
                                         let on_delete = Callback::new(move |_id: String| {
                                             let lid = delete_list_id.clone();
                                             let iid = delete_item_id.clone();
                                             let client_d = client_delete.clone();
                                             let iid_for_mutation = iid.clone();
                                             let iid_for_request = iid.clone();
-                                            run_optimistic_mutation(
-                                                items,
-                                                move |items| {
-                                                    let before_len = items.len();
-                                                    items.retain(|item| item.id != iid_for_mutation);
-                                                    items.len() != before_len
-                                                },
-                                                move || async move { api::delete_item(&client_d, &lid, &iid_for_request).await },
-                                                move |e| toast_delete.push(format!("Błąd: {e}"), ToastKind::Error),
-                                            );
+
+                                            if sync_week_delete.get_untracked() {
+                                                let date_for_week = selected_date_delete.get_untracked();
+                                                let iid_for_week = iid.clone();
+                                                run_dual_optimistic_mutation(
+                                                    items_delete,
+                                                    week_items_delete,
+                                                    move |items| {
+                                                        let before_len = items.len();
+                                                        items.retain(|item| item.id != iid_for_mutation);
+                                                        items.len() != before_len
+                                                    },
+                                                    move |days| {
+                                                        if let Some(day) = days
+                                                            .iter_mut()
+                                                            .find(|day| day.date == date_for_week)
+                                                        {
+                                                            day.items.retain(|item| item.id != iid_for_week);
+                                                        }
+                                                    },
+                                                    move || async move {
+                                                        api::delete_item(&client_d, &lid, &iid_for_request).await
+                                                    },
+                                                    move |e| toast_delete.push(format!("Błąd: {e}"), ToastKind::Error),
+                                                );
+                                            } else {
+                                                run_optimistic_mutation(
+                                                    items_delete,
+                                                    move |items| {
+                                                        let before_len = items.len();
+                                                        items.retain(|item| item.id != iid_for_mutation);
+                                                        items.len() != before_len
+                                                    },
+                                                    move || async move {
+                                                        api::delete_item(&client_d, &lid, &iid_for_request).await
+                                                    },
+                                                    move |e| toast_delete.push(format!("Błąd: {e}"), ToastKind::Error),
+                                                );
+                                            }
                                         });
 
-                                        // Date save
-                                        let ds_lid = item_list_id.clone();
-                                        let ds_iid = item_id.clone();
+                                        let save_list_id = item_list_id.clone();
+                                        let save_item_id = item_id.clone();
                                         let client_date = client.clone();
                                         let toast_date = toast.clone();
+                                        let sync_week_date = sync_week;
+                                        let selected_date_save = selected_date;
+                                        let week_items_save = week_items;
+                                        let items_save = items;
                                         let on_date_save = Callback::new(move |(_iid, dt, date, time): (String, String, String, Option<String>)| {
                                             let Some(field) = ItemDateField::parse(&dt) else { return; };
                                             let Some(req) = build_date_update_request(&dt, &date, time.clone()) else { return; };
-                                            let lid = ds_lid.clone();
-                                            let iid = ds_iid.clone();
+                                            let lid = save_list_id.clone();
+                                            let iid = save_item_id.clone();
                                             let client_ds = client_date.clone();
                                             let iid_for_mutation = iid.clone();
+                                            let iid_for_request = iid.clone();
+                                            let date_for_items = date.clone();
+                                            let date_for_week = date.clone();
                                             let time_for_mutation = time.clone();
-                                            run_optimistic_mutation(
-                                                items,
-                                                move |items| {
-                                                    apply_date_change_to_date_items(
-                                                        items,
-                                                        &iid_for_mutation,
-                                                        field,
-                                                        &date,
-                                                        time_for_mutation.as_deref(),
-                                                    )
-                                                },
-                                                move || async move {
-                                                    api::update_item(&client_ds, &lid, &iid, &req)
-                                                        .await
-                                                        .map(|_| ())
-                                                },
-                                                move |e| toast_date.push(format!("Błąd: {e}"), ToastKind::Error),
-                                            );
+
+                                            if sync_week_date.get_untracked() {
+                                                let selected_day_for_week = selected_date_save.get_untracked();
+                                                let iid_for_week = iid.clone();
+                                                let time_for_week = time.clone();
+                                                run_dual_optimistic_mutation(
+                                                    items_save,
+                                                    week_items_save,
+                                                    move |items| {
+                                                        apply_date_change_to_date_items(
+                                                            items,
+                                                            &iid_for_mutation,
+                                                            field,
+                                                            &date_for_items,
+                                                            time_for_mutation.as_deref(),
+                                                        )
+                                                    },
+                                                    move |days| {
+                                                        let _ = apply_date_change_to_day_items(
+                                                            days,
+                                                            &selected_day_for_week,
+                                                            &iid_for_week,
+                                                            field,
+                                                            &date_for_week,
+                                                            time_for_week.as_deref(),
+                                                        );
+                                                    },
+                                                    move || async move {
+                                                        api::update_item(&client_ds, &lid, &iid_for_request, &req)
+                                                            .await
+                                                            .map(|_| ())
+                                                    },
+                                                    move |e| toast_date.push(format!("Błąd: {e}"), ToastKind::Error),
+                                                );
+                                            } else {
+                                                run_optimistic_mutation(
+                                                    items_save,
+                                                    move |items| {
+                                                        apply_date_change_to_date_items(
+                                                            items,
+                                                            &iid_for_mutation,
+                                                            field,
+                                                            &date,
+                                                            time_for_mutation.as_deref(),
+                                                        )
+                                                    },
+                                                    move || async move {
+                                                        api::update_item(&client_ds, &lid, &iid_for_request, &req)
+                                                            .await
+                                                            .map(|_| ())
+                                                    },
+                                                    move |e| toast_date.push(format!("Błąd: {e}"), ToastKind::Error),
+                                                );
+                                            }
                                         });
 
                                         {if let Some(dt) = date_type {
@@ -289,7 +474,8 @@ pub fn CalendarDayPage() -> impl IntoView {
                                                     date_type=dt
                                                     on_date_save=on_date_save
                                                 />
-                                            }.into_any()
+                                            }
+                                            .into_any()
                                         } else {
                                             view! {
                                                 <DateItemRow
@@ -300,14 +486,16 @@ pub fn CalendarDayPage() -> impl IntoView {
                                                     item_tag_ids=item_tag_ids
                                                     on_date_save=on_date_save
                                                 />
-                                            }.into_any()
+                                            }
+                                            .into_any()
                                         }}
                                     }).collect_view()}
                                 </div>
                             }
                         }).collect_view()}
                     </div>
-                }.into_any()
+                }
+                .into_any()
             }}
         </div>
     }

--- a/crates/frontend/src/pages/calendar/mod.rs
+++ b/crates/frontend/src/pages/calendar/mod.rs
@@ -1,10 +1,11 @@
 pub mod day;
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use chrono::Datelike;
 use leptos::prelude::*;
 use leptos_fluent::move_tr;
+use leptos_router::hooks::{use_navigate, use_params_map, use_query_map};
 
 use crate::api;
 use crate::api::client::GlooClient;
@@ -14,50 +15,251 @@ use crate::components::calendar::calendar_nav::CalendarNav;
 use crate::components::calendar::month_grid::MonthGrid;
 use crate::components::calendar::week_view::WeekView;
 use crate::components::common::date_utils::{
-    add_days, get_today_string, month_grid_range, next_month, parse_date, prev_month, week_range,
+    add_days, get_today_string, month_grid_range, parse_date, week_range,
 };
 use crate::components::common::loading::LoadingSpinner;
 use crate::components::filters::filter_chips::FilterChips;
 use crate::components::tags::tag_tree::build_tag_filter_options;
+use crate::state::calendar_route::{
+    CalendarRouteState, calendar_href, calendar_state_from_maps, calendar_state_toggle_hidden_list,
+    calendar_state_toggle_hidden_tag, calendar_state_toggle_show_completed,
+    calendar_state_with_selected_date, calendar_state_with_view_mode, shift_month_clamped,
+};
+use crate::state::view_helpers::TagFilterOption;
 use kartoteka_shared::*;
+
+use self::day::CalendarDayPanel;
+
+fn collect_unique_lists(items: &[DateItem]) -> Vec<(String, String)> {
+    let mut unique_lists = Vec::new();
+    let mut seen = HashSet::new();
+    for item in items {
+        if seen.insert(item.list_id.clone()) {
+            unique_lists.push((item.list_id.clone(), item.list_name.clone()));
+        }
+    }
+    unique_lists
+}
+
+fn collect_relevant_tags(
+    items: &[DateItem],
+    tags: &[Tag],
+    links: &[ItemTagLink],
+) -> Vec<TagFilterOption> {
+    let item_ids: HashSet<String> = items.iter().map(|item| item.id.clone()).collect();
+    let relevant_tag_ids: HashSet<String> = links
+        .iter()
+        .filter(|link| item_ids.contains(&link.item_id))
+        .map(|link| link.tag_id.clone())
+        .collect();
+
+    let relevant_tag_ids: Vec<String> = relevant_tag_ids.into_iter().collect();
+    build_tag_filter_options(tags, &relevant_tag_ids)
+}
+
+fn filter_day_items(
+    items: &[DateItem],
+    links: &[ItemTagLink],
+    hidden_lists: &HashSet<String>,
+    hidden_tags: &HashSet<String>,
+    show_completed: bool,
+) -> Vec<DateItem> {
+    items
+        .iter()
+        .filter(|item| {
+            if hidden_lists.contains(&item.list_id) {
+                return false;
+            }
+            if !show_completed && item.completed {
+                return false;
+            }
+            if !hidden_tags.is_empty() {
+                let item_tags: HashSet<String> = links
+                    .iter()
+                    .filter(|link| link.item_id == item.id)
+                    .map(|link| link.tag_id.clone())
+                    .collect();
+                if hidden_tags.iter().any(|tag_id| item_tags.contains(tag_id)) {
+                    return false;
+                }
+            }
+            true
+        })
+        .cloned()
+        .collect()
+}
+
+fn filter_week_items(
+    days: &[DayItems],
+    links: &[ItemTagLink],
+    hidden_lists: &HashSet<String>,
+    hidden_tags: &HashSet<String>,
+    show_completed: bool,
+) -> Vec<DayItems> {
+    days.iter()
+        .map(|day| DayItems {
+            date: day.date.clone(),
+            items: filter_day_items(&day.items, links, hidden_lists, hidden_tags, show_completed),
+        })
+        .collect()
+}
+
+fn same_month(left: &str, right: &str) -> bool {
+    left.get(..7) == right.get(..7)
+}
+
+fn same_week(left: &str, right: &str) -> bool {
+    week_range(left) == week_range(right)
+}
+
+#[component]
+pub fn CalendarRootRedirect() -> impl IntoView {
+    let navigate = use_navigate();
+    let today = get_today_string();
+
+    Effect::new(move |_| {
+        let state = CalendarRouteState::new(today.clone());
+        navigate(&calendar_href(&state), Default::default());
+    });
+
+    view! { <LoadingSpinner/> }
+}
 
 #[component]
 pub fn CalendarPage() -> impl IntoView {
     let toast = use_context::<ToastContext>().expect("ToastContext missing");
     let client = use_context::<GlooClient>().expect("GlooClient not provided");
+    let navigate = use_navigate();
+    let params = use_params_map();
+    let query = use_query_map();
     let today = get_today_string();
 
+    let selected_date = RwSignal::new(today.clone());
+    let anchor_date = RwSignal::new(today.clone());
     let view_mode = RwSignal::new(ViewMode::Month);
-    let current_date = RwSignal::new(today.clone());
-
-    // Data signals
-    let month_counts = RwSignal::new(Vec::<DaySummary>::new());
-    let week_data = RwSignal::new(Vec::<DayItems>::new());
-    let all_tags = RwSignal::new(Vec::<Tag>::new());
-    let item_tag_links = RwSignal::new(Vec::<ItemTagLink>::new());
-    let (loading, set_loading) = signal(true);
-
-    // Filter signals (for week view)
     let hidden_lists = RwSignal::new(HashSet::<String>::new());
     let hidden_tags = RwSignal::new(HashSet::<String>::new());
     let show_completed = RwSignal::new(true);
 
-    // Fetch data when current_date or view_mode changes
-    let _resource = {
+    let month_counts = RwSignal::new(Vec::<DaySummary>::new());
+    let week_data = RwSignal::new(Vec::<DayItems>::new());
+    let day_items = RwSignal::new(Vec::<DateItem>::new());
+    let month_counts_cache = RwSignal::new(HashMap::<String, Vec<DaySummary>>::new());
+    let week_data_cache = RwSignal::new(HashMap::<String, Vec<DayItems>>::new());
+    let day_items_cache = RwSignal::new(HashMap::<String, Vec<DateItem>>::new());
+    let all_tags = RwSignal::new(Vec::<Tag>::new());
+    let item_tag_links = RwSignal::new(Vec::<ItemTagLink>::new());
+
+    let (calendar_loading, set_calendar_loading) = signal(true);
+    let (day_loading, set_day_loading) = signal(true);
+
+    let today_for_route = today.clone();
+    let route_state = Memo::new(move |_| {
+        let params = params.read();
+        let query = query.read();
+        calendar_state_from_maps(&params, &query, &today_for_route)
+    });
+
+    Effect::new(move |_| {
+        let state = route_state.get();
+        let current_mode = view_mode.get_untracked();
+        let current_anchor = anchor_date.get_untracked();
+
+        if selected_date.get_untracked() != state.selected_date {
+            selected_date.set(state.selected_date.clone());
+        }
+        let should_sync_anchor = current_mode != state.view_mode
+            || current_anchor.is_empty()
+            || match state.view_mode {
+                ViewMode::Month => !same_month(&current_anchor, &state.selected_date),
+                ViewMode::Week => !same_week(&current_anchor, &state.selected_date),
+            };
+        if should_sync_anchor {
+            anchor_date.set(state.selected_date.clone());
+        }
+        if view_mode.get_untracked() != state.view_mode {
+            view_mode.set(state.view_mode);
+        }
+        if hidden_lists.get_untracked() != state.hidden_lists {
+            hidden_lists.set(state.hidden_lists.clone());
+        }
+        if hidden_tags.get_untracked() != state.hidden_tags {
+            hidden_tags.set(state.hidden_tags.clone());
+        }
+        if show_completed.get_untracked() != state.show_completed {
+            show_completed.set(state.show_completed);
+        }
+    });
+
+    let _metadata_resource = {
         let client = client.clone();
         LocalResource::new(move || {
-            let date = current_date.get();
-            let mode = view_mode.get();
             let client = client.clone();
             async move {
-                set_loading.set(true);
+                if let Ok(tags) = api::fetch_tags(&client).await {
+                    all_tags.set(tags);
+                }
+                if let Ok(links) = api::fetch_item_tag_links(&client).await {
+                    item_tag_links.set(links);
+                }
+            }
+        })
+    };
+
+    let _calendar_resource = {
+        let client = client.clone();
+        LocalResource::new(move || {
+            let date = anchor_date.get();
+            let mode = view_mode.get();
+            let calendar_key = match mode {
+                ViewMode::Month => parse_date(&date)
+                    .map(|date| format!("month-{:04}-{:02}", date.year(), date.month()))
+                    .unwrap_or_else(|| "month-invalid".to_string()),
+                ViewMode::Week => {
+                    let (from, to) = week_range(&date);
+                    format!("week-{from}-{to}")
+                }
+            };
+            let client = client.clone();
+            let month_counts_cache = month_counts_cache;
+            let week_data_cache = week_data_cache;
+            async move {
+                match mode {
+                    ViewMode::Month => {
+                        if let Some(cached) = month_counts_cache
+                            .get_untracked()
+                            .get(&calendar_key)
+                            .cloned()
+                        {
+                            month_counts.set(cached);
+                            set_calendar_loading.set(false);
+                            return;
+                        }
+                    }
+                    ViewMode::Week => {
+                        if let Some(cached) =
+                            week_data_cache.get_untracked().get(&calendar_key).cloned()
+                        {
+                            week_data.set(cached);
+                            set_calendar_loading.set(false);
+                            return;
+                        }
+                    }
+                }
+
+                set_calendar_loading.set(true);
 
                 match mode {
                     ViewMode::Month => {
                         if let Some(d) = parse_date(&date) {
                             let (from, to) = month_grid_range(d.year(), d.month());
                             match api::fetch_calendar_counts(&client, &from, &to, "all").await {
-                                Ok(counts) => month_counts.set(counts),
+                                Ok(counts) => {
+                                    month_counts_cache.update(|cache| {
+                                        cache.insert(calendar_key.clone(), counts.clone());
+                                    });
+                                    month_counts.set(counts);
+                                }
                                 Err(e) => toast.push(format!("Błąd: {e}"), ToastKind::Error),
                             }
                         }
@@ -65,51 +267,147 @@ pub fn CalendarPage() -> impl IntoView {
                     ViewMode::Week => {
                         let (from, to) = week_range(&date);
                         match api::fetch_calendar_full(&client, &from, &to, "all").await {
-                            Ok(days) => week_data.set(days),
+                            Ok(days) => {
+                                week_data_cache.update(|cache| {
+                                    cache.insert(calendar_key.clone(), days.clone());
+                                });
+                                week_data.set(days);
+                            }
                             Err(e) => toast.push(format!("Błąd: {e}"), ToastKind::Error),
-                        }
-                        if let Ok(tags) = api::fetch_tags(&client).await {
-                            all_tags.set(tags);
-                        }
-                        if let Ok(links) = api::fetch_item_tag_links(&client).await {
-                            item_tag_links.set(links);
                         }
                     }
                 }
 
-                set_loading.set(false);
+                set_calendar_loading.set(false);
             }
         })
     };
 
-    let on_prev = Callback::new(move |_: ()| {
-        let date = current_date.get();
-        match view_mode.get() {
-            ViewMode::Month => {
-                if let Some(d) = parse_date(&date) {
-                    let (ny, nm) = prev_month(d.year(), d.month());
-                    current_date.set(format!("{:04}-{:02}-01", ny, nm));
+    let _day_resource = {
+        let client = client.clone();
+        LocalResource::new(move || {
+            let date = selected_date.get();
+            let mode = view_mode.get();
+            let anchor = anchor_date.get();
+            let current_week = week_data.get();
+            let client = client.clone();
+            let day_items_cache = day_items_cache;
+            async move {
+                if mode == ViewMode::Week && same_week(&anchor, &date) {
+                    let week_items_for_day = current_week
+                        .iter()
+                        .find(|day| day.date == date)
+                        .map(|day| day.items.clone())
+                        .unwrap_or_default();
+                    day_items_cache.update(|cache| {
+                        cache.insert(date.clone(), week_items_for_day.clone());
+                    });
+                    day_items.set(week_items_for_day);
+                    set_day_loading.set(false);
+                    return;
                 }
+
+                if let Some(cached) = day_items_cache.get_untracked().get(&date).cloned() {
+                    day_items.set(cached);
+                    set_day_loading.set(false);
+                    return;
+                }
+
+                set_day_loading.set(true);
+                match api::fetch_items_by_date(&client, &date, false, "all").await {
+                    Ok(items) => {
+                        day_items_cache.update(|cache| {
+                            cache.insert(date.clone(), items.clone());
+                        });
+                        day_items.set(items);
+                    }
+                    Err(e) => toast.push(format!("Błąd: {e}"), ToastKind::Error),
+                }
+                set_day_loading.set(false);
             }
-            ViewMode::Week => {
-                current_date.set(add_days(&date, -7));
-            }
-        }
+        })
+    };
+
+    let navigate_prev = navigate.clone();
+    let on_prev = Callback::new(move |_: ()| {
+        let route = route_state.get_untracked();
+        let next_anchor = match route.view_mode {
+            ViewMode::Month => shift_month_clamped(&anchor_date.get_untracked(), -1),
+            ViewMode::Week => add_days(&anchor_date.get_untracked(), -7),
+        };
+        anchor_date.set(next_anchor.clone());
+        selected_date.set(next_anchor.clone());
+        let next_state = calendar_state_with_selected_date(&route, next_anchor);
+        navigate_prev(&calendar_href(&next_state), Default::default());
     });
 
+    let navigate_next = navigate.clone();
     let on_next = Callback::new(move |_: ()| {
-        let date = current_date.get();
-        match view_mode.get() {
-            ViewMode::Month => {
-                if let Some(d) = parse_date(&date) {
-                    let (ny, nm) = next_month(d.year(), d.month());
-                    current_date.set(format!("{:04}-{:02}-01", ny, nm));
-                }
-            }
-            ViewMode::Week => {
-                current_date.set(add_days(&date, 7));
-            }
+        let route = route_state.get_untracked();
+        let next_anchor = match route.view_mode {
+            ViewMode::Month => shift_month_clamped(&anchor_date.get_untracked(), 1),
+            ViewMode::Week => add_days(&anchor_date.get_untracked(), 7),
+        };
+        anchor_date.set(next_anchor.clone());
+        selected_date.set(next_anchor.clone());
+        let next_state = calendar_state_with_selected_date(&route, next_anchor);
+        navigate_next(&calendar_href(&next_state), Default::default());
+    });
+
+    let navigate_select_date = navigate.clone();
+    let on_select_date = Callback::new(move |date: String| {
+        let route = route_state.get_untracked();
+        let current_anchor = anchor_date.get_untracked();
+        let should_update_anchor = match route.view_mode {
+            ViewMode::Month => !same_month(&current_anchor, &date),
+            ViewMode::Week => !same_week(&current_anchor, &date),
+        };
+        selected_date.set(date.clone());
+        if should_update_anchor {
+            anchor_date.set(date.clone());
         }
+        let next_state = calendar_state_with_selected_date(&route, date);
+        navigate_select_date(&calendar_href(&next_state), Default::default());
+    });
+
+    let navigate_view_mode = navigate.clone();
+    let on_view_mode_change = Callback::new(move |mode: ViewMode| {
+        let route = route_state.get_untracked();
+        view_mode.set(mode);
+        anchor_date.set(route.selected_date.clone());
+        let next_state = calendar_state_with_view_mode(&route, mode);
+        navigate_view_mode(&calendar_href(&next_state), Default::default());
+    });
+
+    let navigate_today = navigate.clone();
+    let on_today = Callback::new(move |_: ()| {
+        let route = route_state.get_untracked();
+        let today = get_today_string();
+        anchor_date.set(today.clone());
+        selected_date.set(today.clone());
+        let next_state = calendar_state_with_selected_date(&route, today);
+        navigate_today(&calendar_href(&next_state), Default::default());
+    });
+
+    let navigate_toggle_list = navigate.clone();
+    let on_toggle_list = Callback::new(move |list_id: String| {
+        let route = route_state.get_untracked();
+        let next_state = calendar_state_toggle_hidden_list(&route, &list_id);
+        navigate_toggle_list(&calendar_href(&next_state), Default::default());
+    });
+
+    let navigate_toggle_tag = navigate.clone();
+    let on_toggle_tag = Callback::new(move |tag_id: String| {
+        let route = route_state.get_untracked();
+        let next_state = calendar_state_toggle_hidden_tag(&route, &tag_id);
+        navigate_toggle_tag(&calendar_href(&next_state), Default::default());
+    });
+
+    let navigate_toggle_show_completed = navigate.clone();
+    let on_toggle_show_completed = Callback::new(move |_: ()| {
+        let route = route_state.get_untracked();
+        let next_state = calendar_state_toggle_show_completed(&route);
+        navigate_toggle_show_completed(&calendar_href(&next_state), Default::default());
     });
 
     let today_for_view = today.clone();
@@ -117,104 +415,123 @@ pub fn CalendarPage() -> impl IntoView {
     view! {
         <div class="container mx-auto max-w-5xl p-4">
             <CalendarNav
-                current_date=current_date
+                anchor_date=anchor_date
                 view_mode=view_mode
                 on_prev=on_prev
                 on_next=on_next
+                on_view_mode_change=on_view_mode_change
+                on_today=on_today
             />
 
             {move || {
-                if loading.get() {
-                    return view! { <LoadingSpinner/> }.into_any();
-                }
-
                 match view_mode.get() {
                     ViewMode::Month => {
-                        let date = current_date.get();
+                        let date = anchor_date.get();
                         if let Some(d) = parse_date(&date) {
                             view! {
-                                <MonthGrid
-                                    counts=month_counts.get()
-                                    year=d.year()
-                                    month=d.month()
-                                    today=today_for_view.clone()
-                                />
-                            }.into_any()
+                                <div class="relative">
+                                    <MonthGrid
+                                        counts=month_counts.get()
+                                        year=d.year()
+                                        month=d.month()
+                                        today=today_for_view.clone()
+                                        selected_date=selected_date.get()
+                                        on_select=on_select_date
+                                    />
+                                    {move || {
+                                        if calendar_loading.get() {
+                                            view! {
+                                                <div class="pointer-events-none absolute inset-0 rounded-xl bg-base-100/50"></div>
+                                            }.into_any()
+                                        } else {
+                                            view! { <></> }.into_any()
+                                        }
+                                    }}
+                                </div>
+                            }
+                            .into_any()
                         } else {
                             view! { <p>{move_tr!("calendar-parse-error")}</p> }.into_any()
                         }
                     }
                     ViewMode::Week => {
-                        let days = week_data.get();
-                        let tags = all_tags.get();
                         let links = item_tag_links.get();
-
-                        // Compute filter data from week items
-                        let all_items: Vec<&DateItem> = days.iter()
-                            .flat_map(|d| d.items.iter())
-                            .collect();
-
-                        let mut unique_lists: Vec<(String, String)> = Vec::new();
-                        let mut seen = HashSet::new();
-                        for item in &all_items {
-                            if seen.insert(item.list_id.clone()) {
-                                unique_lists.push((item.list_id.clone(), item.list_name.clone()));
-                            }
-                        }
-
-                        let item_ids: HashSet<String> = all_items.iter().map(|i| i.id.clone()).collect();
-                        let relevant_tag_ids: HashSet<String> = links.iter()
-                            .filter(|l| item_ids.contains(&l.item_id))
-                            .map(|l| l.tag_id.clone())
-                            .collect();
-                        let relevant_tag_ids: Vec<String> = relevant_tag_ids.into_iter().collect();
-                        let relevant_tags = build_tag_filter_options(&tags, &relevant_tag_ids);
-
-                        // Apply filters to week data
-                        let hl = hidden_lists.get();
-                        let ht = hidden_tags.get();
-                        let sc = show_completed.get();
-
-                        let filtered_days: Vec<DayItems> = days.into_iter().map(|day| {
-                            let filtered_items: Vec<DateItem> = day.items.into_iter()
-                                .filter(|item| {
-                                    if hl.contains(&item.list_id) { return false; }
-                                    if !sc && item.completed { return false; }
-                                    if !ht.is_empty() {
-                                        let item_tags: HashSet<String> = links.iter()
-                                            .filter(|l| l.item_id == item.id)
-                                            .map(|l| l.tag_id.clone())
-                                            .collect();
-                                        if ht.iter().any(|t| item_tags.contains(t)) {
-                                            return false;
-                                        }
-                                    }
-                                    true
-                                })
-                                .collect();
-                            DayItems { date: day.date, items: filtered_items }
-                        }).collect();
+                        let filtered_days = filter_week_items(
+                            &week_data.get(),
+                            &links,
+                            &hidden_lists.get(),
+                            &hidden_tags.get(),
+                            show_completed.get(),
+                        );
 
                         view! {
-                            <FilterChips
-                                unique_lists=unique_lists
-                                relevant_tags=relevant_tags
-                                hidden_lists=hidden_lists
-                                hidden_tags=hidden_tags
-                                show_completed=show_completed
-                            />
-                            <WeekView
-                                days=filtered_days
-                                today=today_for_view.clone()
-                                all_tags=tags
-                                item_tag_links=links
-                                items_signal=week_data
-                                start_date=current_date.get()
-                            />
-                        }.into_any()
+                            <div class="relative">
+                                <WeekView
+                                    days=filtered_days
+                                    today=today_for_view.clone()
+                                    all_tags=all_tags.get()
+                                    item_tag_links=links
+                                    items_signal=week_data
+                                    start_date=anchor_date.get()
+                                    selected_date=selected_date.get()
+                                    on_select=on_select_date
+                                />
+                                {move || {
+                                    if calendar_loading.get() {
+                                        view! {
+                                            <div class="pointer-events-none absolute inset-0 rounded-xl bg-base-100/50"></div>
+                                        }.into_any()
+                                    } else {
+                                        view! { <></> }.into_any()
+                                    }
+                                }}
+                            </div>
+                        }
+                        .into_any()
                     }
                 }
             }}
+
+            {move || {
+                let base_items = match view_mode.get() {
+                    ViewMode::Month => day_items.get(),
+                    ViewMode::Week => week_data
+                        .get()
+                        .into_iter()
+                        .flat_map(|day| day.items)
+                        .collect(),
+                };
+
+                let tags = all_tags.get();
+                let links = item_tag_links.get();
+
+                view! {
+                    <FilterChips
+                        unique_lists=collect_unique_lists(&base_items)
+                        relevant_tags=collect_relevant_tags(&base_items, &tags, &links)
+                        hidden_lists=hidden_lists.get()
+                        hidden_tags=hidden_tags.get()
+                        show_completed=show_completed.get()
+                        on_toggle_list=on_toggle_list
+                        on_toggle_tag=on_toggle_tag
+                        on_toggle_show_completed=on_toggle_show_completed
+                    />
+                }
+            }}
+
+            <CalendarDayPanel
+                selected_date=selected_date
+                items=day_items
+                loading=day_loading
+                all_tags=all_tags
+                item_tag_links=item_tag_links
+                hidden_lists=hidden_lists
+                hidden_tags=hidden_tags
+                show_completed=show_completed
+                on_select_date=on_select_date
+                week_items=week_data
+                sync_week=Signal::derive(move || view_mode.get() == ViewMode::Week)
+            />
         </div>
     }
     .into_any()

--- a/crates/frontend/src/pages/today.rs
+++ b/crates/frontend/src/pages/today.rs
@@ -143,15 +143,35 @@ pub fn TodayPage() -> impl IntoView {
                 }
 
                 let client_render = use_context::<GlooClient>().expect("GlooClient not provided");
+                let on_toggle_list = Callback::new(move |list_id: String| {
+                    hidden_lists.update(|lists| {
+                        if !lists.remove(&list_id) {
+                            lists.insert(list_id);
+                        }
+                    });
+                });
+                let on_toggle_tag = Callback::new(move |tag_id: String| {
+                    hidden_tags.update(|tags| {
+                        if !tags.remove(&tag_id) {
+                            tags.insert(tag_id);
+                        }
+                    });
+                });
+                let on_toggle_show_completed = Callback::new(move |_: ()| {
+                    show_completed.update(|value| *value = !*value);
+                });
 
                 view! {
                     <div>
                         <FilterChips
                             unique_lists=unique_lists
                             relevant_tags=relevant_tags
-                            hidden_lists=hidden_lists
-                            hidden_tags=hidden_tags
-                            show_completed=show_completed
+                            hidden_lists=hidden_lists.get()
+                            hidden_tags=hidden_tags.get()
+                            show_completed=show_completed.get()
+                            on_toggle_list=on_toggle_list
+                            on_toggle_tag=on_toggle_tag
+                            on_toggle_show_completed=on_toggle_show_completed
                         />
 
                         // Overdue section

--- a/crates/frontend/src/state/calendar_route.rs
+++ b/crates/frontend/src/state/calendar_route.rs
@@ -1,0 +1,348 @@
+use std::collections::HashSet;
+
+use chrono::{Datelike, NaiveDate};
+use leptos_router::params::ParamsMap;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ViewMode {
+    Month,
+    Week,
+}
+
+impl ViewMode {
+    pub fn parse(value: &str) -> Self {
+        match value {
+            "week" => Self::Week,
+            _ => Self::Month,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Month => "month",
+            Self::Week => "week",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CalendarRouteState {
+    pub selected_date: String,
+    pub view_mode: ViewMode,
+    pub hidden_lists: HashSet<String>,
+    pub hidden_tags: HashSet<String>,
+    pub show_completed: bool,
+}
+
+impl CalendarRouteState {
+    pub fn new(selected_date: String) -> Self {
+        Self {
+            selected_date,
+            view_mode: ViewMode::Month,
+            hidden_lists: HashSet::new(),
+            hidden_tags: HashSet::new(),
+            show_completed: true,
+        }
+    }
+}
+
+pub fn parse_calendar_date_parts(year: &str, month: &str, day: &str) -> Option<String> {
+    let year: i32 = year.parse().ok()?;
+    let month: u32 = month.parse().ok()?;
+    let day: u32 = day.parse().ok()?;
+    NaiveDate::from_ymd_opt(year, month, day).map(|date| date.format("%Y-%m-%d").to_string())
+}
+
+fn parse_query_set(value: Option<&str>) -> HashSet<String> {
+    value
+        .unwrap_or_default()
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+pub fn calendar_state_from_parts(
+    selected_date: Option<String>,
+    view: Option<&str>,
+    hidden_lists: Option<&str>,
+    hidden_tags: Option<&str>,
+    show_completed: Option<&str>,
+    today: &str,
+) -> CalendarRouteState {
+    let selected_date = selected_date.unwrap_or_else(|| today.to_string());
+
+    CalendarRouteState {
+        selected_date,
+        view_mode: ViewMode::parse(view.unwrap_or("month")),
+        hidden_lists: parse_query_set(hidden_lists),
+        hidden_tags: parse_query_set(hidden_tags),
+        show_completed: show_completed.unwrap_or("1") != "0",
+    }
+}
+
+pub fn calendar_state_from_maps(
+    params: &ParamsMap,
+    query: &ParamsMap,
+    today: &str,
+) -> CalendarRouteState {
+    calendar_state_from_parts(
+        parse_calendar_date_parts(
+            params.get_str("year").unwrap_or_default(),
+            params.get_str("month").unwrap_or_default(),
+            params.get_str("day").unwrap_or_default(),
+        ),
+        query.get_str("view"),
+        query.get_str("hidden_lists"),
+        query.get_str("hidden_tags"),
+        query.get_str("show_completed"),
+        today,
+    )
+}
+
+fn serialize_query_set(set: &HashSet<String>) -> Option<String> {
+    if set.is_empty() {
+        return None;
+    }
+
+    let mut values: Vec<_> = set.iter().cloned().collect();
+    values.sort();
+    Some(values.join(","))
+}
+
+fn encode_query_component(value: &str) -> String {
+    let mut encoded = String::new();
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                encoded.push(byte as char)
+            }
+            _ => encoded.push_str(&format!("%{:02X}", byte)),
+        }
+    }
+    encoded
+}
+
+pub fn calendar_query_pairs(state: &CalendarRouteState) -> Vec<(&'static str, String)> {
+    let mut pairs = vec![("view", state.view_mode.as_str().to_string())];
+    if !state.show_completed {
+        pairs.push(("show_completed", "0".to_string()));
+    }
+    if let Some(hidden_lists) = serialize_query_set(&state.hidden_lists) {
+        pairs.push(("hidden_lists", hidden_lists));
+    }
+    if let Some(hidden_tags) = serialize_query_set(&state.hidden_tags) {
+        pairs.push(("hidden_tags", hidden_tags));
+    }
+    pairs
+}
+
+pub fn calendar_href(state: &CalendarRouteState) -> String {
+    let mut path = "/calendar".to_string();
+    let Ok(date) = NaiveDate::parse_from_str(&state.selected_date, "%Y-%m-%d") else {
+        return path;
+    };
+
+    path.push_str(&format!(
+        "/{:04}/{:02}/{:02}",
+        date.year(),
+        date.month(),
+        date.day()
+    ));
+
+    let query = calendar_query_pairs(state);
+    if query.is_empty() {
+        return path;
+    }
+
+    let query = query
+        .into_iter()
+        .map(|(key, value)| format!("{key}={}", encode_query_component(&value)))
+        .collect::<Vec<_>>()
+        .join("&");
+
+    format!("{path}?{query}")
+}
+
+pub fn calendar_state_with_selected_date(
+    state: &CalendarRouteState,
+    selected_date: String,
+) -> CalendarRouteState {
+    CalendarRouteState {
+        selected_date,
+        ..state.clone()
+    }
+}
+
+pub fn calendar_state_with_view_mode(
+    state: &CalendarRouteState,
+    view_mode: ViewMode,
+) -> CalendarRouteState {
+    CalendarRouteState {
+        view_mode,
+        ..state.clone()
+    }
+}
+
+pub fn calendar_state_toggle_hidden_list(
+    state: &CalendarRouteState,
+    list_id: &str,
+) -> CalendarRouteState {
+    let mut next = state.clone();
+    if !next.hidden_lists.remove(list_id) {
+        next.hidden_lists.insert(list_id.to_string());
+    }
+    next
+}
+
+pub fn calendar_state_toggle_hidden_tag(
+    state: &CalendarRouteState,
+    tag_id: &str,
+) -> CalendarRouteState {
+    let mut next = state.clone();
+    if !next.hidden_tags.remove(tag_id) {
+        next.hidden_tags.insert(tag_id.to_string());
+    }
+    next
+}
+
+pub fn calendar_state_toggle_show_completed(state: &CalendarRouteState) -> CalendarRouteState {
+    CalendarRouteState {
+        show_completed: !state.show_completed,
+        ..state.clone()
+    }
+}
+
+pub fn shift_month_clamped(date: &str, month_delta: i32) -> String {
+    let Ok(parsed) = NaiveDate::parse_from_str(date, "%Y-%m-%d") else {
+        return date.to_string();
+    };
+
+    let (year, month) = if month_delta < 0 {
+        if parsed.month() == 1 {
+            (parsed.year() - 1, 12)
+        } else {
+            (parsed.year(), parsed.month() - 1)
+        }
+    } else if parsed.month() == 12 {
+        (parsed.year() + 1, 1)
+    } else {
+        (parsed.year(), parsed.month() + 1)
+    };
+
+    let clamped_day = parsed.day().min(days_in_month(year, month));
+    format!("{year:04}-{month:02}-{clamped_day:02}")
+}
+
+fn days_in_month(year: i32, month: u32) -> u32 {
+    let next_month = if month == 12 {
+        NaiveDate::from_ymd_opt(year + 1, 1, 1)
+    } else {
+        NaiveDate::from_ymd_opt(year, month + 1, 1)
+    };
+    let current_month = NaiveDate::from_ymd_opt(year, month, 1);
+
+    match (current_month, next_month) {
+        (Some(_), Some(next)) => (next - chrono::Days::new(1)).day(),
+        _ => 31,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn calendar_state_from_parts_parses_route_and_filters() {
+        let state = calendar_state_from_parts(
+            Some("2026-04-12".into()),
+            Some("week"),
+            Some("b,a"),
+            Some("tag-2,tag-1"),
+            Some("0"),
+            "2026-04-04",
+        );
+
+        assert_eq!(state.selected_date, "2026-04-12");
+        assert_eq!(state.view_mode, ViewMode::Week);
+        assert_eq!(state.hidden_lists.len(), 2);
+        assert!(state.hidden_lists.contains("a"));
+        assert!(state.hidden_tags.contains("tag-1"));
+        assert!(!state.show_completed);
+    }
+
+    #[test]
+    fn calendar_href_serializes_canonical_route() {
+        let mut state = CalendarRouteState::new("2026-04-12".into());
+        state.view_mode = ViewMode::Week;
+        state.show_completed = false;
+        state.hidden_lists = HashSet::from(["list-b".into(), "list-a".into()]);
+
+        assert_eq!(
+            calendar_href(&state),
+            "/calendar/2026/04/12?view=week&show_completed=0&hidden_lists=list-a%2Clist-b"
+        );
+    }
+
+    #[test]
+    fn shift_month_clamped_keeps_day_when_possible() {
+        assert_eq!(shift_month_clamped("2026-03-31", 1), "2026-04-30");
+        assert_eq!(shift_month_clamped("2026-05-30", -1), "2026-04-30");
+    }
+
+    #[test]
+    fn calendar_state_toggle_hidden_list_adds_and_removes_id() {
+        let state = CalendarRouteState::new("2026-04-12".into());
+        let hidden = calendar_state_toggle_hidden_list(&state, "list-a");
+        let visible = calendar_state_toggle_hidden_list(&hidden, "list-a");
+
+        assert!(hidden.hidden_lists.contains("list-a"));
+        assert!(!visible.hidden_lists.contains("list-a"));
+        assert_eq!(visible.selected_date, state.selected_date);
+    }
+
+    #[test]
+    fn calendar_state_toggle_hidden_tag_adds_and_removes_id() {
+        let state = CalendarRouteState::new("2026-04-12".into());
+        let hidden = calendar_state_toggle_hidden_tag(&state, "tag-a");
+        let visible = calendar_state_toggle_hidden_tag(&hidden, "tag-a");
+
+        assert!(hidden.hidden_tags.contains("tag-a"));
+        assert!(!visible.hidden_tags.contains("tag-a"));
+        assert_eq!(visible.view_mode, state.view_mode);
+    }
+
+    #[test]
+    fn calendar_state_toggle_show_completed_preserves_other_fields() {
+        let mut state = CalendarRouteState::new("2026-04-12".into());
+        state.view_mode = ViewMode::Week;
+        state.hidden_lists.insert("list-a".into());
+        state.hidden_tags.insert("tag-a".into());
+
+        let next = calendar_state_toggle_show_completed(&state);
+
+        assert!(!next.show_completed);
+        assert_eq!(next.selected_date, state.selected_date);
+        assert_eq!(next.view_mode, state.view_mode);
+        assert_eq!(next.hidden_lists, state.hidden_lists);
+        assert_eq!(next.hidden_tags, state.hidden_tags);
+    }
+
+    #[test]
+    fn calendar_state_with_selected_date_preserves_filters_and_view_mode() {
+        let mut state = CalendarRouteState::new("2026-04-12".into());
+        state.view_mode = ViewMode::Week;
+        state.hidden_lists.insert("list-a".into());
+        state.hidden_tags.insert("tag-a".into());
+        state.show_completed = false;
+
+        let next = calendar_state_with_selected_date(&state, "2026-04-15".into());
+
+        assert_eq!(next.selected_date, "2026-04-15");
+        assert_eq!(next.view_mode, ViewMode::Week);
+        assert_eq!(next.hidden_lists, state.hidden_lists);
+        assert_eq!(next.hidden_tags, state.hidden_tags);
+        assert!(!next.show_completed);
+    }
+}

--- a/crates/frontend/src/state/mod.rs
+++ b/crates/frontend/src/state/mod.rs
@@ -1,4 +1,5 @@
 pub mod admin;
+pub mod calendar_route;
 pub mod dnd;
 pub mod item_mutations;
 pub mod reorder;


### PR DESCRIPTION
## Summary
- restore navigation from calendar items to item detail pages
- refactor calendar URL synchronization so route state is updated from explicit actions instead of a global redirect effect
- tighten week-view item layout and selected-day highlighting

## Testing
- cargo test -p kartoteka-frontend -- --nocapture
- Playwright smoke check: clicking a calendar item opens /lists/:list_id/items/:id
