### PR TITLE
feat(frontend): add create list/container form to ContainerPage

### DIFF
--- a/crates/frontend/src/pages/container.rs
+++ b/crates/frontend/src/pages/container.rs
@@ -7,12 +7,14 @@ use crate::components::common::breadcrumbs::Breadcrumbs;
 use crate::components::common::dnd::{DetachDropZone, ReorderDropTarget};
 use crate::components::common::editable_text::EditableText;
 use crate::components::common::loading::LoadingSpinner;
-use crate::components::lists::{container_card::ContainerCard, list_card::ListCard};
+use crate::components::lists::{
+    container_card::ContainerCard, create_entity_input::CreateEntityInput, list_card::ListCard,
+};
 use crate::context::GlobalRefresh;
 use crate::server_fns::containers::{
-    get_container_data, move_container, rename_container, reorder_containers,
+    create_container, get_container_data, move_container, rename_container, reorder_containers,
 };
-use crate::server_fns::lists::{move_list, reorder_lists};
+use crate::server_fns::lists::{create_list, move_list, reorder_lists};
 use crate::state::dnd::{DndState, DropTarget, EntityKind};
 
 fn container_status_icon(status: Option<&str>) -> &'static str {
@@ -179,6 +181,23 @@ pub fn ContainerPage() -> impl IntoView {
                             });
                         });
 
+                        let on_create_list = Callback::new(move |req| {
+                            leptos::task::spawn_local(async move {
+                                match create_list(req).await {
+                                    Ok(_) => global_refresh.bump(),
+                                    Err(e) => toast.push(e.to_string(), ToastKind::Error),
+                                }
+                            });
+                        });
+                        let on_create_container = Callback::new(move |req| {
+                            leptos::task::spawn_local(async move {
+                                match create_container(req).await {
+                                    Ok(_) => global_refresh.bump(),
+                                    Err(e) => toast.push(e.to_string(), ToastKind::Error),
+                                }
+                            });
+                        });
+
                         view! {
                             <div class="flex flex-col gap-6">
                                 <DetachDropZone
@@ -227,6 +246,12 @@ pub fn ContainerPage() -> impl IntoView {
                                         />
                                     </div>
                                 </div>
+
+                                <CreateEntityInput
+                                    parent_container_id=current_id.clone()
+                                    on_create_list=on_create_list
+                                    on_create_container=on_create_container
+                                />
 
                                 // Child containers
                                 {if !children.is_empty() {


### PR DESCRIPTION
## Summary

- Adds `CreateEntityInput` to `ContainerPage` so users can create lists, folders and projects directly from the container view — no more back-navigating to home
- Callbacks extracted before `view!` block, matching the pattern from `home.rs`
- Uses `global_refresh.bump()` (not local refresh) so sibling views invalidate correctly

## Test plan

- [ ] Navigate to a container — creation form is visible below the header
- [ ] Create a list → appears in the Lists section
- [ ] Create a folder → appears in Subcontainers section
- [ ] Create a project → appears in Subcontainers section with 🚀 icon
- [ ] Home page sidebar/recent reflects newly created entities

🤖 Generated with [Claude Code](https://claude.com/claude-code)