### PR TITLE
fix(ci): allow wildcard path deps for internal workspace crates

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -29,6 +29,7 @@ ignore = true
 [bans]
 multiple-versions = "warn"
 wildcards = "deny"
+allow-wildcard-paths = true
 
 [sources]
 unknown-registry = "deny"


### PR DESCRIPTION
## Summary

- Adds `allow-wildcard-paths = true` to `deny.toml`

## Why

PR #135 removed `version = "0.1.1"` from all internal workspace path dependencies (e.g. `kartoteka-shared = { path = "../shared" }`). Without a version field, `cargo-deny` flags these as wildcard dependencies — breaking CI on all subsequent PRs from develop.

`allow-wildcard-paths = true` exempts path dependencies from the wildcard check. External registry dependencies remain protected by `wildcards = "deny"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)