### PR TITLE
fix(release): switch to generic updater for Cargo.toml version bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.1" # x-release-please-version
 edition = "2024"
 
 [workspace.dependencies]

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -18,9 +18,8 @@
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
         {
-          "type": "toml",
-          "path": "Cargo.toml",
-          "jsonpath": "$.workspace.package.version"
+          "type": "generic",
+          "path": "Cargo.toml"
         }
       ]
     }


### PR DESCRIPTION
## Summary

- Changed `extra-files` in `release-please-config.json` from `type: "toml"` (jsonpath) to `type: "generic"`
- Added `# x-release-please-version` annotation to the version line in root `Cargo.toml`

## Why

The TOML jsonpath updater was silently not running (no log output in CI). Additionally, if it did run, it would reformat the entire `Cargo.toml` — removing comments and changing formatting — because it re-serializes through a TOML parser.

The generic updater does a simple string-replace on the annotated line: reliable, non-destructive, no reformatting.

All 11 workspace crates use `version.workspace = true`, so only the root `Cargo.toml` annotation is needed — Cargo propagates the version automatically.

## After merging

Release-please will regenerate PR #131 and this time include a `Cargo.toml` bump from `0.4.1` → `1.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)