### PR TITLE
fix(ci): replace ff-only merge with force push to sync main from develop

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,11 +32,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Merge develop into main
+      - name: Sync main with develop
         if: ${{ steps.release.outputs.release_created }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout main
-          git merge origin/develop --ff-only
-          git push origin main
+          git push origin refs/remotes/origin/develop:refs/heads/main --force


### PR DESCRIPTION
Fixes the "Merge develop into main" step that was failing with `fatal: Not possible to fast-forward`.

**Root cause:** `main` has branch protection removed (now only `develop` is protected), but the `--ff-only` flag still required a linear history. Since PRs create merge commits on `main` that don't exist in `develop`, fast-forward is impossible.

**Fix:** Replace the merge step with a direct force push (`develop → main`). Since `main` no longer has branch protection, this works from CI without a PAT.