### PR TITLE
docs(claude): refresh CLAUDE.md for current stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ data.db-wal
 # Test results
 test-results/
 tests/test-results-debug/
+
+CLAUDE.local.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,31 +1,25 @@
 # CLAUDE.md
 
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
 ## Projekt
 
-Kartoteka — aplikacja todo/listy. Leptos 0.8 SSR (Axum) + SQLite + Better Auth.
+Kartoteka — aplikacja todo/listy. Leptos 0.8 SSR (Axum) + SQLite + `axum-login`/`tower-sessions`. MCP server via `rmcp`.
 
 ## Architektura
 
-- **Monorepo**: Cargo workspace — `crates/shared`, `crates/db`, `crates/domain`, `crates/auth`, `crates/mcp`, `crates/oauth`, `crates/jobs`, `crates/i18n`, `crates/frontend-v2`, `crates/server`
-- **Server**: Axum (`crates/server`) — obsługuje SSR, `/api/*`, auth middleware
-- **Frontend**: Leptos 0.8 SSR w `crates/frontend-v2`, kompilowany przez `cargo leptos`
-- **Auth**: Better Auth — cookie-based sessions, email+password, GitHub OAuth optional
-- **DB**: SQLite przez `sqlx`, migracje w `crates/db/migrations/`
+- **Monorepo**: Cargo workspace — `api`, `auth`, `db`, `domain`, `frontend`, `frontend-v2`, `i18n`, `jobs`, `logging`, `mcp`, `oauth`, `server`, `shared`
+- **Server**: Axum (`crates/server`) — SSR, `/api/*`, auth middleware
+- **Frontend**: Leptos 0.8 SSR w `crates/frontend-v2` (główny). `crates/frontend` trzyma Tailwind input + `node_modules`
+- **MCP**: `crates/mcp` używa `rmcp` (Rust MCP SDK), wystawiany przez `crates/server`
+- **Gateway** (`gateway/`): osobny worker Cloudflare — edge proxy dla MCP, deploy via wrangler. Migracje schema przez endpoint `/migrate`
+- **Auth**: `crates/auth` — `axum-login` + `tower-sessions` (SQLite store), hasła `argon2`, 2FA `totp-rs`. OAuth providers w `crates/oauth`. Sesja via HttpOnly cookie
+- **DB**: SQLite przez `sqlx`, UUID v4 (TEXT) IDs, timestampy `datetime('now')`. Migracje w `crates/db/migrations/` wykonywane przy starcie serwera
 
 ## Kluczowe konwencje
 
-### Env vars (compile-time / .env)
-- `OAUTH_SIGNING_SECRET` — wymagany do dev (min 32 znaków)
-- Zarządzane przez `.env` + `set dotenv-load` w justfile
-
-### Auth / Cookie auth
-- Sesja via HttpOnly cookie
-- Server middleware (`crates/server/src/`) waliduje sesję i udostępnia `UserId` extractor
-
-### SQLite / sqlx
-- IDs jako UUID v4 (TEXT), timestampy jako TEXT (`datetime('now')`)
-- Migracje w `crates/db/migrations/`, wykonywane przy starcie serwera
-- Boolean jako `bool` (sqlx obsługuje natywnie dla SQLite)
+### Env vars
+- `OAUTH_SIGNING_SECRET` — wymagany do dev (min 32 znaków), zarządzane przez `.env` + `set dotenv-load` w justfile
 
 ### Frontend (Leptos 0.8 SSR)
 - Używaj `Resource::new`, nie `LocalResource` — SSR futures muszą być `Send`
@@ -35,73 +29,62 @@ Kartoteka — aplikacja todo/listy. Leptos 0.8 SSR (Axum) + SQLite + Better Auth
 - Non-Copy typy w `Fn` closure → `StoredValue::new()` lub `.clone()` przed wejściem
 
 ### Shared crate (`crates/shared/`)
-- Struktura modułów: `models/` (Container, List, Item, Tag, Settings), `dto/` (requests.rs, responses.rs), `deserializers.rs` (pub(crate)), `constants.rs`, `date_utils.rs`
-- `lib.rs` reeksportuje wszystko flat (`pub use models::*; pub use dto::*; pub use date_utils::*`)
-- `date_utils.rs` — 14 pub funkcji oparte na `chrono` (parse_date, add_days, week_range, month_grid_range, is_overdue, sort_by_deadline, itd.)
-- `chrono = { version = "0.4.44", default-features = false, features = ["alloc"] }` — WASM-safe, bez std::time clock
+- `models/`, `dto/` (requests/responses), `deserializers.rs` (pub(crate)), `constants.rs`, `date_utils.rs`
+- `lib.rs` reeksportuje flat (`pub use models::*; pub use dto::*; pub use date_utils::*`)
+- `chrono = { version = "0.4.44", default-features = false, features = ["alloc"] }` — WASM-safe
+- Daty: zobacz `date_utils.rs` (parse_date, week_range, month_grid_range, is_overdue, sort_by_deadline, …)
 
 ### Tracing / Logging
-
-Każdy handler w `crates/server/src/` **musi** mieć `#[instrument]`. W Axum użyj `fields(action = "verb_noun", <entity_id> = %id)` — extractor `Path` daje `id` już na wejściu:
-
-```rust
-#[instrument(fields(action = "create_list", list_id = %id))]
-pub async fn create(Path(id): Path<String>, ...) -> impl IntoResponse {
-    // ...
-}
-```
-
-- `action` — nazwa operacji w formacie `verb_noun` (`create_list`, `delete_item`, `toggle_item`)
-- **Bez `&` przed `tracing::field::display`** — clippy `needless_borrows_for_generic_args` blokuje CI
+Każdy handler w `crates/server/src/` **musi** mieć `#[instrument(fields(action = "verb_noun", <entity_id> = %id))]`. Bez `&` przed `tracing::field::display` (clippy `needless_borrows_for_generic_args` blokuje CI).
 
 ## Komendy
 
 ```bash
-just dev          # SSR server + Tailwind watch
-just check        # Kompilacja workspace
-just build        # Build server + gateway
+just setup        # cargo-leptos + wasm target + npm install (crates/frontend)
+just dev          # dev-leptos + dev-tailwind w parallel (trap/wait)
+just check        # cargo check --workspace
 just test         # cargo test --workspace
-just test-e2e     # Playwright e2e (wymaga just dev)
+just test-e2e     # Playwright (wymaga running just dev)
 just lint         # Clippy + fmt check
 just fmt          # cargo fmt
 just ci           # fmt + lint + audit + machete + test
-just deploy       # Deploy gateway + auth migrations
-just deploy-dev   # Deploy dev environment
+just deploy       # gateway (Cloudflare) + auth migrations
+just deploy-preview  # build AMD64 obraz lokalnie + deploy preview
 ```
 
 ### Build frontend+server (Leptos SSR)
+- **ZAWSZE** `cargo leptos build` — buduje WASM (hydrate) i serwer w spójnych feature'ach
+- **NIGDY** `cargo build -p kartoteka-server` — default features rozjeżdżają się z WASM, hydration pęka
+- Produkcja: `cargo leptos build --release`
 
-- **ZAWSZE** `cargo leptos build` — buduje WASM (hydrate) i serwer w spójnych feature'ach.
-- **NIGDY** `cargo build -p kartoteka-server` do testów/uruchomienia — default features rozjeżdżają się z WASM i hydration pęka.
-- **Do testów**: `cargo leptos build` (debug). `just test-e2e` już to robi.
-- **Produkcja**: `cargo leptos build --release`.
+## Pre-commit (lefthook)
 
-## Dokumentacja i aktualne wersje bibliotek
+`lefthook.yml` uruchamia `cargo fmt --check` + `cargo clippy --workspace -- -D warnings` w parallel przed każdym commitem.
 
-Projekt używa szybko ewoluujących bibliotek (Leptos 0.8, DaisyUI 5). Przed pisaniem kodu sprawdzaj aktualne API przez context7 MCP:
+## Dokumentacja bibliotek (context7)
 
-- `mcp__context7__resolve-library-id` — znajdź ID biblioteki (np. "leptos")
-- `mcp__context7__query-docs` — pobierz aktualną dokumentację
-
-Używaj tego proaktywnie, nie czekaj na błędy kompilacji.
+Projekt używa szybko ewoluujących bibliotek (Leptos 0.8, DaisyUI 5, rmcp). Przed pisaniem kodu sprawdzaj aktualne API przez context7 MCP (`mcp__context7__resolve-library-id` + `mcp__context7__query-docs`). Proaktywnie, nie czekaj na błędy.
 
 ## Testy
 
-- **Unit testy** (`crates/shared/src/tests/`, `crates/shared/src/date_utils.rs`): deserializery, typy, serde, date_utils — `cargo test -p kartoteka-shared`
-- **i18n testy** (`crates/i18n/tests/`): kompletność tłumaczeń PL/EN, parsowanie FTL, pokrycie MCP
-- **E2E** (`tests/e2e/`): Playwright, auth flow — `just test-e2e` (wymaga `just dev`)
-- CI: `cargo test --workspace`
+- Unit (`crates/shared/`): `cargo test -p kartoteka-shared`
+- i18n (`crates/i18n/tests/`): kompletność PL/EN, parsowanie FTL, pokrycie MCP
+- E2E (`tests/e2e/`): Playwright, 9+ spec files (auth, items, lists, tags, settings, sublists) — `just test-e2e`
+
+## Deployment
+
+- **Główna aplikacja**: Docker (`Dockerfile`: node css-builder → rust nightly builder → debian-slim runtime). Deploy na **Coolify** przez `docker-build-deploy` workflow (push na main)
+- **Gateway** (MCP edge): Cloudflare Workers via `wrangler deploy` (z `gateway/`)
+- Preview: `just deploy-preview` (AMD64 build via Colima)
 
 ## CI/CD
 
-- PR workflow (`.github/workflows/ci.yml`): fmt → check → clippy → deny → machete → test
-- Security audit (`.github/workflows/security-audit.yml`): weekly cron + on Cargo.lock changes
+- `.github/workflows/`: `ci.yml` (fmt→check→clippy→deny→machete→test), `docker-build-deploy.yml`, `docker-preview.yml`, `security-audit.yml` (weekly), `codeql.yml`, `release-please.yml`, `claude-code-review.yml`, `deps-outdated.yml`
 - Workspace lints w `Cargo.toml` — clippy correctness=deny, suspicious/complexity/perf/style=warn
-- `deny.toml` — licencje, advisories, supply chain security
-- Lokalne sprawdzenie: `just ci` (uruchamia wszystko naraz)
+- `deny.toml` — licencje, advisories, supply chain
+- Lokalne sprawdzenie: `just ci`
 
 ## Pliki do NIE commitowania
 
-- `.env` — sekrety i konfiguracja
-- `target/` — build output
-- `.wrangler/`, `build/` — wrangler cache
+- `.env` — sekrety
+- `target/`, `build/`, `.wrangler/` — build/cache


### PR DESCRIPTION
## Summary
- Refresh CLAUDE.md to match current architecture: `axum-login` + `tower-sessions` + `argon2` (no more Better Auth), MCP via `rmcp`, full 13-crate workspace listing
- Add Deployment section (Coolify via Docker for main app + Cloudflare Workers for gateway)
- Add Pre-commit (lefthook) section, refresh CI/CD workflow list, document `just setup`
- Trim bloated SQLite/date_utils/tracing minutiae
- Gitignore `CLAUDE.local.md` for personal preferences

## Test plan
- [ ] CI passes (fmt + clippy + deny + machete + test)
- [ ] Read CLAUDE.md and confirm it accurately reflects the current stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)