### PR TITLE
feat(mcp): batch create tools + create_container + client_ref mechanism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "kartoteka-auth"
-version = "0.1.1"
+version = "0.4.1"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1703,7 +1703,7 @@ dependencies = [
 
 [[package]]
 name = "kartoteka-db"
-version = "0.1.1"
+version = "0.4.1"
 dependencies = [
  "chrono",
  "kartoteka-shared",
@@ -1718,7 +1718,7 @@ dependencies = [
 
 [[package]]
 name = "kartoteka-domain"
-version = "0.1.1"
+version = "0.4.1"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1740,7 +1740,7 @@ dependencies = [
 
 [[package]]
 name = "kartoteka-frontend"
-version = "0.1.1"
+version = "0.4.1"
 dependencies = [
  "axum",
  "axum-login",
@@ -1770,7 +1770,7 @@ dependencies = [
 
 [[package]]
 name = "kartoteka-i18n"
-version = "0.1.1"
+version = "0.4.1"
 dependencies = [
  "fluent-syntax 0.12.0",
  "serde",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "kartoteka-jobs"
-version = "0.1.1"
+version = "0.4.1"
 dependencies = [
  "kartoteka-domain",
  "kartoteka-shared",
@@ -1787,7 +1787,7 @@ dependencies = [
 
 [[package]]
 name = "kartoteka-mcp"
-version = "0.1.1"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1808,11 +1808,12 @@ dependencies = [
  "tracing",
  "unic-langid",
  "urlencoding",
+ "uuid",
 ]
 
 [[package]]
 name = "kartoteka-oauth"
-version = "0.1.1"
+version = "0.4.1"
 dependencies = [
  "axum",
  "axum-login",
@@ -1843,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "kartoteka-server"
-version = "0.1.1"
+version = "0.4.1"
 dependencies = [
  "axum",
  "axum-login",
@@ -1879,7 +1880,7 @@ dependencies = [
 
 [[package]]
 name = "kartoteka-shared"
-version = "0.1.1"
+version = "0.4.1"
 dependencies = [
  "chrono",
  "chrono-tz 0.10.4",

--- a/crates/db/src/containers.rs
+++ b/crates/db/src/containers.rs
@@ -1,7 +1,7 @@
 use crate::types::ContainerRow;
 use crate::{DbError, SqlitePool};
 use kartoteka_shared::types::{CreateContainerRequest, UpdateContainerRequest};
-use sqlx::{QueryBuilder, Sqlite, SqliteConnection};
+use sqlx::SqliteConnection;
 use std::collections::HashSet;
 use uuid::Uuid;
 
@@ -81,27 +81,12 @@ pub async fn insert(
     Ok(row)
 }
 
-/// Returns the subset of `ids` that exist and are owned by `user_id`.
-/// Used for bulk parent-ownership validation before a batch insert.
-#[tracing::instrument(skip(pool, ids))]
 pub async fn find_owned_ids(
     pool: &SqlitePool,
     user_id: &str,
     ids: &[&str],
 ) -> Result<HashSet<String>, DbError> {
-    if ids.is_empty() {
-        return Ok(HashSet::new());
-    }
-    let mut qb: QueryBuilder<Sqlite> =
-        QueryBuilder::new("SELECT id FROM containers WHERE user_id = ");
-    qb.push_bind(user_id).push(" AND id IN (");
-    let mut sep = qb.separated(", ");
-    for id in ids {
-        sep.push_bind(*id);
-    }
-    qb.push(")");
-    let rows: Vec<(String,)> = qb.build_query_as().fetch_all(pool).await?;
-    Ok(rows.into_iter().map(|(id,)| id).collect())
+    crate::find_owned_ids_in(pool, "containers", user_id, ids).await
 }
 
 /// Insert a new container within a caller-owned transaction.

--- a/crates/db/src/containers.rs
+++ b/crates/db/src/containers.rs
@@ -1,6 +1,7 @@
 use crate::types::ContainerRow;
 use crate::{DbError, SqlitePool};
 use kartoteka_shared::types::{CreateContainerRequest, UpdateContainerRequest};
+use sqlx::SqliteConnection;
 use uuid::Uuid;
 
 #[derive(Debug, sqlx::FromRow)]
@@ -77,6 +78,33 @@ pub async fn insert(
     .fetch_one(pool)
     .await?;
     Ok(row)
+}
+
+/// Insert a new container within a caller-owned transaction.
+/// The caller is responsible for generating `id` and for commit/rollback.
+#[tracing::instrument(skip(conn, req), fields(id = %id))]
+pub async fn insert_in_tx(
+    conn: &mut SqliteConnection,
+    id: &str,
+    user_id: &str,
+    req: &CreateContainerRequest,
+    position: i32,
+) -> Result<(), DbError> {
+    sqlx::query(
+        "INSERT INTO containers (id, user_id, name, icon, description, status, parent_container_id, position) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(id)
+    .bind(user_id)
+    .bind(&req.name)
+    .bind(&req.icon)
+    .bind(&req.description)
+    .bind(&req.status)
+    .bind(&req.parent_container_id)
+    .bind(position)
+    .execute(&mut *conn)
+    .await?;
+    Ok(())
 }
 
 /// Update a container using read-modify-write. Returns None if not found.

--- a/crates/db/src/containers.rs
+++ b/crates/db/src/containers.rs
@@ -1,7 +1,8 @@
 use crate::types::ContainerRow;
 use crate::{DbError, SqlitePool};
 use kartoteka_shared::types::{CreateContainerRequest, UpdateContainerRequest};
-use sqlx::SqliteConnection;
+use sqlx::{QueryBuilder, Sqlite, SqliteConnection};
+use std::collections::HashSet;
 use uuid::Uuid;
 
 #[derive(Debug, sqlx::FromRow)]
@@ -78,6 +79,29 @@ pub async fn insert(
     .fetch_one(pool)
     .await?;
     Ok(row)
+}
+
+/// Returns the subset of `ids` that exist and are owned by `user_id`.
+/// Used for bulk parent-ownership validation before a batch insert.
+#[tracing::instrument(skip(pool, ids))]
+pub async fn find_owned_ids(
+    pool: &SqlitePool,
+    user_id: &str,
+    ids: &[&str],
+) -> Result<HashSet<String>, DbError> {
+    if ids.is_empty() {
+        return Ok(HashSet::new());
+    }
+    let mut qb: QueryBuilder<Sqlite> =
+        QueryBuilder::new("SELECT id FROM containers WHERE user_id = ");
+    qb.push_bind(user_id).push(" AND id IN (");
+    let mut sep = qb.separated(", ");
+    for id in ids {
+        sep.push_bind(*id);
+    }
+    qb.push(")");
+    let rows: Vec<(String,)> = qb.build_query_as().fetch_all(pool).await?;
+    Ok(rows.into_iter().map(|(id,)| id).collect())
 }
 
 /// Insert a new container within a caller-owned transaction.
@@ -605,6 +629,30 @@ mod tests {
         assert_eq!(prog.total_lists, 1);
         assert_eq!(prog.total_items, 2);
         assert_eq!(prog.completed_items, 1);
+    }
+
+    #[tokio::test]
+    async fn find_owned_ids_returns_only_owned() {
+        let pool = test_pool().await;
+        let uid_a = create_test_user(&pool).await;
+        let uid_b = create_test_user(&pool).await;
+
+        let a = insert(&pool, &uid_a, &make_req("A"), 0).await.unwrap();
+        let b = insert(&pool, &uid_b, &make_req("B"), 0).await.unwrap();
+
+        let found = find_owned_ids(&pool, &uid_a, &[a.id.as_str(), b.id.as_str()])
+            .await
+            .unwrap();
+        assert!(found.contains(&a.id));
+        assert!(!found.contains(&b.id));
+    }
+
+    #[tokio::test]
+    async fn find_owned_ids_empty_input_returns_empty() {
+        let pool = test_pool().await;
+        let uid = create_test_user(&pool).await;
+        let found = find_owned_ids(&pool, &uid, &[]).await.unwrap();
+        assert!(found.is_empty());
     }
 
     #[tokio::test]

--- a/crates/db/src/items.rs
+++ b/crates/db/src/items.rs
@@ -1,5 +1,5 @@
 use crate::{DbError, types::ItemRow};
-use sqlx::{SqliteConnection, SqlitePool};
+use sqlx::{QueryBuilder, Sqlite, SqliteConnection, SqlitePool};
 
 // ── Input types ───────────────────────────────────────────────────────────────
 
@@ -196,6 +196,45 @@ pub async fn insert(pool: &SqlitePool, input: &InsertItemInput) -> Result<ItemRo
     .fetch_one(pool)
     .await
     .map_err(DbError::Sqlx)
+}
+
+/// Batch-insert multiple items in a single multi-row VALUES statement.
+/// SQLite limits bound parameters to 999; with 14 columns per item that's 71 rows.
+/// Inputs are chunked automatically so callers don't need to worry about the limit.
+#[tracing::instrument(skip(conn, inputs), fields(count = inputs.len()))]
+pub async fn insert_many_in_tx(
+    conn: &mut SqliteConnection,
+    inputs: &[InsertItemInput],
+) -> Result<(), DbError> {
+    const CHUNK: usize = 64; // 64 × 14 = 896 params, safely under 999
+    for chunk in inputs.chunks(CHUNK) {
+        let mut qb: QueryBuilder<Sqlite> = QueryBuilder::new(
+            "INSERT INTO items (id, list_id, position, title, description, quantity, \
+             actual_quantity, unit, start_date, start_time, deadline, deadline_time, \
+             hard_deadline, estimated_duration) ",
+        );
+        qb.push_values(chunk, |mut b, i| {
+            b.push_bind(&i.id)
+                .push_bind(&i.list_id)
+                .push_bind(i.position)
+                .push_bind(&i.title)
+                .push_bind(&i.description)
+                .push_bind(i.quantity)
+                .push_bind(i.actual_quantity)
+                .push_bind(&i.unit)
+                .push_bind(&i.start_date)
+                .push_bind(&i.start_time)
+                .push_bind(&i.deadline)
+                .push_bind(&i.deadline_time)
+                .push_bind(&i.hard_deadline)
+                .push_bind(i.estimated_duration);
+        });
+        qb.build()
+            .execute(&mut *conn)
+            .await
+            .map_err(DbError::Sqlx)?;
+    }
+    Ok(())
 }
 
 /// Same INSERT as `insert` but operates on an existing transaction connection.
@@ -797,5 +836,47 @@ mod tests {
 
         let items = list_all_for_user(&pool, &uid2).await.unwrap();
         assert!(items.is_empty(), "should not see other user's items");
+    }
+
+    #[tokio::test]
+    async fn insert_many_in_tx_inserts_all_in_order() {
+        let pool = test_pool().await;
+        let uid = create_test_user(&pool).await;
+        let list_id = setup_list(&pool, &uid).await;
+
+        let inputs: Vec<InsertItemInput> = (0..5)
+            .map(|i| InsertItemInput {
+                id: uuid::Uuid::new_v4().to_string(),
+                list_id: list_id.clone(),
+                position: i,
+                title: format!("Item {i}"),
+                ..Default::default()
+            })
+            .collect();
+
+        let mut tx = pool.begin().await.unwrap();
+        insert_many_in_tx(&mut tx, &inputs).await.unwrap();
+        tx.commit().await.unwrap();
+
+        let rows = list_for_list(&pool, &list_id, &uid).await.unwrap();
+        assert_eq!(rows.len(), 5);
+        for (i, row) in rows.iter().enumerate() {
+            assert_eq!(row.title, format!("Item {i}"));
+            assert_eq!(row.position, i as i32);
+        }
+    }
+
+    #[tokio::test]
+    async fn insert_many_in_tx_empty_is_noop() {
+        let pool = test_pool().await;
+        let uid = create_test_user(&pool).await;
+        let list_id = setup_list(&pool, &uid).await;
+
+        let mut tx = pool.begin().await.unwrap();
+        insert_many_in_tx(&mut tx, &[]).await.unwrap();
+        tx.commit().await.unwrap();
+
+        let rows = list_for_list(&pool, &list_id, &uid).await.unwrap();
+        assert!(rows.is_empty());
     }
 }

--- a/crates/db/src/items.rs
+++ b/crates/db/src/items.rs
@@ -705,29 +705,27 @@ mod tests {
             let mut conn = pool.acquire().await.unwrap();
             crate::lists::insert(
                 &mut conn,
-                &lid1,
-                &uid,
-                0,
-                "L1",
-                None,
-                None,
-                "checklist",
-                None,
-                None,
+                &crate::lists::InsertListInput {
+                    id: lid1.clone(),
+                    user_id: uid.clone(),
+                    position: 0,
+                    name: "L1".to_owned(),
+                    list_type: "checklist".to_owned(),
+                    ..Default::default()
+                },
             )
             .await
             .unwrap();
             crate::lists::insert(
                 &mut conn,
-                &lid2,
-                &uid,
-                1,
-                "L2",
-                None,
-                None,
-                "checklist",
-                None,
-                None,
+                &crate::lists::InsertListInput {
+                    id: lid2.clone(),
+                    user_id: uid.clone(),
+                    position: 1,
+                    name: "L2".to_owned(),
+                    list_type: "checklist".to_owned(),
+                    ..Default::default()
+                },
             )
             .await
             .unwrap();
@@ -772,15 +770,14 @@ mod tests {
             let mut conn = pool.acquire().await.unwrap();
             crate::lists::insert(
                 &mut conn,
-                &lid,
-                &uid1,
-                0,
-                "L",
-                None,
-                None,
-                "checklist",
-                None,
-                None,
+                &crate::lists::InsertListInput {
+                    id: lid.clone(),
+                    user_id: uid1.clone(),
+                    position: 0,
+                    name: "L".to_owned(),
+                    list_type: "checklist".to_owned(),
+                    ..Default::default()
+                },
             )
             .await
             .unwrap();

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -1,7 +1,31 @@
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous};
+use sqlx::{QueryBuilder, Sqlite};
+use std::collections::HashSet;
 use std::str::FromStr;
 
 pub use sqlx::sqlite::SqlitePool;
+
+/// Bulk ownership check: returns the subset of `ids` that exist in `table` and are owned by `user_id`.
+pub(crate) async fn find_owned_ids_in(
+    pool: &SqlitePool,
+    table: &str,
+    user_id: &str,
+    ids: &[&str],
+) -> Result<HashSet<String>, DbError> {
+    if ids.is_empty() {
+        return Ok(HashSet::new());
+    }
+    let mut qb: QueryBuilder<Sqlite> =
+        QueryBuilder::new(format!("SELECT id FROM {table} WHERE user_id = "));
+    qb.push_bind(user_id).push(" AND id IN (");
+    let mut sep = qb.separated(", ");
+    for id in ids {
+        sep.push_bind(*id);
+    }
+    qb.push(")");
+    let rows: Vec<(String,)> = qb.build_query_as().fetch_all(pool).await?;
+    Ok(rows.into_iter().map(|(id,)| id).collect())
+}
 
 pub mod auth_methods;
 pub mod comments;

--- a/crates/db/src/lists.rs
+++ b/crates/db/src/lists.rs
@@ -22,6 +22,19 @@ pub struct ListRow {
     pub features: String,
 }
 
+#[derive(Debug, Default)]
+pub struct InsertListInput {
+    pub id: String,
+    pub user_id: String,
+    pub position: i64,
+    pub name: String,
+    pub icon: Option<String>,
+    pub description: Option<String>,
+    pub list_type: String,
+    pub container_id: Option<String>,
+    pub parent_list_id: Option<String>,
+}
+
 // Used by domain::items::create (B3)
 #[derive(Debug)]
 pub struct CreateItemContext {
@@ -207,34 +220,22 @@ pub async fn get_create_item_context(
 
 // ── Write queries (called in transaction) ────────────────────────────────────
 
-#[allow(clippy::too_many_arguments)]
-#[tracing::instrument(skip(tx))]
-pub async fn insert(
-    tx: &mut SqliteConnection,
-    id: &str,
-    user_id: &str,
-    position: i64,
-    name: &str,
-    icon: Option<&str>,
-    description: Option<&str>,
-    list_type: &str,
-    container_id: Option<&str>,
-    parent_list_id: Option<&str>,
-) -> Result<(), DbError> {
+#[tracing::instrument(skip(tx, input), fields(id = %input.id))]
+pub async fn insert(tx: &mut SqliteConnection, input: &InsertListInput) -> Result<(), DbError> {
     sqlx::query(
         "INSERT INTO lists (id, user_id, name, icon, description, list_type, \
                             container_id, parent_list_id, position) \
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
     )
-    .bind(id)
-    .bind(user_id)
-    .bind(name)
-    .bind(icon)
-    .bind(description)
-    .bind(list_type)
-    .bind(container_id)
-    .bind(parent_list_id)
-    .bind(position)
+    .bind(&input.id)
+    .bind(&input.user_id)
+    .bind(&input.name)
+    .bind(&input.icon)
+    .bind(&input.description)
+    .bind(&input.list_type)
+    .bind(&input.container_id)
+    .bind(&input.parent_list_id)
+    .bind(input.position)
     .execute(&mut *tx)
     .await
     .map_err(DbError::Sqlx)?;
@@ -382,15 +383,14 @@ mod tests {
         let mut tx = pool.begin().await.unwrap();
         insert(
             &mut tx,
-            &id,
-            user_id,
-            0,
-            name,
-            None,
-            None,
-            "checklist",
-            None,
-            None,
+            &InsertListInput {
+                id: id.clone(),
+                user_id: user_id.to_owned(),
+                position: 0,
+                name: name.to_owned(),
+                list_type: "checklist".to_owned(),
+                ..Default::default()
+            },
         )
         .await
         .unwrap();

--- a/crates/db/src/lists.rs
+++ b/crates/db/src/lists.rs
@@ -1,5 +1,6 @@
 use crate::DbError;
-use sqlx::{SqliteConnection, SqlitePool};
+use sqlx::{QueryBuilder, Sqlite, SqliteConnection, SqlitePool};
+use std::collections::HashSet;
 
 // ── Row types (internal to db crate) ────────────────────────────────────────
 
@@ -216,6 +217,28 @@ pub async fn get_create_item_context(
             }))
         }
     }
+}
+
+/// Returns the subset of `ids` that exist and are owned by `user_id`.
+/// Used for bulk parent-ownership validation before a batch insert.
+#[tracing::instrument(skip(pool, ids))]
+pub async fn find_owned_ids(
+    pool: &SqlitePool,
+    user_id: &str,
+    ids: &[&str],
+) -> Result<HashSet<String>, DbError> {
+    if ids.is_empty() {
+        return Ok(HashSet::new());
+    }
+    let mut qb: QueryBuilder<Sqlite> = QueryBuilder::new("SELECT id FROM lists WHERE user_id = ");
+    qb.push_bind(user_id).push(" AND id IN (");
+    let mut sep = qb.separated(", ");
+    for id in ids {
+        sep.push_bind(*id);
+    }
+    qb.push(")");
+    let rows: Vec<(String,)> = qb.build_query_as().fetch_all(pool).await?;
+    Ok(rows.into_iter().map(|(id,)| id).collect())
 }
 
 // ── Write queries (called in transaction) ────────────────────────────────────
@@ -498,6 +521,29 @@ mod tests {
 
         let ctx = get_create_item_context(&pool, &id, &other).await.unwrap();
         assert!(ctx.is_none());
+    }
+
+    #[tokio::test]
+    async fn find_owned_ids_returns_only_owned() {
+        let pool = test_pool().await;
+        let uid_a = create_test_user(&pool).await;
+        let uid_b = create_test_user(&pool).await;
+        let id_a = insert_test_list(&pool, &uid_a, "A").await;
+        let id_b = insert_test_list(&pool, &uid_b, "B").await;
+
+        let found = find_owned_ids(&pool, &uid_a, &[id_a.as_str(), id_b.as_str()])
+            .await
+            .unwrap();
+        assert!(found.contains(&id_a));
+        assert!(!found.contains(&id_b));
+    }
+
+    #[tokio::test]
+    async fn find_owned_ids_empty_input_returns_empty() {
+        let pool = test_pool().await;
+        let uid = create_test_user(&pool).await;
+        let found = find_owned_ids(&pool, &uid, &[]).await.unwrap();
+        assert!(found.is_empty());
     }
 
     #[tokio::test]

--- a/crates/db/src/lists.rs
+++ b/crates/db/src/lists.rs
@@ -1,5 +1,5 @@
 use crate::DbError;
-use sqlx::{QueryBuilder, Sqlite, SqliteConnection, SqlitePool};
+use sqlx::{SqliteConnection, SqlitePool};
 use std::collections::HashSet;
 
 // ── Row types (internal to db crate) ────────────────────────────────────────
@@ -219,26 +219,12 @@ pub async fn get_create_item_context(
     }
 }
 
-/// Returns the subset of `ids` that exist and are owned by `user_id`.
-/// Used for bulk parent-ownership validation before a batch insert.
-#[tracing::instrument(skip(pool, ids))]
 pub async fn find_owned_ids(
     pool: &SqlitePool,
     user_id: &str,
     ids: &[&str],
 ) -> Result<HashSet<String>, DbError> {
-    if ids.is_empty() {
-        return Ok(HashSet::new());
-    }
-    let mut qb: QueryBuilder<Sqlite> = QueryBuilder::new("SELECT id FROM lists WHERE user_id = ");
-    qb.push_bind(user_id).push(" AND id IN (");
-    let mut sep = qb.separated(", ");
-    for id in ids {
-        sep.push_bind(*id);
-    }
-    qb.push(")");
-    let rows: Vec<(String,)> = qb.build_query_as().fetch_all(pool).await?;
-    Ok(rows.into_iter().map(|(id,)| id).collect())
+    crate::find_owned_ids_in(pool, "lists", user_id, ids).await
 }
 
 // ── Write queries (called in transaction) ────────────────────────────────────

--- a/crates/db/src/search.rs
+++ b/crates/db/src/search.rs
@@ -66,15 +66,14 @@ mod tests {
         let mut conn = pool.acquire().await.unwrap();
         crate::lists::insert(
             &mut conn,
-            &id,
-            user_id,
-            0,
-            name,
-            None,
-            None,
-            "checklist",
-            None,
-            None,
+            &crate::lists::InsertListInput {
+                id: id.clone(),
+                user_id: user_id.to_owned(),
+                position: 0,
+                name: name.to_owned(),
+                list_type: "checklist".to_owned(),
+                ..Default::default()
+            },
         )
         .await
         .unwrap();

--- a/crates/domain/src/containers.rs
+++ b/crates/domain/src/containers.rs
@@ -54,6 +54,8 @@ pub async fn create(
     user_id: &str,
     req: &CreateContainerRequest,
 ) -> Result<Container, DomainError> {
+    rules::containers::validate_status(req.status.as_deref())?;
+
     // Phase 1: READ — if a parent is specified, fetch it
     if let Some(parent_id) = req.parent_container_id.as_deref() {
         let parent = db_containers::get_one(pool, parent_id, user_id)

--- a/crates/domain/src/lists.rs
+++ b/crates/domain/src/lists.rs
@@ -201,15 +201,17 @@ pub async fn create(
     let mut tx = pool.begin().await.map_err(db::DbError::Sqlx)?;
     db::lists::insert(
         &mut tx,
-        &list_id,
-        user_id,
-        position,
-        &req.name,
-        req.icon.as_deref(),
-        req.description.as_deref(),
-        list_type,
-        req.container_id.as_deref(),
-        req.parent_list_id.as_deref(),
+        &db::lists::InsertListInput {
+            id: list_id.clone(),
+            user_id: user_id.to_owned(),
+            position,
+            name: req.name.clone(),
+            icon: req.icon.clone(),
+            description: req.description.clone(),
+            list_type: list_type.to_owned(),
+            container_id: req.container_id.clone(),
+            parent_list_id: req.parent_list_id.clone(),
+        },
     )
     .await?;
     if !req.features.is_empty() {

--- a/crates/domain/src/lists.rs
+++ b/crates/domain/src/lists.rs
@@ -111,7 +111,7 @@ pub(crate) fn parse_features(json: &str) -> Result<Vec<ListFeature>, DomainError
 }
 
 /// Build a features JSON object from a list of names (each gets an empty config).
-fn features_from_names(names: &[String]) -> serde_json::Value {
+pub fn features_from_names(names: &[String]) -> serde_json::Value {
     let obj: serde_json::Map<String, serde_json::Value> = names
         .iter()
         .map(|n| (n.clone(), serde_json::json!({})))

--- a/crates/domain/src/rules/containers.rs
+++ b/crates/domain/src/rules/containers.rs
@@ -1,5 +1,13 @@
 use crate::DomainError;
 
+/// Validate that `status` is one of the accepted project states or absent (folder).
+pub fn validate_status(status: Option<&str>) -> Result<(), DomainError> {
+    match status {
+        None | Some("active") | Some("done") | Some("paused") => Ok(()),
+        Some(_) => Err(DomainError::Validation("invalid_container_status")),
+    }
+}
+
 /// Validate that a parent container is a folder (status IS NULL), not a project.
 /// Called before creating or moving a container under a parent.
 pub fn validate_hierarchy(parent_status: Option<&str>) -> Result<(), DomainError> {
@@ -21,6 +29,24 @@ pub fn validate_move(container_id: &str, new_parent_id: Option<&str>) -> Result<
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn valid_statuses() {
+        assert!(validate_status(None).is_ok());
+        assert!(validate_status(Some("active")).is_ok());
+        assert!(validate_status(Some("done")).is_ok());
+        assert!(validate_status(Some("paused")).is_ok());
+    }
+
+    #[test]
+    fn invalid_status_rejected() {
+        assert!(matches!(
+            validate_status(Some("invalid")),
+            Err(DomainError::Validation("invalid_container_status"))
+        ));
+        assert!(validate_status(Some("")).is_err());
+        assert!(validate_status(Some("ACTIVE")).is_err());
+    }
 
     #[test]
     fn folder_is_valid_parent() {

--- a/crates/domain/src/templates.rs
+++ b/crates/domain/src/templates.rs
@@ -169,7 +169,15 @@ pub async fn create_list_from_template(
     let mut tx = pool.begin().await.map_err(db::DbError::Sqlx)?;
 
     db::lists::insert(
-        &mut tx, &list_id, user_id, position, list_name, None, None, list_type, None, None,
+        &mut tx,
+        &db::lists::InsertListInput {
+            id: list_id.clone(),
+            user_id: user_id.to_owned(),
+            position,
+            name: list_name.to_owned(),
+            list_type: list_type.to_owned(),
+            ..Default::default()
+        },
     )
     .await?;
 

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -17,6 +17,7 @@ schemars = "1"
 sqlx = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+uuid = { workspace = true }
 http = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }

--- a/crates/mcp/src/client_ref.rs
+++ b/crates/mcp/src/client_ref.rs
@@ -1,0 +1,183 @@
+use std::collections::HashMap;
+
+/// Maps caller-chosen string labels to real UUIDs during a single batch operation.
+///
+/// Allows a batch to reference an entity created earlier in the same batch via
+/// `*_ref` fields instead of a real UUID. References are forward-only: a ref can
+/// only point to an entity registered before the current position in the batch.
+pub struct RefResolver {
+    map: HashMap<String, String>,
+}
+
+#[derive(Debug, thiserror::Error, PartialEq)]
+pub enum RefError {
+    #[error("duplicate client_ref '{0}'")]
+    Duplicate(String),
+    #[error("unknown client_ref '{0}'")]
+    Unknown(String),
+    #[error("cannot set both id '{id}' and ref '{reference}' for the same field")]
+    Conflicting { id: String, reference: String },
+    #[error("required field has neither an id nor a ref")]
+    MissingRequired,
+}
+
+impl RefResolver {
+    pub fn new() -> Self {
+        Self {
+            map: HashMap::new(),
+        }
+    }
+
+    /// Register a newly-created entity under its `client_ref` label (no-op when `None`).
+    pub fn register(&mut self, client_ref: Option<&str>, real_id: &str) -> Result<(), RefError> {
+        if let Some(label) = client_ref {
+            if self.map.contains_key(label) {
+                return Err(RefError::Duplicate(label.to_owned()));
+            }
+            self.map.insert(label.to_owned(), real_id.to_owned());
+        }
+        Ok(())
+    }
+
+    /// Resolve a reference to the real UUID registered for it.
+    pub fn resolve(&self, reference: &str) -> Result<&str, RefError> {
+        self.map
+            .get(reference)
+            .map(String::as_str)
+            .ok_or_else(|| RefError::Unknown(reference.to_owned()))
+    }
+
+    /// Pick the effective ID from an (id, ref) pair.
+    ///
+    /// - Both set → `RefError::Conflicting`
+    /// - Only `id` set → returns `Some(id)` (not resolved, already a real UUID)
+    /// - Only `reference` set → resolves and returns `Some(resolved_id)`
+    /// - Neither set and `required` → `RefError::MissingRequired`
+    /// - Neither set and optional → returns `None`
+    pub fn pick<'a>(
+        &'a self,
+        id: Option<&'a str>,
+        reference: Option<&'a str>,
+        required: bool,
+    ) -> Result<Option<&'a str>, RefError> {
+        match (id, reference) {
+            (Some(id), Some(reference)) => Err(RefError::Conflicting {
+                id: id.to_owned(),
+                reference: reference.to_owned(),
+            }),
+            (Some(id), None) => Ok(Some(id)),
+            (None, Some(reference)) => Ok(Some(self.resolve(reference)?)),
+            (None, None) if required => Err(RefError::MissingRequired),
+            (None, None) => Ok(None),
+        }
+    }
+}
+
+impl Default for RefResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn register_and_resolve() {
+        let mut r = RefResolver::new();
+        r.register(Some("proj"), "uuid-1").unwrap();
+        assert_eq!(r.resolve("proj").unwrap(), "uuid-1");
+    }
+
+    #[test]
+    fn register_none_is_noop() {
+        let mut r = RefResolver::new();
+        r.register(None, "uuid-1").unwrap();
+        assert!(r.map.is_empty());
+    }
+
+    #[test]
+    fn duplicate_ref_is_error() {
+        let mut r = RefResolver::new();
+        r.register(Some("x"), "uuid-1").unwrap();
+        assert_eq!(
+            r.register(Some("x"), "uuid-2").unwrap_err(),
+            RefError::Duplicate("x".into())
+        );
+    }
+
+    #[test]
+    fn unknown_ref_is_error() {
+        let r = RefResolver::new();
+        assert_eq!(
+            r.resolve("missing").unwrap_err(),
+            RefError::Unknown("missing".into())
+        );
+    }
+
+    #[test]
+    fn pick_id_only() {
+        let r = RefResolver::new();
+        assert_eq!(
+            r.pick(Some("real-id"), None, false).unwrap(),
+            Some("real-id")
+        );
+    }
+
+    #[test]
+    fn pick_ref_only_resolves() {
+        let mut r = RefResolver::new();
+        r.register(Some("proj"), "uuid-42").unwrap();
+        assert_eq!(r.pick(None, Some("proj"), false).unwrap(), Some("uuid-42"));
+    }
+
+    #[test]
+    fn pick_both_is_conflicting() {
+        let r = RefResolver::new();
+        assert!(matches!(
+            r.pick(Some("id"), Some("ref"), false).unwrap_err(),
+            RefError::Conflicting { .. }
+        ));
+    }
+
+    #[test]
+    fn pick_neither_optional_returns_none() {
+        let r = RefResolver::new();
+        assert_eq!(r.pick(None, None, false).unwrap(), None);
+    }
+
+    #[test]
+    fn pick_neither_required_is_error() {
+        let r = RefResolver::new();
+        assert_eq!(
+            r.pick(None, None, true).unwrap_err(),
+            RefError::MissingRequired
+        );
+    }
+
+    #[test]
+    fn forward_only_works_in_sequence() {
+        let mut r = RefResolver::new();
+        // A is created first
+        let id_a = "uuid-a";
+        r.register(Some("a"), id_a).unwrap();
+        // B references A (forward-only is maintained by the caller ordering the loop)
+        let resolved = r.pick(None, Some("a"), false).unwrap();
+        assert_eq!(resolved, Some(id_a));
+        // After creating B, register it
+        r.register(Some("b"), "uuid-b").unwrap();
+        // C references B
+        assert_eq!(r.pick(None, Some("b"), false).unwrap(), Some("uuid-b"));
+    }
+
+    #[test]
+    fn backward_ref_to_unregistered_fails() {
+        let r = RefResolver::new();
+        // "future" was never registered — behaves as unknown
+        assert_eq!(
+            r.pick(None, Some("future"), false).unwrap_err(),
+            RefError::Unknown("future".into())
+        );
+    }
+}

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -21,7 +21,7 @@ pub enum McpError {
     #[error(transparent)]
     Serde(#[from] serde_json::Error),
     #[error("bad request: {0}")]
-    BadRequest(&'static str),
+    BadRequest(String),
 }
 
 #[allow(dead_code)]

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -1,5 +1,6 @@
 //! MCP server — tools, resources, i18n. Consumed by `crates/server`.
 
+pub mod client_ref;
 pub mod i18n;
 pub mod resources;
 pub mod server;

--- a/crates/mcp/src/server.rs
+++ b/crates/mcp/src/server.rs
@@ -827,6 +827,11 @@ impl KartotekaServer {
             }
         }
 
+        for c in &p.containers {
+            domain::rules::containers::validate_status(c.status.as_deref())
+                .map_err(|e| self.map_err(McpError::Domain(e), &locale))?;
+        }
+
         // Pre-fetch next_position per unique parent scope.
         let mut scope_pos: std::collections::HashMap<Option<String>, i32> =
             std::collections::HashMap::new();

--- a/crates/mcp/src/server.rs
+++ b/crates/mcp/src/server.rs
@@ -77,7 +77,7 @@ impl KartotekaServer {
                 ("mcp-err-feature-required", vec![("feature", f)])
             }
             McpError::Domain(domain::DomainError::Forbidden) => ("mcp-err-forbidden", vec![]),
-            McpError::BadRequest(r) => ("mcp-err-validation", vec![("reason", r)]),
+            McpError::BadRequest(r) => ("mcp-err-validation", vec![("reason", r.as_str())]),
             _ => ("mcp-err-internal", vec![]),
         };
         let msg = self.i18n.translate_args(locale, key, &args);
@@ -634,9 +634,6 @@ impl KartotekaServer {
             })
             .collect();
 
-        let ids: Vec<String> = inputs.iter().map(|i| i.id.clone()).collect();
-        let titles: Vec<String> = p.items.iter().map(|i| i.title.clone()).collect();
-
         let mut tx =
             self.pool.begin().await.map_err(|e| {
                 self.map_err(McpError::Domain(db::DbError::Sqlx(e).into()), &locale)
@@ -648,10 +645,9 @@ impl KartotekaServer {
             .await
             .map_err(|e| self.map_err(McpError::Domain(db::DbError::Sqlx(e).into()), &locale))?;
 
-        let result: Vec<_> = ids
-            .into_iter()
-            .zip(titles)
-            .map(|(id, title)| serde_json::json!({"id": id, "title": title}))
+        let result: Vec<_> = inputs
+            .iter()
+            .map(|i| serde_json::json!({"id": i.id, "title": i.title}))
             .collect();
         self.json_result(result, &locale)
     }
@@ -671,11 +667,13 @@ impl KartotekaServer {
         }
 
         // Validate real container_ids / parent_list_ids referenced by UUID (not ref)
-        let container_ids: Vec<&str> = p
+        let mut container_ids: Vec<&str> = p
             .lists
             .iter()
             .filter_map(|l| l.container_id.as_deref())
             .collect();
+        container_ids.sort_unstable();
+        container_ids.dedup();
         if !container_ids.is_empty() {
             let owned = db::containers::find_owned_ids(&self.pool, &uid, &container_ids)
                 .await
@@ -686,15 +684,32 @@ impl KartotekaServer {
                 .collect();
             if !missing.is_empty() {
                 return Err(self.map_err(
-                    McpError::BadRequest("one or more container_id values not found"),
+                    McpError::BadRequest("one or more container_id values not found".into()),
                     &locale,
                 ));
             }
         }
 
-        let start_pos = db::lists::next_position(&self.pool, &uid, None, None)
-            .await
-            .map_err(|e| self.map_err(McpError::Domain(e.into()), &locale))?;
+        // Pre-fetch next_position per unique (container_id, parent_list_id) scope so that
+        // batch-created lists don't collide with existing positions within each scope.
+        // Items using *_ref fields resolve to brand-new parents (position 0) and are
+        // handled via the fallback in scope_offsets below.
+        let mut scope_pos: std::collections::HashMap<(Option<String>, Option<String>), i64> =
+            std::collections::HashMap::new();
+        for l in &p.lists {
+            if l.container_ref.is_none() && l.parent_list_ref.is_none() {
+                scope_pos
+                    .entry((l.container_id.clone(), l.parent_list_id.clone()))
+                    .or_insert(0);
+            }
+        }
+        for (key, pos) in &mut scope_pos {
+            *pos = db::lists::next_position(&self.pool, &uid, key.0.as_deref(), key.1.as_deref())
+                .await
+                .map_err(|e| self.map_err(McpError::Domain(e.into()), &locale))?;
+        }
+        let mut scope_offsets: std::collections::HashMap<(Option<String>, Option<String>), i64> =
+            std::collections::HashMap::new();
 
         let mut tx =
             self.pool.begin().await.map_err(|e| {
@@ -704,31 +719,30 @@ impl KartotekaServer {
         let mut resolver = RefResolver::new();
         let mut result = Vec::with_capacity(p.lists.len());
 
-        for (i, list) in p.lists.iter().enumerate() {
+        for list in &p.lists {
             let container_id = resolver
                 .pick(
                     list.container_id.as_deref(),
                     list.container_ref.as_deref(),
                     false,
                 )
-                .map_err(|e| {
-                    self.map_err(
-                        McpError::BadRequest(Box::leak(e.to_string().into_boxed_str())),
-                        &locale,
-                    )
-                })?;
+                .map_err(|e| self.map_err(McpError::BadRequest(e.to_string()), &locale))?;
             let parent_list_id = resolver
                 .pick(
                     list.parent_list_id.as_deref(),
                     list.parent_list_ref.as_deref(),
                     false,
                 )
-                .map_err(|e| {
-                    self.map_err(
-                        McpError::BadRequest(Box::leak(e.to_string().into_boxed_str())),
-                        &locale,
-                    )
-                })?;
+                .map_err(|e| self.map_err(McpError::BadRequest(e.to_string()), &locale))?;
+
+            let scope_key = (
+                container_id.map(str::to_owned),
+                parent_list_id.map(str::to_owned),
+            );
+            let base = scope_pos.get(&scope_key).copied().unwrap_or(0);
+            let offset = scope_offsets.entry(scope_key).or_insert(0);
+            let position = base + *offset;
+            *offset += 1;
 
             let list_type = list.list_type.as_deref().unwrap_or("custom");
             let new_id = Uuid::new_v4().to_string();
@@ -738,7 +752,7 @@ impl KartotekaServer {
                 &InsertListInput {
                     id: new_id.clone(),
                     user_id: uid.clone(),
-                    position: start_pos + i as i64,
+                    position,
                     name: list.name.clone(),
                     icon: list.icon.clone(),
                     description: list.description.clone(),
@@ -761,12 +775,7 @@ impl KartotekaServer {
 
             resolver
                 .register(list.client_ref.as_deref(), &new_id)
-                .map_err(|e| {
-                    self.map_err(
-                        McpError::BadRequest(Box::leak(e.to_string().into_boxed_str())),
-                        &locale,
-                    )
-                })?;
+                .map_err(|e| self.map_err(McpError::BadRequest(e.to_string()), &locale))?;
 
             result.push(serde_json::json!({"id": new_id, "name": list.name}));
         }
@@ -795,11 +804,13 @@ impl KartotekaServer {
         }
 
         // Validate real parent_container_ids referenced by UUID (not ref)
-        let parent_ids: Vec<&str> = p
+        let mut parent_ids: Vec<&str> = p
             .containers
             .iter()
             .filter_map(|c| c.parent_container_id.as_deref())
             .collect();
+        parent_ids.sort_unstable();
+        parent_ids.dedup();
         if !parent_ids.is_empty() {
             let owned = db::containers::find_owned_ids(&self.pool, &uid, &parent_ids)
                 .await
@@ -810,15 +821,27 @@ impl KartotekaServer {
                 .collect();
             if !missing.is_empty() {
                 return Err(self.map_err(
-                    McpError::BadRequest("one or more parent_container_id values not found"),
+                    McpError::BadRequest("one or more parent_container_id values not found".into()),
                     &locale,
                 ));
             }
         }
 
-        let start_pos = db::containers::next_position(&self.pool, &uid, None)
-            .await
-            .map_err(|e| self.map_err(McpError::Domain(e.into()), &locale))?;
+        // Pre-fetch next_position per unique parent scope.
+        let mut scope_pos: std::collections::HashMap<Option<String>, i32> =
+            std::collections::HashMap::new();
+        for c in &p.containers {
+            if c.parent_container_ref.is_none() {
+                scope_pos.entry(c.parent_container_id.clone()).or_insert(0);
+            }
+        }
+        for (key, pos) in &mut scope_pos {
+            *pos = db::containers::next_position(&self.pool, &uid, key.as_deref())
+                .await
+                .map_err(|e| self.map_err(McpError::Domain(e.into()), &locale))?;
+        }
+        let mut scope_offsets: std::collections::HashMap<Option<String>, i32> =
+            std::collections::HashMap::new();
 
         let mut tx =
             self.pool.begin().await.map_err(|e| {
@@ -828,19 +851,20 @@ impl KartotekaServer {
         let mut resolver = RefResolver::new();
         let mut result = Vec::with_capacity(p.containers.len());
 
-        for (i, container) in p.containers.iter().enumerate() {
+        for container in &p.containers {
             let parent_id = resolver
                 .pick(
                     container.parent_container_id.as_deref(),
                     container.parent_container_ref.as_deref(),
                     false,
                 )
-                .map_err(|e| {
-                    self.map_err(
-                        McpError::BadRequest(Box::leak(e.to_string().into_boxed_str())),
-                        &locale,
-                    )
-                })?;
+                .map_err(|e| self.map_err(McpError::BadRequest(e.to_string()), &locale))?;
+
+            let scope_key = parent_id.map(str::to_owned);
+            let base = scope_pos.get(&scope_key).copied().unwrap_or(0);
+            let offset = scope_offsets.entry(scope_key).or_insert(0);
+            let position = base + *offset;
+            *offset += 1;
 
             let new_id = Uuid::new_v4().to_string();
             let req = CreateContainerRequest {
@@ -851,18 +875,13 @@ impl KartotekaServer {
                 parent_container_id: parent_id.map(str::to_owned),
             };
 
-            db::containers::insert_in_tx(&mut tx, &new_id, &uid, &req, start_pos + i as i32)
+            db::containers::insert_in_tx(&mut tx, &new_id, &uid, &req, position)
                 .await
                 .map_err(|e| self.map_err(McpError::Domain(e.into()), &locale))?;
 
             resolver
                 .register(container.client_ref.as_deref(), &new_id)
-                .map_err(|e| {
-                    self.map_err(
-                        McpError::BadRequest(Box::leak(e.to_string().into_boxed_str())),
-                        &locale,
-                    )
-                })?;
+                .map_err(|e| self.map_err(McpError::BadRequest(e.to_string()), &locale))?;
 
             result.push(serde_json::json!({"id": new_id, "name": container.name}));
         }

--- a/crates/mcp/src/server.rs
+++ b/crates/mcp/src/server.rs
@@ -1,6 +1,10 @@
 use http::request::Parts;
+use kartoteka_db::{self as db, lists::InsertListInput};
 use kartoteka_domain as domain;
-use kartoteka_shared::auth_ctx::{UserId, UserLocale};
+use kartoteka_shared::{
+    auth_ctx::{UserId, UserLocale},
+    types::CreateContainerRequest,
+};
 use rmcp::{
     ErrorData, RoleServer, ServerHandler,
     handler::server::{
@@ -18,10 +22,15 @@ use rmcp::{
 use serde_json::json;
 use sqlx::SqlitePool;
 use std::sync::Arc;
+use uuid::Uuid;
 
+use crate::client_ref::RefResolver;
 use crate::tools::{
     comments::AddCommentParams,
-    items::{CreateItemParams, CreateListParams, UpdateItemParams},
+    items::{
+        CreateContainerParams, CreateContainersParams, CreateItemParams, CreateItemsParams,
+        CreateListParams, CreateListsParams, UpdateItemParams,
+    },
     read::{GetContainerParams, GetItemParams, GetListParams, ListItemsParams},
     relations::{AddRelationParams, RemoveRelationParams},
     search::SearchItemsParams,
@@ -549,6 +558,320 @@ impl KartotekaServer {
             .map_err(|e| self.map_err(McpError::Domain(e), &locale))?;
         self.json_result(data, &locale)
     }
+
+    // ── New tools: create_container + batch creates ───────────────────────────
+
+    #[rmcp::tool(
+        name = "create_container",
+        description = "mcp-tool-create_container-desc"
+    )]
+    #[tracing::instrument(skip(self, parts), fields(action = "mcp_create_container"))]
+    async fn create_container(
+        &self,
+        Extension(parts): Extension<Parts>,
+        Parameters(p): Parameters<CreateContainerParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let (uid, locale) =
+            Self::extract_user_id_and_locale(&parts).map_err(|e| self.map_err(e, "en"))?;
+        let req = CreateContainerRequest {
+            name: p.name,
+            icon: p.icon,
+            description: p.description,
+            status: p.status,
+            parent_container_id: p.parent_container_id,
+        };
+        let container = domain::containers::create(&self.pool, &uid, &req)
+            .await
+            .map_err(|e| self.map_err(McpError::Domain(e), &locale))?;
+        self.json_result(container, &locale)
+    }
+
+    #[rmcp::tool(name = "create_items", description = "mcp-tool-create_items-desc")]
+    #[tracing::instrument(skip(self, parts), fields(action = "mcp_create_items"))]
+    async fn create_items(
+        &self,
+        Extension(parts): Extension<Parts>,
+        Parameters(p): Parameters<CreateItemsParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let (uid, locale) =
+            Self::extract_user_id_and_locale(&parts).map_err(|e| self.map_err(e, "en"))?;
+
+        if p.items.is_empty() {
+            return self.json_result(Vec::<serde_json::Value>::new(), &locale);
+        }
+
+        // Validate list ownership + get starting position in one query
+        let ctx = db::lists::get_create_item_context(&self.pool, &p.list_id, &uid)
+            .await
+            .map_err(|e| self.map_err(McpError::Domain(e.into()), &locale))?
+            .ok_or_else(|| {
+                self.map_err(
+                    McpError::Domain(domain::DomainError::NotFound("list")),
+                    &locale,
+                )
+            })?;
+
+        let start_pos = ctx.next_position as i32;
+        let inputs: Vec<db::items::InsertItemInput> = p
+            .items
+            .iter()
+            .enumerate()
+            .map(|(i, item)| db::items::InsertItemInput {
+                id: Uuid::new_v4().to_string(),
+                list_id: p.list_id.clone(),
+                position: start_pos + i as i32,
+                title: item.title.clone(),
+                description: item.description.clone(),
+                start_date: item.start_date.clone(),
+                deadline: item.deadline.clone(),
+                hard_deadline: item.hard_deadline.clone(),
+                start_time: item.start_time.clone(),
+                deadline_time: item.deadline_time.clone(),
+                quantity: item.quantity,
+                actual_quantity: item.actual_quantity,
+                unit: item.unit.clone(),
+                estimated_duration: item.estimated_duration,
+            })
+            .collect();
+
+        let ids: Vec<String> = inputs.iter().map(|i| i.id.clone()).collect();
+        let titles: Vec<String> = p.items.iter().map(|i| i.title.clone()).collect();
+
+        let mut tx =
+            self.pool.begin().await.map_err(|e| {
+                self.map_err(McpError::Domain(db::DbError::Sqlx(e).into()), &locale)
+            })?;
+        db::items::insert_many_in_tx(&mut tx, &inputs)
+            .await
+            .map_err(|e| self.map_err(McpError::Domain(e.into()), &locale))?;
+        tx.commit()
+            .await
+            .map_err(|e| self.map_err(McpError::Domain(db::DbError::Sqlx(e).into()), &locale))?;
+
+        let result: Vec<_> = ids
+            .into_iter()
+            .zip(titles)
+            .map(|(id, title)| serde_json::json!({"id": id, "title": title}))
+            .collect();
+        self.json_result(result, &locale)
+    }
+
+    #[rmcp::tool(name = "create_lists", description = "mcp-tool-create_lists-desc")]
+    #[tracing::instrument(skip(self, parts), fields(action = "mcp_create_lists"))]
+    async fn create_lists(
+        &self,
+        Extension(parts): Extension<Parts>,
+        Parameters(p): Parameters<CreateListsParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let (uid, locale) =
+            Self::extract_user_id_and_locale(&parts).map_err(|e| self.map_err(e, "en"))?;
+
+        if p.lists.is_empty() {
+            return self.json_result(Vec::<serde_json::Value>::new(), &locale);
+        }
+
+        // Validate real container_ids / parent_list_ids referenced by UUID (not ref)
+        let container_ids: Vec<&str> = p
+            .lists
+            .iter()
+            .filter_map(|l| l.container_id.as_deref())
+            .collect();
+        if !container_ids.is_empty() {
+            let owned = db::containers::find_owned_ids(&self.pool, &uid, &container_ids)
+                .await
+                .map_err(|e| self.map_err(McpError::Domain(e.into()), &locale))?;
+            let missing: Vec<_> = container_ids
+                .iter()
+                .filter(|id| !owned.contains(**id))
+                .collect();
+            if !missing.is_empty() {
+                return Err(self.map_err(
+                    McpError::BadRequest("one or more container_id values not found"),
+                    &locale,
+                ));
+            }
+        }
+
+        let start_pos = db::lists::next_position(&self.pool, &uid, None, None)
+            .await
+            .map_err(|e| self.map_err(McpError::Domain(e.into()), &locale))?;
+
+        let mut tx =
+            self.pool.begin().await.map_err(|e| {
+                self.map_err(McpError::Domain(db::DbError::Sqlx(e).into()), &locale)
+            })?;
+
+        let mut resolver = RefResolver::new();
+        let mut result = Vec::with_capacity(p.lists.len());
+
+        for (i, list) in p.lists.iter().enumerate() {
+            let container_id = resolver
+                .pick(
+                    list.container_id.as_deref(),
+                    list.container_ref.as_deref(),
+                    false,
+                )
+                .map_err(|e| {
+                    self.map_err(
+                        McpError::BadRequest(Box::leak(e.to_string().into_boxed_str())),
+                        &locale,
+                    )
+                })?;
+            let parent_list_id = resolver
+                .pick(
+                    list.parent_list_id.as_deref(),
+                    list.parent_list_ref.as_deref(),
+                    false,
+                )
+                .map_err(|e| {
+                    self.map_err(
+                        McpError::BadRequest(Box::leak(e.to_string().into_boxed_str())),
+                        &locale,
+                    )
+                })?;
+
+            let list_type = list.list_type.as_deref().unwrap_or("custom");
+            let new_id = Uuid::new_v4().to_string();
+
+            db::lists::insert(
+                &mut tx,
+                &InsertListInput {
+                    id: new_id.clone(),
+                    user_id: uid.clone(),
+                    position: start_pos + i as i64,
+                    name: list.name.clone(),
+                    icon: list.icon.clone(),
+                    description: list.description.clone(),
+                    list_type: list_type.to_owned(),
+                    container_id: container_id.map(str::to_owned),
+                    parent_list_id: parent_list_id.map(str::to_owned),
+                },
+            )
+            .await
+            .map_err(|e| self.map_err(McpError::Domain(e.into()), &locale))?;
+
+            if let Some(features) = &list.features {
+                if !features.is_empty() {
+                    let features_json = domain::lists::features_from_names(features);
+                    db::lists::set_features(&mut tx, &new_id, &features_json)
+                        .await
+                        .map_err(|e| self.map_err(McpError::Domain(e.into()), &locale))?;
+                }
+            }
+
+            resolver
+                .register(list.client_ref.as_deref(), &new_id)
+                .map_err(|e| {
+                    self.map_err(
+                        McpError::BadRequest(Box::leak(e.to_string().into_boxed_str())),
+                        &locale,
+                    )
+                })?;
+
+            result.push(serde_json::json!({"id": new_id, "name": list.name}));
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| self.map_err(McpError::Domain(db::DbError::Sqlx(e).into()), &locale))?;
+        self.json_result(result, &locale)
+    }
+
+    #[rmcp::tool(
+        name = "create_containers",
+        description = "mcp-tool-create_containers-desc"
+    )]
+    #[tracing::instrument(skip(self, parts), fields(action = "mcp_create_containers"))]
+    async fn create_containers(
+        &self,
+        Extension(parts): Extension<Parts>,
+        Parameters(p): Parameters<CreateContainersParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let (uid, locale) =
+            Self::extract_user_id_and_locale(&parts).map_err(|e| self.map_err(e, "en"))?;
+
+        if p.containers.is_empty() {
+            return self.json_result(Vec::<serde_json::Value>::new(), &locale);
+        }
+
+        // Validate real parent_container_ids referenced by UUID (not ref)
+        let parent_ids: Vec<&str> = p
+            .containers
+            .iter()
+            .filter_map(|c| c.parent_container_id.as_deref())
+            .collect();
+        if !parent_ids.is_empty() {
+            let owned = db::containers::find_owned_ids(&self.pool, &uid, &parent_ids)
+                .await
+                .map_err(|e| self.map_err(McpError::Domain(e.into()), &locale))?;
+            let missing: Vec<_> = parent_ids
+                .iter()
+                .filter(|id| !owned.contains(**id))
+                .collect();
+            if !missing.is_empty() {
+                return Err(self.map_err(
+                    McpError::BadRequest("one or more parent_container_id values not found"),
+                    &locale,
+                ));
+            }
+        }
+
+        let start_pos = db::containers::next_position(&self.pool, &uid, None)
+            .await
+            .map_err(|e| self.map_err(McpError::Domain(e.into()), &locale))?;
+
+        let mut tx =
+            self.pool.begin().await.map_err(|e| {
+                self.map_err(McpError::Domain(db::DbError::Sqlx(e).into()), &locale)
+            })?;
+
+        let mut resolver = RefResolver::new();
+        let mut result = Vec::with_capacity(p.containers.len());
+
+        for (i, container) in p.containers.iter().enumerate() {
+            let parent_id = resolver
+                .pick(
+                    container.parent_container_id.as_deref(),
+                    container.parent_container_ref.as_deref(),
+                    false,
+                )
+                .map_err(|e| {
+                    self.map_err(
+                        McpError::BadRequest(Box::leak(e.to_string().into_boxed_str())),
+                        &locale,
+                    )
+                })?;
+
+            let new_id = Uuid::new_v4().to_string();
+            let req = CreateContainerRequest {
+                name: container.name.clone(),
+                icon: container.icon.clone(),
+                description: container.description.clone(),
+                status: container.status.clone(),
+                parent_container_id: parent_id.map(str::to_owned),
+            };
+
+            db::containers::insert_in_tx(&mut tx, &new_id, &uid, &req, start_pos + i as i32)
+                .await
+                .map_err(|e| self.map_err(McpError::Domain(e.into()), &locale))?;
+
+            resolver
+                .register(container.client_ref.as_deref(), &new_id)
+                .map_err(|e| {
+                    self.map_err(
+                        McpError::BadRequest(Box::leak(e.to_string().into_boxed_str())),
+                        &locale,
+                    )
+                })?;
+
+            result.push(serde_json::json!({"id": new_id, "name": container.name}));
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| self.map_err(McpError::Domain(db::DbError::Sqlx(e).into()), &locale))?;
+        self.json_result(result, &locale)
+    }
 }
 
 // ── Tool annotations ─────────────────────────────────────────────────────────
@@ -568,6 +891,10 @@ fn tool_annotations(name: &str) -> ToolAnnotations {
         // Additive writes — create new data, non-destructive
         "create_list"
         | "create_item"
+        | "create_container"
+        | "create_items"
+        | "create_lists"
+        | "create_containers"
         | "add_comment"
         | "add_relation"
         | "log_time"

--- a/crates/mcp/src/tools/items.rs
+++ b/crates/mcp/src/tools/items.rs
@@ -122,3 +122,88 @@ pub struct CreateListParams {
     /// Feature names to enable, e.g. ["quantity", "deadline"]
     pub features: Option<Vec<String>>,
 }
+
+// ── create_container ──────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CreateContainerParams {
+    pub name: String,
+    pub icon: Option<String>,
+    pub description: Option<String>,
+    /// null/omit = folder; "active" | "done" | "paused" = project
+    pub status: Option<String>,
+    pub parent_container_id: Option<String>,
+}
+
+// ── create_items (batch) ──────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CreateItemsInput {
+    pub title: String,
+    pub description: Option<String>,
+    pub start_date: Option<String>,
+    pub deadline: Option<String>,
+    pub hard_deadline: Option<String>,
+    pub start_time: Option<String>,
+    pub deadline_time: Option<String>,
+    pub quantity: Option<i32>,
+    pub actual_quantity: Option<i32>,
+    pub unit: Option<String>,
+    pub estimated_duration: Option<i32>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CreateItemsParams {
+    /// Target list ID — all items are appended to this list in order.
+    pub list_id: String,
+    pub items: Vec<CreateItemsInput>,
+}
+
+// ── create_lists (batch) ──────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CreateListsInput {
+    pub name: String,
+    pub list_type: Option<String>,
+    pub icon: Option<String>,
+    pub description: Option<String>,
+    pub features: Option<Vec<String>>,
+    /// Real UUID of an existing container. Use `container_ref` instead to
+    /// reference a container created earlier in this batch.
+    pub container_id: Option<String>,
+    /// `client_ref` of a container created earlier in this same batch.
+    pub container_ref: Option<String>,
+    /// Real UUID of an existing parent list.
+    pub parent_list_id: Option<String>,
+    /// `client_ref` of a list created earlier in this same batch.
+    pub parent_list_ref: Option<String>,
+    /// Label that other entries in this batch can reference via `*_ref` fields.
+    pub client_ref: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CreateListsParams {
+    pub lists: Vec<CreateListsInput>,
+}
+
+// ── create_containers (batch) ─────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CreateContainersInput {
+    pub name: String,
+    pub icon: Option<String>,
+    pub description: Option<String>,
+    /// null/omit = folder; "active" | "done" | "paused" = project
+    pub status: Option<String>,
+    /// Real UUID of an existing parent container.
+    pub parent_container_id: Option<String>,
+    /// `client_ref` of a container created earlier in this same batch.
+    pub parent_container_ref: Option<String>,
+    /// Label that other entries in this batch can reference via `parent_container_ref`.
+    pub client_ref: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CreateContainersParams {
+    pub containers: Vec<CreateContainersInput>,
+}

--- a/crates/mcp/src/tools/items.rs
+++ b/crates/mcp/src/tools/items.rs
@@ -46,67 +46,39 @@ impl UpdateItemParams {
             .is_some_and(|v| v.iter().any(|s| s == name))
     }
 
-    pub fn nullable<T>(val: Option<T>, _name: &str, cleared: bool) -> Option<Option<T>> {
+    pub fn nullable<T>(val: Option<T>, cleared: bool) -> Option<Option<T>> {
         if cleared { Some(None) } else { val.map(Some) }
     }
 
     pub fn description_field(&self) -> Option<Option<String>> {
-        Self::nullable(
-            self.description.clone(),
-            "description",
-            self.cleared("description"),
-        )
+        Self::nullable(self.description.clone(), self.cleared("description"))
     }
     pub fn start_date_field(&self) -> Option<Option<String>> {
-        Self::nullable(
-            self.start_date.clone(),
-            "start_date",
-            self.cleared("start_date"),
-        )
+        Self::nullable(self.start_date.clone(), self.cleared("start_date"))
     }
     pub fn deadline_field(&self) -> Option<Option<String>> {
-        Self::nullable(self.deadline.clone(), "deadline", self.cleared("deadline"))
+        Self::nullable(self.deadline.clone(), self.cleared("deadline"))
     }
     pub fn hard_deadline_field(&self) -> Option<Option<String>> {
-        Self::nullable(
-            self.hard_deadline.clone(),
-            "hard_deadline",
-            self.cleared("hard_deadline"),
-        )
+        Self::nullable(self.hard_deadline.clone(), self.cleared("hard_deadline"))
     }
     pub fn start_time_field(&self) -> Option<Option<String>> {
-        Self::nullable(
-            self.start_time.clone(),
-            "start_time",
-            self.cleared("start_time"),
-        )
+        Self::nullable(self.start_time.clone(), self.cleared("start_time"))
     }
     pub fn deadline_time_field(&self) -> Option<Option<String>> {
-        Self::nullable(
-            self.deadline_time.clone(),
-            "deadline_time",
-            self.cleared("deadline_time"),
-        )
+        Self::nullable(self.deadline_time.clone(), self.cleared("deadline_time"))
     }
     pub fn quantity_field(&self) -> Option<Option<i32>> {
-        Self::nullable(self.quantity, "quantity", self.cleared("quantity"))
+        Self::nullable(self.quantity, self.cleared("quantity"))
     }
     pub fn actual_quantity_field(&self) -> Option<Option<i32>> {
-        Self::nullable(
-            self.actual_quantity,
-            "actual_quantity",
-            self.cleared("actual_quantity"),
-        )
+        Self::nullable(self.actual_quantity, self.cleared("actual_quantity"))
     }
     pub fn unit_field(&self) -> Option<Option<String>> {
-        Self::nullable(self.unit.clone(), "unit", self.cleared("unit"))
+        Self::nullable(self.unit.clone(), self.cleared("unit"))
     }
     pub fn estimated_duration_field(&self) -> Option<Option<i32>> {
-        Self::nullable(
-            self.estimated_duration,
-            "estimated_duration",
-            self.cleared("estimated_duration"),
-        )
+        Self::nullable(self.estimated_duration, self.cleared("estimated_duration"))
     }
 }
 

--- a/locales/en/mcp.ftl
+++ b/locales/en/mcp.ftl
@@ -93,3 +93,7 @@ mcp-tool-get_item-desc = Get details of a specific item by ID.
 mcp-tool-list_templates-desc = List all saved list templates.
 mcp-tool-list_overdue-desc = Get all items past their deadline that are not yet completed.
 mcp-tool-get_active_timer-desc = Get the currently running timer, if any.
+mcp-tool-create_container-desc = Create a single folder (omit status) or project (status: "active", "done", or "paused"). To build a workspace, call create_containers (batch) + create_lists + create_items in sequence.
+mcp-tool-create_items-desc = Append multiple items to one list atomically. Provide list_id once at the top level; all items go into that list in the given order.
+mcp-tool-create_lists-desc = Create multiple lists atomically. Use container_ref to reference a container created in a prior create_containers call (set client_ref on it first). Use parent_list_ref to nest under a list created earlier in this same batch. Forward-only references within a batch.
+mcp-tool-create_containers-desc = Create multiple folders/projects atomically. Use parent_container_ref to nest under a container created earlier in this same batch (set client_ref on the parent first). Forward-only: cannot reference an item later in the array.

--- a/locales/pl/mcp.ftl
+++ b/locales/pl/mcp.ftl
@@ -93,3 +93,7 @@ mcp-tool-get_item-desc = Pobierz szczegóły konkretnego elementu po ID.
 mcp-tool-list_templates-desc = Pobierz wszystkie zapisane szablony list.
 mcp-tool-list_overdue-desc = Pobierz wszystkie elementy po terminie, które nie są jeszcze ukończone.
 mcp-tool-get_active_timer-desc = Pobierz aktualnie działający timer, jeśli istnieje.
+mcp-tool-create_container-desc = Utwórz pojedynczy folder (bez status) lub projekt (status: "active", "done" lub "paused"). Aby zbudować przestrzeń roboczą, wywołaj create_containers (batch) + create_lists + create_items sekwencyjnie.
+mcp-tool-create_items-desc = Dodaj wiele elementów do jednej listy atomowo. Podaj list_id raz na poziomie głównym; wszystkie elementy trafiają do tej listy w podanej kolejności.
+mcp-tool-create_lists-desc = Utwórz wiele list atomowo. Użyj container_ref aby odwołać się do kontenera z poprzedniego wywołania create_containers (ustaw na nim client_ref). Użyj parent_list_ref aby zagnieździć pod listą z tego samego batcha. Referencje tylko do wcześniejszych elementów.
+mcp-tool-create_containers-desc = Utwórz wiele folderów/projektów atomowo. Użyj parent_container_ref aby zagnieździć pod kontenerem z wcześniej w tym samym batchu (ustaw client_ref na rodzicu). Tylko referencje do wcześniejszych elementów w tablicy.


### PR DESCRIPTION
## Summary

- **New tool `create_container`** — singular folder/project creation was missing entirely from MCP
- **Three atomic batch tools**: `create_items`, `create_lists`, `create_containers` — single transaction, multi-row INSERT
- **`ClientRef` mechanism** (`crates/mcp/src/client_ref.rs`) — forward-only references within a batch so a single call can create parent + children (e.g. nest lists under a container created in the same batch)
- **DB simplifications**: `lists::insert` refactored from 10 positional args to `InsertListInput` struct; `containers::insert_in_tx` added; `items::insert_many_in_tx` with chunked multi-row VALUES (64 rows/chunk, keeps under SQLite 999-param limit); `find_owned_ids` bulk-validation helpers in both `containers` and `lists`
- **i18n**: 4 new keys in `en/pl mcp.ftl` with onboarding-style descriptions explaining `client_ref` usage

## Commits

1. `refactor(db)`: InsertListInput struct (replaces 10-arg positional insert)
2. `feat(db)`: containers::insert_in_tx
3. `feat(db)`: items::insert_many_in_tx with chunked multi-row VALUES
4. `feat(db)`: find_owned_ids bulk helpers in containers + lists
5. `feat(mcp)`: client_ref module with RefResolver + 11 unit tests
6. `feat(mcp)`: all 4 new MCP tools, tool_annotations, i18n, auth_locale() helper

## Test plan

- [ ] `just check` — workspace compiles clean
- [ ] `just lint` — clippy + fmt pass
- [ ] `just test` — unit tests including RefResolver tests pass
- [ ] Smoke: `create_container { name: "Test" }` → returns container id
- [ ] Smoke: `create_items { list_id: <id>, items: [{title:"A"},{title:"B"}] }` → 2 items appended
- [ ] Smoke: `create_containers` with `parent_container_ref` → nested containers in one call
- [ ] Smoke: `create_lists` with `container_ref` → lists placed under just-created container
- [ ] Negative: duplicate `client_ref` → clear error message
- [ ] Negative: both `container_id` and `container_ref` set → Conflicting error

🤖 Generated with [Claude Code](https://claude.com/claude-code)