### PR TITLE
feat(domain): validate item title and dates on create/update

### DIFF
--- a/crates/domain/src/items.rs
+++ b/crates/domain/src/items.rs
@@ -92,6 +92,30 @@ fn row_to_item(row: db::types::ItemRow) -> Item {
     }
 }
 
+// ── Private helpers ───────────────────────────────────────────────────────────
+
+fn effective_date_field(
+    current: &Option<FlexDate>,
+    req: Option<&Option<String>>,
+) -> Option<String> {
+    match req {
+        None => current.as_ref().map(|f| f.to_string()),
+        Some(None) => None,
+        Some(Some(s)) => Some(s.clone()),
+    }
+}
+
+fn effective_str_field<'a>(
+    current: Option<&'a str>,
+    req: Option<&'a Option<String>>,
+) -> Option<&'a str> {
+    match req {
+        None => current,
+        Some(None) => None,
+        Some(Some(s)) => Some(s.as_str()),
+    }
+}
+
 // ── Orchestration ─────────────────────────────────────────────────────────────
 
 #[tracing::instrument(skip(pool))]
@@ -128,6 +152,14 @@ pub async fn create(
         .ok_or(DomainError::NotFound("list"))?;
 
     // Phase 2: THINK
+    rules::items::validate_title(&req.title)?;
+    rules::items::validate_item_dates(
+        req.start_date.as_deref(),
+        req.start_time.as_deref(),
+        req.deadline.as_deref(),
+        req.deadline_time.as_deref(),
+        req.hard_deadline.as_deref(),
+    )?;
     let has_dates =
         req.start_date.is_some() || req.deadline.is_some() || req.hard_deadline.is_some();
     let has_quantity = req.quantity.is_some() || req.unit.is_some();
@@ -165,6 +197,36 @@ pub async fn update(
     id: &str,
     req: &UpdateItemRequest,
 ) -> Result<Option<Item>, DomainError> {
+    // Phase 1: READ
+    let current = match db::items::get_one(pool, id, user_id)
+        .await?
+        .map(row_to_item)
+    {
+        Some(i) => i,
+        None => return Ok(None),
+    };
+
+    // Phase 2: THINK
+    if let Some(title) = &req.title {
+        rules::items::validate_title(title)?;
+    }
+    let eff_start_date = effective_date_field(&current.start_date, req.start_date.as_ref());
+    let eff_start_time =
+        effective_str_field(current.start_time.as_deref(), req.start_time.as_ref());
+    let eff_deadline = effective_date_field(&current.deadline, req.deadline.as_ref());
+    let eff_deadline_time =
+        effective_str_field(current.deadline_time.as_deref(), req.deadline_time.as_ref());
+    let eff_hard_deadline =
+        effective_date_field(&current.hard_deadline, req.hard_deadline.as_ref());
+    rules::items::validate_item_dates(
+        eff_start_date.as_deref(),
+        eff_start_time,
+        eff_deadline.as_deref(),
+        eff_deadline_time,
+        eff_hard_deadline.as_deref(),
+    )?;
+
+    // Phase 3: WRITE
     let input = db::items::UpdateItemInput {
         title: req.title.clone(),
         description: req.description.clone(),
@@ -841,5 +903,136 @@ mod tests {
         let result = overdue(&pool, &user_id).await.unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].id, past.id);
+    }
+
+    #[tokio::test]
+    async fn create_item_empty_title_rejected() {
+        let pool = test_pool().await;
+        let user_id = create_test_user(&pool).await;
+        let list_id = create_list(&pool, &user_id, &[]).await;
+
+        let err = create(&pool, &user_id, &list_id, &basic_req(""))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, DomainError::Validation("title_empty")));
+    }
+
+    #[tokio::test]
+    async fn create_item_start_after_deadline_rejected() {
+        let pool = test_pool().await;
+        let user_id = create_test_user(&pool).await;
+        let list_id = create_list(&pool, &user_id, &["deadlines"]).await;
+
+        let req = CreateItemRequest {
+            start_date: Some("2026-05-10".to_string()),
+            deadline: Some("2026-05-01".to_string()),
+            ..basic_req("Bad dates")
+        };
+        let err = create(&pool, &user_id, &list_id, &req).await.unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::Validation("start_date_after_deadline")
+        ));
+    }
+
+    #[tokio::test]
+    async fn create_item_deadline_after_hard_deadline_rejected() {
+        let pool = test_pool().await;
+        let user_id = create_test_user(&pool).await;
+        let list_id = create_list(&pool, &user_id, &["deadlines"]).await;
+
+        let req = CreateItemRequest {
+            deadline: Some("2026-05-30".to_string()),
+            hard_deadline: Some("2026-05-20".to_string()),
+            ..basic_req("Bad hard deadline")
+        };
+        let err = create(&pool, &user_id, &list_id, &req).await.unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::Validation("deadline_after_hard_deadline")
+        ));
+    }
+
+    #[tokio::test]
+    async fn create_item_deadline_time_without_date_rejected() {
+        let pool = test_pool().await;
+        let user_id = create_test_user(&pool).await;
+        let list_id = create_list(&pool, &user_id, &["deadlines"]).await;
+
+        let req = CreateItemRequest {
+            deadline_time: Some("18:00".to_string()),
+            ..basic_req("Time no date")
+        };
+        let err = create(&pool, &user_id, &list_id, &req).await.unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::Validation("deadline_time_without_date")
+        ));
+    }
+
+    #[tokio::test]
+    async fn update_item_empty_title_rejected() {
+        let pool = test_pool().await;
+        let user_id = create_test_user(&pool).await;
+        let list_id = create_list(&pool, &user_id, &[]).await;
+        let item = create(&pool, &user_id, &list_id, &basic_req("Valid"))
+            .await
+            .unwrap();
+
+        let req = UpdateItemRequest {
+            title: Some("".to_string()),
+            description: None,
+            completed: None,
+            quantity: None,
+            actual_quantity: None,
+            unit: None,
+            start_date: None,
+            start_time: None,
+            deadline: None,
+            deadline_time: None,
+            hard_deadline: None,
+            estimated_duration: None,
+        };
+        let err = update(&pool, &user_id, &item.id, &req).await.unwrap_err();
+        assert!(matches!(err, DomainError::Validation("title_empty")));
+    }
+
+    #[tokio::test]
+    async fn update_item_date_order_violation_rejected() {
+        let pool = test_pool().await;
+        let user_id = create_test_user(&pool).await;
+        let list_id = create_list(&pool, &user_id, &["deadlines"]).await;
+        let item = create(
+            &pool,
+            &user_id,
+            &list_id,
+            &CreateItemRequest {
+                deadline: Some("2026-05-10".to_string()),
+                ..basic_req("Has deadline")
+            },
+        )
+        .await
+        .unwrap();
+
+        // Setting start_date after the existing deadline should fail
+        let req = UpdateItemRequest {
+            start_date: Some(Some("2026-05-20".to_string())),
+            title: None,
+            description: None,
+            completed: None,
+            quantity: None,
+            actual_quantity: None,
+            unit: None,
+            start_time: None,
+            deadline: None,
+            deadline_time: None,
+            hard_deadline: None,
+            estimated_duration: None,
+        };
+        let err = update(&pool, &user_id, &item.id, &req).await.unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::Validation("start_date_after_deadline")
+        ));
     }
 }

--- a/crates/domain/src/rules/items.rs
+++ b/crates/domain/src/rules/items.rs
@@ -1,4 +1,51 @@
 use crate::DomainError;
+use kartoteka_shared::date_utils::parse_date;
+
+pub fn validate_title(title: &str) -> Result<(), DomainError> {
+    if title.trim().is_empty() {
+        return Err(DomainError::Validation("title_empty"));
+    }
+    Ok(())
+}
+
+pub fn validate_item_dates(
+    start_date: Option<&str>,
+    start_time: Option<&str>,
+    deadline: Option<&str>,
+    deadline_time: Option<&str>,
+    hard_deadline: Option<&str>,
+) -> Result<(), DomainError> {
+    if start_time.is_some() && start_date.is_none() {
+        return Err(DomainError::Validation("start_time_without_date"));
+    }
+    if deadline_time.is_some() && deadline.is_none() {
+        return Err(DomainError::Validation("deadline_time_without_date"));
+    }
+
+    let parse = |s: &str| parse_date(s).ok_or(DomainError::Validation("invalid_date"));
+
+    let start = start_date.map(parse).transpose()?;
+    let dl = deadline.map(parse).transpose()?;
+    let hard = hard_deadline.map(parse).transpose()?;
+
+    if let (Some(s), Some(d)) = (start, dl) {
+        if s > d {
+            return Err(DomainError::Validation("start_date_after_deadline"));
+        }
+    }
+    if let (Some(d), Some(h)) = (dl, hard) {
+        if d > h {
+            return Err(DomainError::Validation("deadline_after_hard_deadline"));
+        }
+    }
+    if let (Some(s), None, Some(h)) = (start, dl, hard) {
+        if s > h {
+            return Err(DomainError::Validation("start_date_after_hard_deadline"));
+        }
+    }
+
+    Ok(())
+}
 
 /// Returns Err if item uses date/quantity fields but the list lacks the required feature.
 pub fn validate_features(
@@ -95,5 +142,90 @@ mod tests {
     #[test]
     fn validate_can_complete_passes_when_no_blockers() {
         assert!(validate_can_complete(0).is_ok());
+    }
+
+    #[test]
+    fn title_empty_rejected() {
+        assert!(matches!(
+            validate_title(""),
+            Err(DomainError::Validation("title_empty"))
+        ));
+        assert!(matches!(
+            validate_title("   "),
+            Err(DomainError::Validation("title_empty"))
+        ));
+    }
+
+    #[test]
+    fn title_nonempty_ok() {
+        assert!(validate_title("Buy milk").is_ok());
+        assert!(validate_title(" x ").is_ok());
+    }
+
+    #[test]
+    fn dates_all_none_ok() {
+        assert!(validate_item_dates(None, None, None, None, None).is_ok());
+    }
+
+    #[test]
+    fn dates_valid_order_ok() {
+        assert!(
+            validate_item_dates(
+                Some("2026-05-01"),
+                None,
+                Some("2026-05-10"),
+                None,
+                Some("2026-05-20"),
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn start_date_after_deadline_rejected() {
+        let err = validate_item_dates(Some("2026-05-10"), None, Some("2026-05-01"), None, None)
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::Validation("start_date_after_deadline")
+        ));
+    }
+
+    #[test]
+    fn deadline_after_hard_deadline_rejected() {
+        let err = validate_item_dates(None, None, Some("2026-05-30"), None, Some("2026-05-20"))
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::Validation("deadline_after_hard_deadline")
+        ));
+    }
+
+    #[test]
+    fn start_time_without_date_rejected() {
+        let err = validate_item_dates(None, Some("09:00"), None, None, None).unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::Validation("start_time_without_date")
+        ));
+    }
+
+    #[test]
+    fn deadline_time_without_date_rejected() {
+        let err = validate_item_dates(None, None, None, Some("18:00"), None).unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::Validation("deadline_time_without_date")
+        ));
+    }
+
+    #[test]
+    fn start_after_hard_deadline_without_deadline_rejected() {
+        let err = validate_item_dates(Some("2026-05-25"), None, None, None, Some("2026-05-20"))
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::Validation("start_date_after_hard_deadline")
+        ));
     }
 }

--- a/crates/domain/src/rules/items.rs
+++ b/crates/domain/src/rules/items.rs
@@ -1,5 +1,5 @@
 use crate::DomainError;
-use kartoteka_shared::date_utils::parse_date;
+use kartoteka_shared::types::FlexDate;
 
 pub fn validate_title(title: &str) -> Result<(), DomainError> {
     if title.trim().is_empty() {
@@ -22,24 +22,27 @@ pub fn validate_item_dates(
         return Err(DomainError::Validation("deadline_time_without_date"));
     }
 
-    let parse = |s: &str| parse_date(s).ok_or(DomainError::Validation("invalid_date"));
+    let parse = |s: &str| {
+        s.parse::<FlexDate>()
+            .map_err(|_| DomainError::Validation("invalid_date"))
+    };
 
-    let start = start_date.map(parse).transpose()?;
-    let dl = deadline.map(parse).transpose()?;
-    let hard = hard_deadline.map(parse).transpose()?;
+    let start: Option<FlexDate> = start_date.map(parse).transpose()?;
+    let dl: Option<FlexDate> = deadline.map(parse).transpose()?;
+    let hard: Option<FlexDate> = hard_deadline.map(parse).transpose()?;
 
-    if let (Some(s), Some(d)) = (start, dl) {
-        if s > d {
+    if let (Some(s), Some(d)) = (&start, &dl) {
+        if s.start() > d.start() {
             return Err(DomainError::Validation("start_date_after_deadline"));
         }
     }
-    if let (Some(d), Some(h)) = (dl, hard) {
-        if d > h {
+    if let (Some(d), Some(h)) = (&dl, &hard) {
+        if d.start() > h.start() {
             return Err(DomainError::Validation("deadline_after_hard_deadline"));
         }
     }
-    if let (Some(s), None, Some(h)) = (start, dl, hard) {
-        if s > h {
+    if let (Some(s), None, Some(h)) = (&start, &dl, &hard) {
+        if s.start() > h.start() {
             return Err(DomainError::Validation("start_date_after_hard_deadline"));
         }
     }
@@ -226,6 +229,27 @@ mod tests {
         assert!(matches!(
             err,
             DomainError::Validation("start_date_after_hard_deadline")
+        ));
+    }
+
+    #[test]
+    fn week_and_month_formats_accepted() {
+        // Week deadline after day start — both formats must parse without error
+        assert!(
+            validate_item_dates(Some("2026-05-01"), None, Some("2026-W20"), None, None).is_ok()
+        );
+        // Month hard_deadline after week deadline
+        assert!(validate_item_dates(None, None, Some("2026-W20"), None, Some("2026-06")).is_ok());
+    }
+
+    #[test]
+    fn week_format_order_violation_rejected() {
+        // W18 starts 2026-04-27, W17 starts 2026-04-20 — so start > deadline
+        let err =
+            validate_item_dates(Some("2026-W18"), None, Some("2026-W17"), None, None).unwrap_err();
+        assert!(matches!(
+            err,
+            DomainError::Validation("start_date_after_deadline")
         ));
     }
 }

--- a/crates/mcp/src/server.rs
+++ b/crates/mcp/src/server.rs
@@ -498,7 +498,13 @@ impl KartotekaServer {
             Self::extract_user_id_and_locale(&parts).map_err(|e| self.map_err(e, "en"))?;
         let data = domain::items::get_one(&self.pool, &p.item_id, &uid)
             .await
-            .map_err(|e| self.map_err(McpError::Domain(e), &locale))?;
+            .map_err(|e| self.map_err(McpError::Domain(e), &locale))?
+            .ok_or_else(|| {
+                self.map_err(
+                    McpError::Domain(domain::DomainError::NotFound("item")),
+                    &locale,
+                )
+            })?;
         self.json_result(data, &locale)
     }
 


### PR DESCRIPTION
## Summary

- `validate_title` — rejects empty/whitespace-only titles
- `validate_item_dates` — enforces:
  - `start_time` requires `start_date`
  - `deadline_time` requires `deadline`
  - date ordering: `start_date ≤ deadline ≤ hard_deadline`
- Both validations run before the DB write in `create` and `update`
- `update` reads the current item first and merges with the patch to validate the resulting state (not just the fields being changed)
- MCP `get_item` handler: returns `NotFound` instead of panicking on missing item

## Test plan

- [ ] Unit tests for `validate_title` and `validate_item_dates` in `crates/domain/src/rules/items.rs`
- [ ] Integration tests for `create` and `update` in `crates/domain/src/items.rs`
- [ ] `cargo test -p kartoteka-domain`

🤖 Generated with [Claude Code](https://claude.com/claude-code)