### PR TITLE
feat: refine tag and item detail pages

### DIFF
--- a/crates/frontend/src/components/items/item_date_summary.rs
+++ b/crates/frontend/src/components/items/item_date_summary.rs
@@ -1,0 +1,73 @@
+use kartoteka_shared::Item;
+use leptos::prelude::*;
+
+use crate::components::common::date_utils::format_date_short;
+
+fn chip_meta(item: &Item) -> Vec<(&'static str, &'static str, String)> {
+    let mut chips = Vec::new();
+
+    if let Some(date) = item.start_date.as_deref() {
+        let time = item
+            .start_time
+            .as_deref()
+            .filter(|value| !value.is_empty())
+            .map(|value| format!(" {value}"))
+            .unwrap_or_default();
+        chips.push((
+            "badge badge-info badge-sm",
+            "Start",
+            format!("{}{}", format_date_short(date), time),
+        ));
+    }
+
+    if let Some(date) = item.deadline.as_deref() {
+        let time = item
+            .deadline_time
+            .as_deref()
+            .filter(|value| !value.is_empty())
+            .map(|value| format!(" {value}"))
+            .unwrap_or_default();
+        chips.push((
+            "badge badge-warning badge-sm",
+            "Termin",
+            format!("{}{}", format_date_short(date), time),
+        ));
+    }
+
+    if let Some(date) = item.hard_deadline.as_deref() {
+        chips.push((
+            "badge badge-error badge-sm",
+            "Twardy",
+            format_date_short(date),
+        ));
+    }
+
+    chips
+}
+
+#[component]
+pub fn ItemDateSummary(item: Item) -> impl IntoView {
+    let chips = chip_meta(&item);
+
+    if chips.is_empty() {
+        return view! {}.into_any();
+    }
+
+    view! {
+        <div class="mt-2 flex flex-wrap gap-1">
+            {chips
+                .into_iter()
+                .map(|(class, label, value)| {
+                    view! {
+                        <span class=class>
+                            <span class="font-medium">{label}</span>
+                            <span class="opacity-70">"·"</span>
+                            <span>{value}</span>
+                        </span>
+                    }
+                })
+                .collect_view()}
+        </div>
+    }
+    .into_any()
+}

--- a/crates/frontend/src/components/items/mod.rs
+++ b/crates/frontend/src/components/items/mod.rs
@@ -5,5 +5,6 @@ pub mod date_editor;
 pub mod date_item_row;
 pub mod inline_date_editor_section;
 pub mod item_actions;
+pub mod item_date_summary;
 pub mod item_row;
 pub mod quantity_stepper;

--- a/crates/frontend/src/pages/item_detail.rs
+++ b/crates/frontend/src/pages/item_detail.rs
@@ -1,6 +1,7 @@
 use crate::api;
 use crate::api::client::GlooClient;
 use crate::app::{ToastContext, ToastKind};
+use crate::components::common::breadcrumbs::{BreadcrumbCrumb, Breadcrumbs};
 use crate::components::common::editable_description::EditableDescription;
 use crate::components::common::editable_title::EditableTitle;
 use crate::components::common::inline_confirm_button::InlineConfirmButton;
@@ -9,7 +10,40 @@ use crate::components::items::date_editor::DateEditor;
 use crate::components::items::quantity_stepper::QuantityStepper;
 use kartoteka_shared::*;
 use leptos::prelude::*;
-use leptos_router::hooks::use_params_map;
+use leptos_router::hooks::{use_navigate, use_params_map};
+
+fn section_card(title: &'static str, body: impl IntoView) -> impl IntoView {
+    view! {
+        <section class="rounded-[1.75rem] border border-base-300/80 bg-base-200/75 shadow-[0_24px_70px_-42px_rgba(0,0,0,0.9)] backdrop-blur-sm">
+            <div class="p-5 sm:p-6">
+                <div class="mb-4 flex items-center gap-3">
+                    <div class="h-px flex-1 bg-base-300/80"></div>
+                    <h2 class="text-sm font-semibold uppercase tracking-[0.2em] text-base-content/55">
+                        {title}
+                    </h2>
+                    <div class="h-px w-8 bg-primary/45"></div>
+                </div>
+                {body.into_view()}
+            </div>
+        </section>
+    }
+}
+
+fn detail_panel(
+    label: &'static str,
+    tone_class: &'static str,
+    body: impl IntoView,
+) -> impl IntoView {
+    view! {
+        <div class=format!("rounded-[1.35rem] border bg-base-100/90 p-4 shadow-[0_16px_40px_-28px_rgba(0,0,0,0.9)] {tone_class}")>
+            <div class="mb-3 flex items-center gap-2 text-sm font-semibold text-base-content/78">
+                <span class="inline-flex h-2.5 w-2.5 rounded-full bg-current opacity-70"></span>
+                <span>{label}</span>
+            </div>
+            {body.into_view()}
+        </div>
+    }
+}
 
 /// Helper: spawn an update_item call with toast feedback.
 fn spawn_save(
@@ -32,12 +66,11 @@ pub fn ItemDetailPage() -> impl IntoView {
     let params = use_params_map();
     let toast = expect_context::<ToastContext>();
     let client = use_context::<GlooClient>().expect("GlooClient not provided");
-    let navigate = leptos_router::hooks::use_navigate();
+    let navigate = use_navigate();
 
     let list_id = move || params.with(|p| p.get("list_id").unwrap_or_default().to_string());
     let item_id = move || params.with(|p| p.get("id").unwrap_or_default().to_string());
 
-    // Single call returns item + list context
     let detail_resource = {
         let client = client.clone();
         LocalResource::new(move || {
@@ -49,315 +82,421 @@ pub fn ItemDetailPage() -> impl IntoView {
     };
 
     view! {
-        <Suspense fallback=move || view! { <LoadingSpinner /> }>
-            {move || {
-                let result = detail_resource.get();
-
-                match result {
-                    Some(Ok(detail)) => {
-                        let item = detail.item;
-                        let lid = list_id();
-                        let list_name = detail.list_name;
-                        let features = detail.list_features;
-
-                        // Deadlines config
-                        let deadlines_config = features
-                            .iter()
-                            .find(|f| f.name == FEATURE_DEADLINES)
-                            .map(|f| f.config.clone())
-                            .unwrap_or(serde_json::Value::Null);
-                        let has_quantity = features.iter().any(|f| f.name == FEATURE_QUANTITY);
-
-                        let cfg_start = deadlines_config
-                            .get("has_start_date")
-                            .and_then(|v| v.as_bool())
-                            .unwrap_or(false);
-                        let cfg_deadline = deadlines_config
-                            .get("has_deadline")
-                            .and_then(|v| v.as_bool())
-                            .unwrap_or(false);
-                        let cfg_hard = deadlines_config
-                            .get("has_hard_deadline")
-                            .and_then(|v| v.as_bool())
-                            .unwrap_or(false);
-
-                        // Breadcrumbs (list name as link, item title as plain text)
-                        let crumbs = vec![(list_name, format!("/lists/{lid}"))];
-                        let item_title_for_crumb = item.title.clone();
-
-                        // Completed toggle
-                        let completed = RwSignal::new(item.completed);
-
-                        // Delete
-                        let lid_for_delete = list_id();
-                        let iid_for_delete = item_id();
-                        let toast_del = toast.clone();
-                        let nav = navigate.clone();
-                        let client_del = client.clone();
-
-                        // Pre-clone client for each closure
-                        let client_toggle = client.clone();
-                        let client_title = client.clone();
-                        let client_desc = client.clone();
-                        let client_start = client.clone();
-                        let client_deadline = client.clone();
-                        let client_hard = client.clone();
-                        let client_qty = client.clone();
-
-                        view! {
-                            // Breadcrumbs with item title as non-linked final crumb
-                            <div class="breadcrumbs text-sm mb-4">
-                                <ul>
-                                    <li><a href="/">"Home"</a></li>
-                                    {crumbs
-                                        .into_iter()
-                                        .map(|(label, href)| {
-                                            view! { <li><a href=href>{label}</a></li> }
-                                        })
-                                        .collect::<Vec<_>>()}
-                                    <li>{item_title_for_crumb}</li>
-                                </ul>
-                            </div>
-
-                            // Completed checkbox + title
-                            <div class="flex items-center gap-3 mb-4">
-                                <input
-                                    type="checkbox"
-                                    class="checkbox checkbox-secondary checkbox-lg"
-                                    checked=item.completed
-                                    on:change=move |_| {
-                                        let new_val = !completed.get();
-                                        completed.set(new_val);
-                                        spawn_save(
-                                            client_toggle.clone(),
-                                            list_id(),
-                                            item_id(),
-                                            toast.clone(),
-                                            UpdateItemRequest {
-                                                completed: Some(new_val),
-                                                ..Default::default()
-                                            },
-                                        );
-                                    }
-                                />
-                                <EditableTitle
-                                    value=item.title.clone()
-                                    on_save=Callback::new(move |new_title: String| {
-                                        spawn_save(
-                                            client_title.clone(),
-                                            list_id(),
-                                            item_id(),
-                                            toast.clone(),
-                                            UpdateItemRequest {
-                                                title: Some(new_title),
-                                                ..Default::default()
-                                            },
-                                        );
-                                    })
-                                />
-                            </div>
-
-                            // Description — send explicit null to clear, keep string when set
-                            <EditableDescription
-                                value=item.description.clone()
-                                on_save=Callback::new(move |new_desc: Option<String>| {
-                                    spawn_save(
-                                        client_desc.clone(),
-                                        list_id(),
-                                        item_id(),
-                                        toast.clone(),
-                                        UpdateItemRequest {
-                                            description: Some(new_desc),
-                                            ..Default::default()
-                                        },
-                                    );
-                                })
-                            />
-
-                            // Dates section
-                            {if cfg_start {
-                                view! {
-                                    <div class="mb-4">
-                                        <label class="label text-sm font-medium">
-                                            "Data rozpoczęcia"
-                                        </label>
-                                        <DateEditor
-                                            border_color="border-info"
-                                            initial_date=item.start_date.clone()
-                                            initial_time=item.start_time.clone()
-                                            has_time=true
-                                            on_change=Callback::new(
-                                                move |(date, time): (String, Option<String>)| {
-                                                    let (d, t) = if date.is_empty() {
-                                                        (Some(None), Some(None))
-                                                    } else {
-                                                        (Some(Some(date)), time.map(Some))
-                                                    };
-                                                    spawn_save(
-                                                        client_start.clone(),
-                                                        list_id(),
-                                                        item_id(),
-                                                        toast.clone(),
-                                                        UpdateItemRequest {
-                                                            start_date: d,
-                                                            start_time: t,
-                                                            ..Default::default()
-                                                        },
-                                                    );
-                                                },
-                                            )
-                                        />
-                                    </div>
-                                }
-                                    .into_any()
-                            } else {
-                                view! {}.into_any()
-                            }}
-
-                            {if cfg_deadline {
-                                view! {
-                                    <div class="mb-4">
-                                        <label class="label text-sm font-medium">"Termin"</label>
-                                        <DateEditor
-                                            border_color="border-warning"
-                                            initial_date=item.deadline.clone()
-                                            initial_time=item.deadline_time.clone()
-                                            has_time=true
-                                            on_change=Callback::new(
-                                                move |(date, time): (String, Option<String>)| {
-                                                    let (d, t) = if date.is_empty() {
-                                                        (Some(None), Some(None))
-                                                    } else {
-                                                        (Some(Some(date)), time.map(Some))
-                                                    };
-                                                    spawn_save(
-                                                        client_deadline.clone(),
-                                                        list_id(),
-                                                        item_id(),
-                                                        toast.clone(),
-                                                        UpdateItemRequest {
-                                                            deadline: d,
-                                                            deadline_time: t,
-                                                            ..Default::default()
-                                                        },
-                                                    );
-                                                },
-                                            )
-                                        />
-                                    </div>
-                                }
-                                    .into_any()
-                            } else {
-                                view! {}.into_any()
-                            }}
-
-                            {if cfg_hard {
-                                let no_time: Option<String> = None;
-                                view! {
-                                    <div class="mb-4">
-                                        <label class="label text-sm font-medium">"Twardy termin"</label>
-                                        <DateEditor
-                                            border_color="border-error"
-                                            initial_date=item.hard_deadline.clone()
-                                            initial_time=no_time
-                                            has_time=false
-                                            on_change=Callback::new(
-                                                move |(date, _time): (String, Option<String>)| {
-                                                    let d = if date.is_empty() {
-                                                        Some(None)
-                                                    } else {
-                                                        Some(Some(date))
-                                                    };
-                                                    spawn_save(
-                                                        client_hard.clone(),
-                                                        list_id(),
-                                                        item_id(),
-                                                        toast.clone(),
-                                                        UpdateItemRequest {
-                                                            hard_deadline: d,
-                                                            ..Default::default()
-                                                        },
-                                                    );
-                                                },
-                                            )
-                                        />
-                                    </div>
-                                }
-                                    .into_any()
-                            } else {
-                                view! {}.into_any()
-                            }}
-
-                            // Quantity section
-                            {if has_quantity {
-                                let target = item.quantity.unwrap_or(0);
-                                let unit = item.unit.clone().unwrap_or_default();
-                                view! {
-                                    <div class="mb-4">
-                                        <label class="label text-sm font-medium">"Ilość"</label>
-                                        <QuantityStepper
-                                            target=target
-                                            initial_actual=item.actual_quantity.unwrap_or(0)
-                                            unit=unit
-                                            on_change=Callback::new(move |new_val: i32| {
-                                                spawn_save(
-                                                    client_qty.clone(),
-                                                    list_id(),
-                                                    item_id(),
-                                                    toast.clone(),
-                                                    UpdateItemRequest {
-                                                        actual_quantity: Some(new_val),
-                                                        ..Default::default()
-                                                    },
-                                                );
-                                            })
-                                        />
-                                    </div>
-                                }
-                                    .into_any()
-                            } else {
-                                view! {}.into_any()
-                            }}
-
-                            // Delete button
-                            <div class="mt-8 pt-4 border-t border-base-300">
-                                <InlineConfirmButton
-                                    on_confirm=Callback::new(move |()| {
-                                        let lid = lid_for_delete.clone();
-                                        let iid = iid_for_delete.clone();
-                                        let toast = toast_del.clone();
-                                        let nav = nav.clone();
-                                        let client = client_del.clone();
-                                        leptos::task::spawn_local(async move {
-                                            match api::delete_item(&client, &lid, &iid).await {
-                                                Ok(_) => {
-                                                    toast.push("Usunięto".into(), ToastKind::Success);
-                                                    nav(&format!("/lists/{lid}"), Default::default());
-                                                }
-                                                Err(e) => {
-                                                    toast.push(
-                                                        format!("Błąd: {e}"),
-                                                        ToastKind::Error,
-                                                    )
-                                                }
-                                            }
-                                        });
-                                    })
-                                    label="Usuń element".to_string()
-                                    confirm_label="Na pewno usunąć?".to_string()
-                                    class="btn btn-error btn-outline btn-sm".to_string()
-                                    confirm_class="btn btn-error btn-sm".to_string()
-                                />
-                            </div>
-                        }
-                            .into_any()
-                    }
-                    Some(Err(e)) => {
-                        view! { <p class="text-error">{format!("Błąd: {e}")}</p> }.into_any()
-                    }
-                    None => view! { <LoadingSpinner /> }.into_any(),
+        <div class="mx-auto w-full max-w-4xl px-5 py-6 sm:px-8 lg:px-10">
+            <Suspense fallback=move || {
+                view! {
+                    <div class="flex min-h-64 items-center justify-center px-2">
+                        <LoadingSpinner />
+                    </div>
                 }
-            }}
-        </Suspense>
+            }>
+                {move || {
+                    let result = detail_resource.get();
+
+                    match result {
+                        Some(Ok(detail)) => {
+                            let item = detail.item;
+                            let lid = list_id();
+                            let list_name = detail.list_name;
+                            let features = detail.list_features;
+
+                            let deadlines_config = features
+                                .iter()
+                                .find(|f| f.name == FEATURE_DEADLINES)
+                                .map(|f| f.config.clone())
+                                .unwrap_or(serde_json::Value::Null);
+                            let has_quantity = features.iter().any(|f| f.name == FEATURE_QUANTITY);
+
+                            let cfg_start = deadlines_config
+                                .get("has_start_date")
+                                .and_then(|v| v.as_bool())
+                                .unwrap_or(false);
+                            let cfg_deadline = deadlines_config
+                                .get("has_deadline")
+                                .and_then(|v| v.as_bool())
+                                .unwrap_or(false);
+                            let cfg_hard = deadlines_config
+                                .get("has_hard_deadline")
+                                .and_then(|v| v.as_bool())
+                                .unwrap_or(false);
+
+                            let crumbs: Vec<BreadcrumbCrumb> =
+                                vec![(list_name.clone(), format!("/lists/{lid}"))];
+
+                            let completed = RwSignal::new(item.completed);
+
+                            let lid_for_delete = list_id();
+                            let iid_for_delete = item_id();
+                            let toast_del = toast.clone();
+                            let nav = navigate.clone();
+                            let client_del = client.clone();
+
+                            let client_toggle = client.clone();
+                            let client_title = client.clone();
+                            let client_desc = client.clone();
+                            let client_start = client.clone();
+                            let client_deadline = client.clone();
+                            let client_hard = client.clone();
+                            let client_qty = client.clone();
+
+                            let title_value = item.title.clone();
+                            let description_value = item.description.clone();
+                            let start_date = item.start_date.clone();
+                            let start_time = item.start_time.clone();
+                            let deadline_date = item.deadline.clone();
+                            let deadline_time = item.deadline_time.clone();
+                            let hard_deadline = item.hard_deadline.clone();
+                            let quantity_target = item.quantity.unwrap_or(0);
+                            let quantity_actual = item.actual_quantity.unwrap_or(0);
+                            let quantity_unit = item.unit.clone().unwrap_or_default();
+
+                            view! {
+                                <div class="space-y-6 pb-8">
+                                    <Breadcrumbs crumbs=crumbs />
+
+                                    <section class="relative overflow-hidden rounded-[2rem] border border-primary/18 bg-linear-to-br from-base-200 via-base-200/96 to-primary/10 shadow-[0_34px_100px_-48px_rgba(0,0,0,0.95)]">
+                                        <div class="pointer-events-none absolute inset-y-0 right-0 w-48 bg-linear-to-l from-primary/12 to-transparent blur-2xl"></div>
+                                        <div class="relative p-6 sm:p-8">
+                                            <div class="flex flex-col gap-5">
+                                                <div class="min-w-0 flex-1">
+                                                    <div class="mb-4 flex flex-wrap items-center gap-2">
+                                                        <a
+                                                            href=format!("/lists/{lid}")
+                                                            class="badge badge-outline h-8 border-primary/35 px-3 font-medium text-primary hover:border-primary hover:bg-primary/10"
+                                                        >
+                                                            {list_name}
+                                                        </a>
+                                                        <span
+                                                            class=move || {
+                                                                if completed.get() {
+                                                                    "badge badge-success h-8 px-3 font-medium"
+                                                                } else {
+                                                                    "badge h-8 border border-base-300 bg-base-100/70 px-3 font-medium text-base-content/72"
+                                                                }
+                                                            }
+                                                        >
+                                                            {move || if completed.get() { "Zrobione" } else { "W toku" }}
+                                                        </span>
+                                                    </div>
+
+                                                    <div class="flex items-start gap-4">
+                                                        <div class="rounded-[1.35rem] border border-primary/45 bg-primary/8 p-3 shadow-inner shadow-primary/10">
+                                                            <input
+                                                                type="checkbox"
+                                                                class="checkbox checkbox-secondary checkbox-lg"
+                                                                checked=item.completed
+                                                                on:change=move |_| {
+                                                                    let new_val = !completed.get();
+                                                                    completed.set(new_val);
+                                                                    spawn_save(
+                                                                        client_toggle.clone(),
+                                                                        list_id(),
+                                                                        item_id(),
+                                                                        toast.clone(),
+                                                                        UpdateItemRequest {
+                                                                            completed: Some(new_val),
+                                                                            ..Default::default()
+                                                                        },
+                                                                    );
+                                                                }
+                                                            />
+                                                        </div>
+                                                        <div class="min-w-0 flex-1 pt-1">
+                                                            <div class="mb-2 text-xs font-semibold uppercase tracking-[0.22em] text-base-content/45">
+                                                                "Element"
+                                                            </div>
+                                                            <div
+                                                                class=move || {
+                                                                    if completed.get() {
+                                                                        "line-through opacity-45".to_string()
+                                                                    } else {
+                                                                        String::new()
+                                                                    }
+                                                                }
+                                                            >
+                                                                <EditableTitle
+                                                                    value=title_value
+                                                                    class="block text-4xl leading-tight font-bold break-words".to_string()
+                                                                    on_save=Callback::new(move |new_title: String| {
+                                                                        spawn_save(
+                                                                            client_title.clone(),
+                                                                            list_id(),
+                                                                            item_id(),
+                                                                            toast.clone(),
+                                                                            UpdateItemRequest {
+                                                                                title: Some(new_title),
+                                                                                ..Default::default()
+                                                                            },
+                                                                        );
+                                                                    })
+                                                                />
+                                                            </div>
+                                                            <p class="mt-3 max-w-2xl text-sm leading-6 text-base-content/62">
+                                                                "Edytuj tytuł, status i szczegóły elementu w jednym miejscu."
+                                                            </p>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </section>
+
+                                    {section_card(
+                                        "Opis",
+                                        view! {
+                                            <div class="rounded-[1.35rem] border border-dashed border-base-300/80 bg-base-100/72 p-5">
+                                                <EditableDescription
+                                                    value=description_value
+                                                    on_save=Callback::new(move |new_desc: Option<String>| {
+                                                        spawn_save(
+                                                            client_desc.clone(),
+                                                            list_id(),
+                                                            item_id(),
+                                                            toast.clone(),
+                                                            UpdateItemRequest {
+                                                                description: Some(new_desc),
+                                                                ..Default::default()
+                                                            },
+                                                        );
+                                                    })
+                                                />
+                                            </div>
+                                        },
+                                    )}
+
+                                    {section_card(
+                                        "Daty",
+                                        view! {
+                                            <div class="grid gap-4 lg:grid-cols-2">
+                                                {if cfg_start {
+                                                    detail_panel(
+                                                        "Data rozpoczęcia",
+                                                        "border-info/45",
+                                                        view! {
+                                                            <DateEditor
+                                                                border_color="border-info"
+                                                                initial_date=start_date
+                                                                initial_time=start_time
+                                                                has_time=true
+                                                                on_change=Callback::new(
+                                                                    move |(date, time): (String, Option<String>)| {
+                                                                        let (d, t) = if date.is_empty() {
+                                                                            (Some(None), Some(None))
+                                                                        } else {
+                                                                            (Some(Some(date)), time.map(Some))
+                                                                        };
+                                                                        spawn_save(
+                                                                            client_start.clone(),
+                                                                            list_id(),
+                                                                            item_id(),
+                                                                            toast.clone(),
+                                                                            UpdateItemRequest {
+                                                                                start_date: d,
+                                                                                start_time: t,
+                                                                                ..Default::default()
+                                                                            },
+                                                                        );
+                                                                    },
+                                                                )
+                                                            />
+                                                        },
+                                                    ).into_any()
+                                                } else {
+                                                    view! {}.into_any()
+                                                }}
+
+                                                {if cfg_deadline {
+                                                    detail_panel(
+                                                        "Termin",
+                                                        "border-warning/45",
+                                                        view! {
+                                                            <DateEditor
+                                                                border_color="border-warning"
+                                                                initial_date=deadline_date
+                                                                initial_time=deadline_time
+                                                                has_time=true
+                                                                on_change=Callback::new(
+                                                                    move |(date, time): (String, Option<String>)| {
+                                                                        let (d, t) = if date.is_empty() {
+                                                                            (Some(None), Some(None))
+                                                                        } else {
+                                                                            (Some(Some(date)), time.map(Some))
+                                                                        };
+                                                                        spawn_save(
+                                                                            client_deadline.clone(),
+                                                                            list_id(),
+                                                                            item_id(),
+                                                                            toast.clone(),
+                                                                            UpdateItemRequest {
+                                                                                deadline: d,
+                                                                                deadline_time: t,
+                                                                                ..Default::default()
+                                                                            },
+                                                                        );
+                                                                    },
+                                                                )
+                                                            />
+                                                        },
+                                                    ).into_any()
+                                                } else {
+                                                    view! {}.into_any()
+                                                }}
+
+                                                {if cfg_hard {
+                                                    let no_time: Option<String> = None;
+                                                    detail_panel(
+                                                        "Twardy termin",
+                                                        "border-error/45",
+                                                        view! {
+                                                            <DateEditor
+                                                                border_color="border-error"
+                                                                initial_date=hard_deadline
+                                                                initial_time=no_time
+                                                                has_time=false
+                                                                on_change=Callback::new(
+                                                                    move |(date, _time): (String, Option<String>)| {
+                                                                        let d = if date.is_empty() {
+                                                                            Some(None)
+                                                                        } else {
+                                                                            Some(Some(date))
+                                                                        };
+                                                                        spawn_save(
+                                                                            client_hard.clone(),
+                                                                            list_id(),
+                                                                            item_id(),
+                                                                            toast.clone(),
+                                                                            UpdateItemRequest {
+                                                                                hard_deadline: d,
+                                                                                ..Default::default()
+                                                                            },
+                                                                        );
+                                                                    },
+                                                                )
+                                                            />
+                                                        },
+                                                    ).into_any()
+                                                } else {
+                                                    view! {}.into_any()
+                                                }}
+                                            </div>
+                                        },
+                                    )}
+
+                                    {if has_quantity {
+                                        section_card(
+                                            "Ilość",
+                                            view! {
+                                                <div class="rounded-[1.35rem] border border-base-300/80 bg-base-100/86 p-5 shadow-[0_16px_40px_-28px_rgba(0,0,0,0.9)]">
+                                                    <div class="mb-3 text-sm text-base-content/60">
+                                                        "Postęp względem celu elementu"
+                                                    </div>
+                                                    <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                                                        <div>
+                                                            <div class="text-[11px] font-semibold uppercase tracking-[0.18em] text-base-content/42">
+                                                                "Cel"
+                                                            </div>
+                                                            <div class="mt-1 text-2xl font-semibold">
+                                                                {quantity_target}
+                                                                {if quantity_unit.is_empty() { "".to_string() } else { format!(" {quantity_unit}") }}
+                                                            </div>
+                                                        </div>
+                                                        <QuantityStepper
+                                                            target=quantity_target
+                                                            initial_actual=quantity_actual
+                                                            unit=quantity_unit
+                                                            on_change=Callback::new(move |new_val: i32| {
+                                                                spawn_save(
+                                                                    client_qty.clone(),
+                                                                    list_id(),
+                                                                    item_id(),
+                                                                    toast.clone(),
+                                                                    UpdateItemRequest {
+                                                                        actual_quantity: Some(new_val),
+                                                                        ..Default::default()
+                                                                    },
+                                                                );
+                                                            })
+                                                        />
+                                                    </div>
+                                                </div>
+                                            },
+                                        ).into_any()
+                                    } else {
+                                        view! {}.into_any()
+                                    }}
+
+                                    {section_card(
+                                        "Usuń element",
+                                        view! {
+                                            <div class="flex flex-col gap-4 rounded-[1.35rem] border border-error/30 bg-linear-to-r from-error/12 to-transparent p-5 sm:flex-row sm:items-center sm:justify-between">
+                                                <div class="space-y-1">
+                                                    <p class="text-lg font-semibold text-error">
+                                                        "Ta operacja jest nieodwracalna"
+                                                    </p>
+                                                    <p class="max-w-xl text-sm leading-6 text-base-content/62">
+                                                        "Element zostanie usunięty z listy i nie będzie można go przywrócić."
+                                                    </p>
+                                                </div>
+                                                <InlineConfirmButton
+                                                    on_confirm=Callback::new(move |()| {
+                                                        let lid = lid_for_delete.clone();
+                                                        let iid = iid_for_delete.clone();
+                                                        let toast = toast_del.clone();
+                                                        let nav = nav.clone();
+                                                        let client = client_del.clone();
+                                                        leptos::task::spawn_local(async move {
+                                                            match api::delete_item(&client, &lid, &iid).await {
+                                                                Ok(_) => {
+                                                                    toast.push("Usunięto".into(), ToastKind::Success);
+                                                                    nav(&format!("/lists/{lid}"), Default::default());
+                                                                }
+                                                                Err(e) => {
+                                                                    toast.push(
+                                                                        format!("Błąd: {e}"),
+                                                                        ToastKind::Error,
+                                                                    )
+                                                                }
+                                                            }
+                                                        });
+                                                    })
+                                                    label="Usuń element".to_string()
+                                                    confirm_label="Na pewno usunąć?".to_string()
+                                                    class="btn btn-error btn-outline btn-sm".to_string()
+                                                    confirm_class="btn btn-error btn-sm".to_string()
+                                                />
+                                            </div>
+                                        },
+                                    )}
+                                </div>
+                            }
+                            .into_any()
+                        }
+                        Some(Err(e)) => {
+                            view! {
+                                <div class="space-y-4 px-2">
+                                    <div class="rounded-[1.75rem] border border-error/30 bg-error/10 p-6 shadow-[0_24px_70px_-42px_rgba(0,0,0,0.9)]">
+                                        <div>
+                                            <h2 class="text-lg font-semibold text-error">
+                                                "Nie udało się załadować elementu"
+                                            </h2>
+                                            <p class="mt-2 text-sm text-base-content/70">{format!("Błąd: {e}")}</p>
+                                        </div>
+                                    </div>
+                                </div>
+                            }
+                            .into_any()
+                        }
+                        None => {
+                            view! {
+                                <div class="flex min-h-64 items-center justify-center px-2">
+                                    <LoadingSpinner />
+                                </div>
+                            }
+                            .into_any()
+                        }
+                    }
+                }}
+            </Suspense>
+        </div>
     }
 }

--- a/crates/frontend/src/pages/tags/detail.rs
+++ b/crates/frontend/src/pages/tags/detail.rs
@@ -3,10 +3,11 @@ use crate::api::client::GlooClient;
 use crate::components::common::loading::LoadingSpinner;
 use crate::components::editable_color::EditableColor;
 use crate::components::editable_title::EditableTitle;
+use crate::components::items::item_date_summary::ItemDateSummary;
 use crate::components::tag_tree::{
     TagTreeRow, build_breadcrumb, build_subtree, get_descendant_ids,
 };
-use kartoteka_shared::{DateItem, Tag, UpdateTagRequest};
+use kartoteka_shared::{DateItem, Item, Tag, UpdateTagRequest};
 use leptos::prelude::*;
 use leptos_fluent::move_tr;
 use leptos_router::components::A;
@@ -361,17 +362,35 @@ pub fn TagDetailPage() -> impl IntoView {
                                                             </A>
                                                         </h4>
                                                         {group_items.into_iter().map(|item| {
-                                                            let title = item.title.clone();
+                                                            let detail_href = format!("/lists/{}/items/{}", item.list_id, item.id);
                                                             let completed = item.completed;
+                                                            let title = item.title.clone();
+                                                            let item: Item = item.into();
                                                             view! {
-                                                                <div class="flex items-center gap-2 py-1 pl-2">
-                                                                    <span class=if completed { "text-base-content/40" } else { "" }>
-                                                                        {if completed { "\u{2611}" } else { "\u{2610}" }}
-                                                                    </span>
-                                                                    <span class=if completed { "line-through text-base-content/40" } else { "" }>
-                                                                        {title}
-                                                                    </span>
-                                                                </div>
+                                                                <A
+                                                                    href=detail_href
+                                                                    attr:class="block rounded-box border border-transparent px-3 py-2 transition-colors hover:border-base-300 hover:bg-base-200/60"
+                                                                >
+                                                                    <div class="flex items-start gap-2">
+                                                                        <span class=if completed {
+                                                                            "pt-0.5 text-base-content/40"
+                                                                        } else {
+                                                                            "pt-0.5 text-base-content/70"
+                                                                        }>
+                                                                            {if completed { "\u{2611}" } else { "\u{2610}" }}
+                                                                        </span>
+                                                                        <div class="min-w-0 flex-1">
+                                                                            <div class=if completed {
+                                                                                "truncate line-through text-base-content/40"
+                                                                            } else {
+                                                                                "truncate text-base-content"
+                                                                            }>
+                                                                                {title}
+                                                                            </div>
+                                                                            <ItemDateSummary item=item/>
+                                                                        </div>
+                                                                    </div>
+                                                                </A>
                                                             }
                                                         }).collect::<Vec<_>>()}
                                                     </div>


### PR DESCRIPTION
## Summary
- make tag detail items clickable and show item date summaries
- redesign item detail layout into clearer section cards
- remove the extra hero metadata tiles and tighten spacing

## Testing
- cargo test -p kartoteka-frontend