### PR TITLE
fix(ci): scope docker build cache by cargo_profile to share dev+preview

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -29,14 +29,16 @@ jobs:
       - id: buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
+      # Cache scope is per cargo_profile (debug/release) so dev (debug) and preview
+      # (debug) share buildkit mount cache and GHA layer cache; prod (release) is isolated.
       - name: Cache mounts
         id: cache
         uses: actions/cache@v4
         with:
           path: cache-mount
-          key: cache-mount-${{ inputs.image_tag }}-${{ hashFiles('Dockerfile', 'Cargo.lock') }}
+          key: cache-mount-${{ inputs.cargo_profile }}-${{ hashFiles('Dockerfile', 'Cargo.lock') }}
           restore-keys: |
-            cache-mount-${{ inputs.image_tag }}-
+            cache-mount-${{ inputs.cargo_profile }}-
 
       - name: Inject cache mounts
         uses: reproducible-containers/buildkit-cache-dance@v3
@@ -88,5 +90,5 @@ jobs:
           tags: ${{ steps.tags.outputs.tags }}
           build-args: |
             CARGO_PROFILE=${{ inputs.cargo_profile }}
-          cache-from: type=gha,scope=${{ inputs.image_tag }}
-          cache-to: type=gha,mode=max,scope=${{ inputs.image_tag }}
+          cache-from: type=gha,scope=${{ inputs.cargo_profile }}
+          cache-to: type=gha,mode=max,scope=${{ inputs.cargo_profile }}


### PR DESCRIPTION
Dev and preview both build with the debug profile but the cache scope was keyed by \`image_tag\` (\"develop\" vs \"preview\"), so each maintained its own cache from cold every time. Scoping by \`cargo_profile\` lets them share:
- the actions/cache tarball that backs buildkit cache mounts (\`/app/target\`, cargo registry, cargo git)
- the \`type=gha\` layer cache used by docker/build-push-action

Effect: a fresh PR's preview build warms the same cache that the next push to develop reuses (and vice-versa). Prod (release) is on its own scope so its cache isn't polluted by debug artifacts.