### PR TITLE
fix(release): fix release-please Cargo.toml version bumping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.1"
+version = "0.4.1"
 edition = "2024"
 
 [workspace.dependencies]

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -8,9 +8,9 @@ publish = false
 workspace = true
 
 [dependencies]
-kartoteka-shared = { path = "../shared", version = "0.1.1" }
-kartoteka-domain = { path = "../domain", version = "0.1.1" }
-kartoteka-db = { path = "../db", version = "0.1.1" }
+kartoteka-shared = { path = "../shared" }
+kartoteka-domain = { path = "../domain" }
+kartoteka-db = { path = "../db" }
 axum-login.workspace = true
 tower-sessions.workspace = true
 argon2.workspace = true
@@ -23,4 +23,4 @@ async-trait.workspace = true
 
 [dev-dependencies]
 tokio.workspace = true
-kartoteka-db = { path = "../db", version = "0.1.1", features = ["test-helpers"] }
+kartoteka-db = { path = "../db", features = ["test-helpers"] }

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 test-helpers = []
 
 [dependencies]
-kartoteka-shared = { path = "../shared", version = "0.1.1", features = ["sqlx"] }
+kartoteka-shared = { path = "../shared", features = ["sqlx"] }
 sqlx.workspace = true
 chrono.workspace = true
 thiserror.workspace = true

--- a/crates/domain/Cargo.toml
+++ b/crates/domain/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 workspace = true
 
 [dependencies]
-kartoteka-shared = { path = "../shared", version = "0.1.1" }
-kartoteka-db = { path = "../db", version = "0.1.1" }
+kartoteka-shared = { path = "../shared" }
+kartoteka-db = { path = "../db" }
 thiserror.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -27,4 +27,4 @@ jsonwebtoken.workspace = true
 
 [dev-dependencies]
 tokio.workspace = true
-kartoteka-db = { path = "../db", version = "0.1.1", features = ["test-helpers"] }
+kartoteka-db = { path = "../db", features = ["test-helpers"] }

--- a/crates/frontend/Cargo.toml
+++ b/crates/frontend/Cargo.toml
@@ -11,8 +11,8 @@ crate-type = ["cdylib", "rlib"]
 workspace = true
 
 [dependencies]
-kartoteka-shared = { path = "../shared", version = "0.1.1" }
-kartoteka-i18n = { path = "../i18n", version = "0.1.1" }
+kartoteka-shared = { path = "../shared" }
+kartoteka-i18n = { path = "../i18n" }
 leptos = { workspace = true }
 leptos_router = { workspace = true }
 leptos_meta = { workspace = true, optional = true }
@@ -37,10 +37,10 @@ leptos_axum = { workspace = true, optional = true }
 axum = { workspace = true, optional = true }
 axum-login = { workspace = true, optional = true }
 sqlx = { workspace = true, optional = true }
-kartoteka-domain = { path = "../domain", version = "0.1.1", optional = true }
-kartoteka-auth = { path = "../auth", version = "0.1.1", optional = true }
-kartoteka-db = { path = "../db", version = "0.1.1", optional = true }
-kartoteka-oauth = { path = "../oauth", version = "0.1.1", optional = true }
+kartoteka-domain = { path = "../domain", optional = true }
+kartoteka-auth = { path = "../auth", optional = true }
+kartoteka-db = { path = "../db", optional = true }
+kartoteka-oauth = { path = "../oauth", optional = true }
 tower-sessions = { workspace = true, optional = true }
 chrono-tz = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }

--- a/crates/jobs/Cargo.toml
+++ b/crates/jobs/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 workspace = true
 
 [dependencies]
-kartoteka-shared = { path = "../shared", version = "0.1.1" }
-kartoteka-domain = { path = "../domain", version = "0.1.1" }
+kartoteka-shared = { path = "../shared" }
+kartoteka-domain = { path = "../domain" }

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -8,9 +8,9 @@ publish = false
 workspace = true
 
 [dependencies]
-kartoteka-shared = { path = "../shared", version = "0.1.1" }
-kartoteka-domain = { path = "../domain", version = "0.1.1" }
-kartoteka-db     = { path = "../db", version = "0.1.1" }
+kartoteka-shared = { path = "../shared" }
+kartoteka-domain = { path = "../domain" }
+kartoteka-db     = { path = "../db" }
 
 rmcp = { version = "0.3", features = ["server", "transport-streamable-http-server", "transport-worker", "macros"] }
 schemars = "1"

--- a/crates/oauth/Cargo.toml
+++ b/crates/oauth/Cargo.toml
@@ -8,10 +8,10 @@ publish = false
 workspace = true
 
 [dependencies]
-kartoteka-shared = { path = "../shared", version = "0.1.1" }
-kartoteka-domain = { path = "../domain", version = "0.1.1" }
-kartoteka-auth = { path = "../auth", version = "0.1.1" }
-kartoteka-db = { path = "../db", version = "0.1.1" }
+kartoteka-shared = { path = "../shared" }
+kartoteka-domain = { path = "../domain" }
+kartoteka-auth = { path = "../auth" }
+kartoteka-db = { path = "../db" }
 
 axum = { workspace = true }
 axum-login = { workspace = true }
@@ -37,4 +37,4 @@ urlencoding = "2"
 [dev-dependencies]
 hmac = "0.12"
 tower = { version = "0.5", features = ["util"] }
-kartoteka-db = { path = "../db", version = "0.1.1", features = ["test-helpers"] }
+kartoteka-db = { path = "../db", features = ["test-helpers"] }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -12,16 +12,16 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-kartoteka-shared = { path = "../shared", version = "0.1.1" }
-kartoteka-db = { path = "../db", version = "0.1.1" }
-kartoteka-domain = { path = "../domain", version = "0.1.1" }
-kartoteka-auth = { path = "../auth", version = "0.1.1" }
-kartoteka-mcp = { path = "../mcp", version = "0.1.1" }
-kartoteka-oauth = { path = "../oauth", version = "0.1.1" }
+kartoteka-shared = { path = "../shared" }
+kartoteka-db = { path = "../db" }
+kartoteka-domain = { path = "../domain" }
+kartoteka-auth = { path = "../auth" }
+kartoteka-mcp = { path = "../mcp" }
+kartoteka-oauth = { path = "../oauth" }
 rmcp = { version = "0.3", features = ["server", "transport-streamable-http-server"] }
 tower.workspace = true
-kartoteka-jobs = { path = "../jobs", version = "0.1.1" }
-kartoteka-frontend = { path = "../frontend", version = "0.1.1", features = ["ssr"] }
+kartoteka-jobs = { path = "../jobs" }
+kartoteka-frontend = { path = "../frontend", features = ["ssr"] }
 leptos = { workspace = true, features = ["ssr"] }
 leptos_axum = { workspace = true }
 axum-macros = { workspace = true }
@@ -46,12 +46,12 @@ tower.workspace = true
 tower-sessions.workspace = true
 tower-sessions-sqlx-store.workspace = true
 axum-login.workspace = true
-kartoteka-db = { path = "../db", version = "0.1.1", features = ["test-helpers"] }
-kartoteka-domain = { path = "../domain", version = "0.1.1" }
-kartoteka-auth = { path = "../auth", version = "0.1.1" }
+kartoteka-db = { path = "../db", features = ["test-helpers"] }
+kartoteka-domain = { path = "../domain" }
+kartoteka-auth = { path = "../auth" }
 serde_json.workspace = true
 totp-rs.workspace = true
 sha2 = "0.10"
 base64 = "0.22"
 chrono.workspace = true
-kartoteka-mcp = { path = "../mcp", version = "0.1.1" }
+kartoteka-mcp = { path = "../mcp" }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,17 +12,17 @@
     { "type": "chore", "section": "Miscellaneous", "hidden": true },
     { "type": "ci", "section": "Miscellaneous", "hidden": true }
   ],
-  "extra-files": [
-    {
-      "type": "toml",
-      "path": "Cargo.toml",
-      "jsonpath": "$.workspace.package.version"
-    }
-  ],
   "packages": {
     ".": {
       "release-type": "simple",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        {
+          "type": "toml",
+          "path": "Cargo.toml",
+          "jsonpath": "$.workspace.package.version"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

- Moved `extra-files` from root config level into `packages["."]` — release-please ignores top-level `extra-files` when a package has its own `release-type` set
- Removed hardcoded `version = "0.1.1"` from all internal workspace path dependencies — these version constraints broke the build whenever the workspace version changed (path deps within a workspace don't need version pinning)
- Synced `[workspace.package] version` from `0.1.1` → `0.4.1` to match `.release-please-manifest.json` (they were out of sync since the project started)

**Root cause of PR #131 not bumping Cargo.toml:** The `extra-files` config at root level was silently ignored. After this fix, the next release-please PR will include a `Cargo.toml` version bump alongside `CHANGELOG.md`.

## Test plan

- [ ] Verify `cargo check` passes
- [ ] Merge this PR into develop, then check that release-please regenerates PR #131 with a `Cargo.toml` change included

🤖 Generated with [Claude Code](https://claude.com/claude-code)