### PR TITLE
chore(deps): batch upgrade — rmcp 1.5, axum-login 0.18, rand 0.9, GH Actions v4/v5

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -27,13 +27,13 @@ jobs:
       - uses: actions/checkout@v6
 
       - id: buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       # Cache scope is per cargo_profile (debug/release) so dev (debug) and preview
       # (debug) share buildkit mount cache and GHA layer cache; prod (release) is isolated.
       - name: Cache mounts
         id: cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: cache-mount
           key: cache-mount-${{ inputs.cargo_profile }}-${{ hashFiles('Dockerfile', 'Cargo.lock') }}
@@ -61,7 +61,7 @@ jobs:
             }
           skip-extraction: ${{ steps.cache.outputs.cache-hit }}
 
-      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,7 +20,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           release-type: simple

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -23,6 +23,4 @@ jobs:
         with:
           # rsa: Marvin Attack - no fix available, transitive via sqlx-mysql (unused, we use SQLite)
           # paste: unmaintained warning - transitive via leptos, no alternative
-          ignore: |
-            RUSTSEC-2023-0071
-            RUSTSEC-2024-0436
+          ignore: RUSTSEC-2023-0071 RUSTSEC-2024-0436

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "password-hash",
 ]
 
@@ -194,11 +194,10 @@ dependencies = [
 
 [[package]]
 name = "axum-login"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0da8e8e4cf127a9b71b578e9a8fa9833e70f893e428ed5453c85e44bf0fd8eb"
+checksum = "964ea6eb764a227baa8c3368e45c94d23b6863cc7b880c6c9e341c143c5a5ff7"
 dependencies = [
- "async-trait",
  "axum",
  "form_urlencoded",
  "serde",
@@ -268,7 +267,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -278,6 +277,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -340,6 +348,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,35 +374,19 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
-dependencies = [
- "chrono",
- "chrono-tz-build",
- "phf 0.11.3",
-]
-
-[[package]]
-name = "chrono-tz"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
- "phf 0.12.1",
+ "phf",
 ]
 
 [[package]]
-name = "chrono-tz-build"
-version = "0.3.0"
+name = "cmov"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
-dependencies = [
- "parse-zoneinfo",
- "phf 0.11.3",
- "phf_codegen",
-]
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "codee"
@@ -439,6 +442,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-str"
@@ -533,6 +542,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,6 +622,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "current_platform"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,9 +652,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -638,9 +674,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -648,11 +684,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -662,9 +697,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
@@ -683,7 +718,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -715,10 +750,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -757,7 +804,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -783,7 +830,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -815,7 +862,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -915,32 +962,16 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fluent-bundle"
-version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe0a21ee80050c678013f82edf4b705fe2f26f1f9877593d13198612503f493"
-dependencies = [
- "fluent-langneg",
- "fluent-syntax 0.11.1",
- "intl-memoizer",
- "intl_pluralrules",
- "rustc-hash 1.1.0",
- "self_cell 0.10.3",
- "smallvec",
- "unic-langid",
-]
-
-[[package]]
-name = "fluent-bundle"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01203cb8918f5711e73891b347816d932046f95f54207710bda99beaeb423bf4"
 dependencies = [
  "fluent-langneg",
- "fluent-syntax 0.12.0",
+ "fluent-syntax",
  "intl-memoizer",
  "intl_pluralrules",
- "rustc-hash 2.1.2",
- "self_cell 1.2.2",
+ "rustc-hash",
+ "self_cell",
  "smallvec",
  "unic-langid",
 ]
@@ -952,15 +983,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eebbe59450baee8282d71676f3bfed5689aeab00b27545e83e5f14b1195e8b0"
 dependencies = [
  "unic-langid",
-]
-
-[[package]]
-name = "fluent-syntax"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a530c4694a6a8d528794ee9bbd8ba0122e779629ac908d15ad5a7ae7763a33d"
-dependencies = [
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -992,9 +1014,9 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d48ac2b8e7c3a2198fc584af78e674d15dacdede8a6cebb686c844713f7d0ba"
 dependencies = [
- "fluent-bundle 0.16.0",
+ "fluent-bundle",
  "fluent-langneg",
- "fluent-syntax 0.12.0",
+ "fluent-syntax",
  "fluent-template-macros",
  "intl-memoizer",
  "log",
@@ -1013,12 +1035,6 @@ dependencies = [
  "futures-sink",
  "spin",
 ]
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -1178,6 +1194,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
  "wasm-bindgen",
@@ -1302,7 +1319,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -1311,7 +1328,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -1382,6 +1408,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hydration_context"
@@ -1671,7 +1706,7 @@ dependencies = [
  "base64",
  "ed25519-dalek",
  "getrandom 0.2.17",
- "hmac",
+ "hmac 0.12.1",
  "js-sys",
  "p256",
  "p384",
@@ -1679,7 +1714,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "signature",
 ]
 
@@ -1723,7 +1758,7 @@ dependencies = [
  "argon2",
  "async-trait",
  "chrono",
- "chrono-tz 0.10.4",
+ "chrono-tz",
  "jsonwebtoken",
  "kartoteka-db",
  "kartoteka-shared",
@@ -1745,7 +1780,7 @@ dependencies = [
  "axum",
  "axum-login",
  "chrono",
- "chrono-tz 0.10.4",
+ "chrono-tz",
  "console_error_panic_hook",
  "js-sys",
  "kartoteka-auth",
@@ -1772,7 +1807,7 @@ dependencies = [
 name = "kartoteka-i18n"
 version = "0.4.1"
 dependencies = [
- "fluent-syntax 0.12.0",
+ "fluent-syntax",
  "serde",
  "serde_json",
 ]
@@ -1791,15 +1826,15 @@ version = "0.4.1"
 dependencies = [
  "async-trait",
  "chrono",
- "chrono-tz 0.9.0",
- "fluent-bundle 0.15.3",
- "fluent-syntax 0.11.1",
+ "chrono-tz",
+ "fluent-bundle",
+ "fluent-syntax",
  "http",
  "kartoteka-db",
  "kartoteka-domain",
  "kartoteka-shared",
  "rmcp",
- "schemars 1.2.1",
+ "schemars",
  "serde",
  "serde_json",
  "sqlx",
@@ -1819,18 +1854,18 @@ dependencies = [
  "axum-login",
  "base64",
  "chrono",
- "hmac",
+ "hmac 0.13.0",
  "http",
  "jsonwebtoken",
  "kartoteka-auth",
  "kartoteka-db",
  "kartoteka-domain",
  "kartoteka-shared",
- "rand 0.8.6",
+ "rand 0.9.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sha2",
+ "sha2 0.11.0",
  "subtle",
  "thiserror 2.0.18",
  "tokio",
@@ -1864,7 +1899,7 @@ dependencies = [
  "rmcp",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "sqlx",
  "thiserror 2.0.18",
  "time",
@@ -1883,8 +1918,8 @@ name = "kartoteka-shared"
 version = "0.4.1"
 dependencies = [
  "chrono",
- "chrono-tz 0.10.4",
- "schemars 0.8.22",
+ "chrono-tz",
+ "schemars",
  "serde",
  "serde_json",
  "sqlx",
@@ -1943,7 +1978,7 @@ dependencies = [
  "paste",
  "rand 0.9.4",
  "reactive_graph",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "rustc_version",
  "send_wrapper",
  "serde",
@@ -1968,7 +2003,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ceccb30b7c23825c4379d60e14402b866515743825b6976fbf45d2f1afe26e5"
 dependencies = [
- "fluent-bundle 0.16.0",
+ "fluent-bundle",
  "fluent-templates",
  "leptos",
  "leptos-fluent-macros",
@@ -1985,8 +2020,8 @@ checksum = "5e592fe73c658a1431f0993045cddfb3b87467207656bb9476746820047986e8"
 dependencies = [
  "cfg-expr",
  "current_platform",
- "fluent-bundle 0.16.0",
- "fluent-syntax 0.12.0",
+ "fluent-bundle",
+ "fluent-syntax",
  "fluent-templates",
  "globwalk",
  "pathdiff",
@@ -2279,7 +2314,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2430,7 +2465,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2442,7 +2477,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2475,15 +2510,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parse-zoneinfo"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
-dependencies = [
- "regex",
-]
-
-[[package]]
 name = "password-hash"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2499,6 +2525,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
 
 [[package]]
 name = "pathdiff"
@@ -2523,49 +2555,11 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
 dependencies = [
- "phf_shared 0.12.1",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
-dependencies = [
- "phf_generator",
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared 0.11.3",
- "rand 0.8.6",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
+ "phf_shared",
 ]
 
 [[package]]
@@ -2816,6 +2810,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2854,6 +2859,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "reactive_graph"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2868,7 +2879,7 @@ dependencies = [
  "or_poisoned",
  "paste",
  "pin-project-lite",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "rustc_version",
  "send_wrapper",
  "serde",
@@ -2890,7 +2901,7 @@ dependencies = [
  "paste",
  "reactive_graph",
  "reactive_stores_macro",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "send_wrapper",
 ]
 
@@ -2980,16 +2991,17 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
 [[package]]
 name = "rmcp"
-version = "0.3.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f0d0d5493be0d181a62db489eab7838669b81885972ca00ceca893cf6ac2883"
+checksum = "67d69668de0b0ccd9cc435f700f3b39a7861863cf37a15e1f304ea78688a4826"
 dependencies = [
+ "async-trait",
  "base64",
  "bytes",
  "chrono",
@@ -2997,11 +3009,11 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
- "paste",
+ "pastey",
  "pin-project-lite",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rmcp-macros",
- "schemars 1.2.1",
+ "schemars",
  "serde",
  "serde_json",
  "sse-stream",
@@ -3016,9 +3028,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.3.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aebc912b8fa7d54999adc4e45601d1d95fe458f97eb0a1277eddcd6382cf4b1"
+checksum = "48fdc01c81097b0aed18633e676e269fefa3a78ec1df56b4fe597c1241b92025"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3052,8 +3064,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -3080,12 +3092,6 @@ dependencies = [
  "syn_derive",
  "thiserror 2.0.18",
 ]
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -3125,18 +3131,6 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
-dependencies = [
- "dyn-clone",
- "schemars_derive 0.8.22",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
@@ -3144,21 +3138,9 @@ dependencies = [
  "chrono",
  "dyn-clone",
  "ref-cast",
- "schemars_derive 1.2.1",
+ "schemars_derive",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn",
 ]
 
 [[package]]
@@ -3191,15 +3173,6 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "self_cell"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14e4d63b804dc0c7ec4a1e52bcb63f02c7ac94476755aa579edac21e01f915d"
-dependencies = [
- "self_cell 1.2.2",
 ]
 
 [[package]]
@@ -3392,8 +3365,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3403,8 +3376,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -3438,7 +3422,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -3540,7 +3524,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.18",
  "time",
@@ -3578,7 +3562,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -3601,7 +3585,7 @@ dependencies = [
  "bytes",
  "chrono",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -3611,7 +3595,7 @@ dependencies = [
  "generic-array",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "itoa",
  "log",
  "md-5",
@@ -3622,7 +3606,7 @@ dependencies = [
  "rsa",
  "serde",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -3651,7 +3635,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "home",
  "itoa",
  "log",
@@ -3661,7 +3645,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -3802,7 +3786,7 @@ dependencies = [
  "paste",
  "reactive_graph",
  "reactive_stores",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "rustc_version",
  "send_wrapper",
  "slotmap",
@@ -4029,10 +4013,10 @@ checksum = "a2b36a9dd327e9f401320a2cb4572cc76ff43742bcfc3291f871691050f140ba"
 dependencies = [
  "base32",
  "constant_time_eq",
- "hmac",
+ "hmac 0.12.1",
  "rand 0.9.4",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "url",
  "urlencoding",
 ]
@@ -4269,7 +4253,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
 dependencies = [
- "rustc-hash 2.1.2",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -4593,7 +4577,7 @@ checksum = "d0a659ffe5c7f4538aa6357c07e3d73221cc61eba03bd9a081e14bc91ed09b8c"
 dependencies = [
  "base16",
  "quote",
- "sha2",
+ "sha2 0.10.9",
  "syn",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 axum = { version = "0.8", features = ["json", "macros"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
-axum-login = "0.17"
+axum-login = "0.18"
 tower-sessions = "0.14"
 tower-sessions-sqlx-store = { version = "0.15", features = ["sqlite"] }
 argon2 = "0.5"

--- a/crates/auth/src/lib.rs
+++ b/crates/auth/src/lib.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use axum_login::{AuthUser, AuthnBackend};
 use kartoteka_db as db;
 use serde::{Deserialize, Serialize};
@@ -75,7 +74,6 @@ fn build_session_hash(credential: &str, user_id: &str) -> Vec<u8> {
     }
 }
 
-#[async_trait]
 impl AuthnBackend for KartotekaBackend {
     type User = KartotekaUser;
     type Credentials = LoginCredentials;

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -12,7 +12,7 @@ kartoteka-shared = { path = "../shared" }
 kartoteka-domain = { path = "../domain" }
 kartoteka-db     = { path = "../db" }
 
-rmcp = { version = "0.3", features = ["server", "transport-streamable-http-server", "transport-worker", "macros"] }
+rmcp = { version = "1.5", features = ["server", "transport-streamable-http-server", "transport-worker", "macros"] }
 schemars = "1"
 sqlx = { workspace = true }
 serde = { version = "1", features = ["derive"] }
@@ -24,12 +24,12 @@ tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
-chrono-tz = "0.9"
+chrono-tz = "0.10"
 urlencoding = "2"
 
 # MCP-side i18n (outside Leptos)
-fluent-bundle = "0.15"
-fluent-syntax = "0.11"
+fluent-bundle = "0.16"
+fluent-syntax = "0.12"
 unic-langid = "0.9"
 
 [package.metadata.cargo-machete]

--- a/crates/mcp/src/resources.rs
+++ b/crates/mcp/src/resources.rs
@@ -83,9 +83,12 @@ pub fn static_resources(i18n: &McpI18n, locale: &str) -> Vec<rmcp::model::Resour
             RawResource {
                 uri: uri.into(),
                 name: name.into(),
+                title: None,
                 description: Some(i18n.translate(locale, key)),
                 mime_type: Some("application/json".into()),
                 size: None,
+                icons: None,
+                meta: None,
             },
             None,
         )
@@ -112,8 +115,10 @@ pub fn resource_templates(i18n: &McpI18n, locale: &str) -> Vec<rmcp::model::Reso
             RawResourceTemplate {
                 uri_template: uri.into(),
                 name: name.into(),
+                title: None,
                 description: Some(i18n.translate(locale, key)),
                 mime_type: Some("application/json".into()),
+                icons: None,
             },
             None,
         )

--- a/crates/mcp/src/server.rs
+++ b/crates/mcp/src/server.rs
@@ -9,11 +9,12 @@ use rmcp::{
     ErrorData, RoleServer, ServerHandler,
     handler::server::{
         router::tool::ToolRouter,
-        tool::{Extension, Parameters, ToolCallContext},
+        tool::{Extension, ToolCallContext},
+        wrapper::Parameters,
     },
     model::{
-        CallToolRequestParam, CallToolResult, Content, ListResourceTemplatesResult,
-        ListResourcesResult, ListToolsResult, PaginatedRequestParam, ReadResourceRequestParam,
+        CallToolRequestParams, CallToolResult, Content, ListResourceTemplatesResult,
+        ListResourcesResult, ListToolsResult, PaginatedRequestParams, ReadResourceRequestParams,
         ReadResourceResult, ResourceContents, ServerCapabilities, ServerInfo,
     },
     service::RequestContext,
@@ -1071,32 +1072,28 @@ impl KartotekaServer {
 
 impl ServerHandler for KartotekaServer {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            server_info: rmcp::model::Implementation {
-                name: "kartoteka".into(),
-                version: env!("CARGO_PKG_VERSION").into(),
-            },
-            capabilities: ServerCapabilities::builder()
-                .enable_tools()
-                .enable_resources()
-                .build(),
-            instructions: Some(
-                "Kartoteka is a personal task and list manager. \
-                Start every session by calling list_lists to orient yourself — \
-                you need list IDs for most item operations. \
-                Use search_items to find items by keyword before acting on them. \
-                When adding comments: omit author_name to write in the user's voice; \
-                set author_name to your name (e.g. \"Claude\") for your own observations. \
-                Prefer get_today and list_overdue to surface what needs attention now."
-                    .into(),
-            ),
-            ..ServerInfo::default()
-        }
+        let mut info = ServerInfo::default();
+        info.server_info = rmcp::model::Implementation::new("kartoteka", env!("CARGO_PKG_VERSION"));
+        info.capabilities = ServerCapabilities::builder()
+            .enable_tools()
+            .enable_resources()
+            .build();
+        info.instructions = Some(
+            "Kartoteka is a personal task and list manager. \
+            Start every session by calling list_lists to orient yourself — \
+            you need list IDs for most item operations. \
+            Use search_items to find items by keyword before acting on them. \
+            When adding comments: omit author_name to write in the user's voice; \
+            set author_name to your name (e.g. \"Claude\") for your own observations. \
+            Prefer get_today and list_overdue to surface what needs attention now."
+                .into(),
+        );
+        info
     }
 
     async fn list_tools(
         &self,
-        _request: Option<PaginatedRequestParam>,
+        _request: Option<PaginatedRequestParams>,
         context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, ErrorData> {
         let locale = context
@@ -1117,7 +1114,7 @@ impl ServerHandler for KartotekaServer {
 
     async fn call_tool(
         &self,
-        request: CallToolRequestParam,
+        request: CallToolRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
         let tcc = ToolCallContext::new(self, request, context);
@@ -1126,7 +1123,7 @@ impl ServerHandler for KartotekaServer {
 
     async fn list_resources(
         &self,
-        _request: Option<PaginatedRequestParam>,
+        _request: Option<PaginatedRequestParams>,
         context: RequestContext<RoleServer>,
     ) -> Result<ListResourcesResult, ErrorData> {
         let locale = context
@@ -1137,12 +1134,13 @@ impl ServerHandler for KartotekaServer {
         Ok(ListResourcesResult {
             resources: crate::resources::static_resources(&self.i18n, &locale),
             next_cursor: None,
+            meta: None,
         })
     }
 
     async fn list_resource_templates(
         &self,
-        _request: Option<PaginatedRequestParam>,
+        _request: Option<PaginatedRequestParams>,
         context: RequestContext<RoleServer>,
     ) -> Result<ListResourceTemplatesResult, ErrorData> {
         let locale = context
@@ -1153,12 +1151,13 @@ impl ServerHandler for KartotekaServer {
         Ok(ListResourceTemplatesResult {
             resource_templates: crate::resources::resource_templates(&self.i18n, &locale),
             next_cursor: None,
+            meta: None,
         })
     }
 
     async fn read_resource(
         &self,
-        request: ReadResourceRequestParam,
+        request: ReadResourceRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<ReadResourceResult, ErrorData> {
         use crate::resources::{ResourceUri, parse as parse_uri};
@@ -1241,12 +1240,10 @@ impl ServerHandler for KartotekaServer {
             }
         };
 
-        Ok(ReadResourceResult {
-            contents: vec![ResourceContents::text(
-                serde_json::to_string_pretty(&json).unwrap_or_default(),
-                request.uri,
-            )],
-        })
+        Ok(ReadResourceResult::new(vec![ResourceContents::text(
+            serde_json::to_string_pretty(&json).unwrap_or_default(),
+            request.uri,
+        )]))
     }
 }
 

--- a/crates/mcp/src/server/annotations.rs
+++ b/crates/mcp/src/server/annotations.rs
@@ -40,39 +40,24 @@ const ADDITIVE_WRITE: &[&str] = &[
 const DESTRUCTIVE: &[&str] = &["update_item", "remove_relation", "stop_timer"];
 
 pub fn for_tool(name: &str) -> ToolAnnotations {
+    let mut ann = ToolAnnotations::default();
     if READ_ONLY.contains(&name) {
-        ToolAnnotations {
-            read_only_hint: Some(true),
-            destructive_hint: Some(false),
-            idempotent_hint: Some(true),
-            open_world_hint: Some(false),
-            title: None,
-        }
+        ann.read_only_hint = Some(true);
+        ann.destructive_hint = Some(false);
+        ann.idempotent_hint = Some(true);
+        ann.open_world_hint = Some(false);
     } else if ADDITIVE_WRITE.contains(&name) {
-        ToolAnnotations {
-            read_only_hint: Some(false),
-            destructive_hint: Some(false),
-            idempotent_hint: Some(false),
-            open_world_hint: Some(false),
-            title: None,
-        }
+        ann.read_only_hint = Some(false);
+        ann.destructive_hint = Some(false);
+        ann.idempotent_hint = Some(false);
+        ann.open_world_hint = Some(false);
     } else if DESTRUCTIVE.contains(&name) {
-        ToolAnnotations {
-            read_only_hint: Some(false),
-            destructive_hint: Some(true),
-            idempotent_hint: Some(false),
-            open_world_hint: Some(false),
-            title: None,
-        }
-    } else {
-        ToolAnnotations {
-            read_only_hint: None,
-            destructive_hint: None,
-            idempotent_hint: None,
-            open_world_hint: None,
-            title: None,
-        }
+        ann.read_only_hint = Some(false);
+        ann.destructive_hint = Some(true);
+        ann.idempotent_hint = Some(false);
+        ann.open_world_hint = Some(false);
     }
+    ann
 }
 
 #[cfg(test)]

--- a/crates/oauth/Cargo.toml
+++ b/crates/oauth/Cargo.toml
@@ -19,9 +19,9 @@ tower = { workspace = true }
 tower-sessions = { workspace = true }
 http = "1"
 jsonwebtoken = { workspace = true }
-sha2 = "0.10"
+sha2 = "0.11"
 base64 = "0.22"
-rand = "0.8"
+rand = "0.9"
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_urlencoded = "0.7"
@@ -38,6 +38,6 @@ urlencoding = "2"
 ignored = ["kartoteka-domain", "tracing"]
 
 [dev-dependencies]
-hmac = "0.12"
+hmac = "0.13"
 tower = { version = "0.5", features = ["util"] }
 kartoteka-db = { path = "../db", features = ["test-helpers"] }

--- a/crates/oauth/src/handlers.rs
+++ b/crates/oauth/src/handlers.rs
@@ -156,7 +156,7 @@ pub async fn authorize_get(
     }
 
     let mut csrf_bytes = [0u8; 32];
-    rand::thread_rng().fill_bytes(&mut csrf_bytes);
+    rand::rng().fill_bytes(&mut csrf_bytes);
     let csrf_token = URL_SAFE_NO_PAD.encode(csrf_bytes);
 
     let pending = PendingOAuthRequest {
@@ -230,7 +230,7 @@ pub async fn authorize_post(
     }
 
     let mut code_bytes = [0u8; 32];
-    rand::thread_rng().fill_bytes(&mut code_bytes);
+    rand::rng().fill_bytes(&mut code_bytes);
     let code = URL_SAFE_NO_PAD.encode(code_bytes);
     let expires_at = Utc::now() + Duration::minutes(AUTH_CODE_TTL_MIN);
 
@@ -375,7 +375,7 @@ async fn token_refresh(s: OAuthState, form: JsonValue) -> Result<Json<TokenRespo
 
 fn mint_refresh_token() -> (String, String) {
     let mut bytes = [0u8; 32];
-    rand::thread_rng().fill_bytes(&mut bytes);
+    rand::rng().fill_bytes(&mut bytes);
     let token = URL_SAFE_NO_PAD.encode(bytes);
     let hash = URL_SAFE_NO_PAD.encode(Sha256::digest(token.as_bytes()));
     (token, hash)

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -18,7 +18,7 @@ kartoteka-domain = { path = "../domain" }
 kartoteka-auth = { path = "../auth" }
 kartoteka-mcp = { path = "../mcp" }
 kartoteka-oauth = { path = "../oauth" }
-rmcp = { version = "0.3", features = ["server", "transport-streamable-http-server"] }
+rmcp = { version = "1.5", features = ["server", "transport-streamable-http-server"] }
 tower.workspace = true
 kartoteka-jobs = { path = "../jobs" }
 kartoteka-frontend = { path = "../frontend", features = ["ssr"] }
@@ -54,7 +54,7 @@ kartoteka-domain = { path = "../domain" }
 kartoteka-auth = { path = "../auth" }
 serde_json.workspace = true
 totp-rs.workspace = true
-sha2 = "0.10"
+sha2 = "0.11"
 base64 = "0.22"
 chrono.workspace = true
 kartoteka-mcp = { path = "../mcp" }

--- a/crates/server/tests/mcp_oauth_e2e.rs
+++ b/crates/server/tests/mcp_oauth_e2e.rs
@@ -124,6 +124,7 @@ async fn dcr_then_token_then_mcp_initialize() {
                 .header("authorization", format!("Bearer {access_token}"))
                 .header("content-type", "application/json")
                 .header("accept", "application/json, text/event-stream")
+                .header("host", "localhost")
                 .body(Body::from(init_body))
                 .unwrap(),
         )

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -18,5 +18,5 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", default-features = false, features = ["alloc", "serde"] }
 chrono-tz = { workspace = true }
-schemars = "0.8"
+schemars = "1"
 sqlx = { workspace = true, optional = true }


### PR DESCRIPTION
## Summary

Batches 13 out of 14 open Dependabot PRs into a single upgrade commit. Each dependency required code fixes for breaking changes.

- **rmcp 0.3 → 1.5**: model structs became `#[non_exhaustive]`; switched to mutable assignment pattern; `Parameters` import path changed; deprecated `*Param` aliases replaced with `*Params`; `ReadResourceResult::new()` constructor used
- **axum-login 0.17 → 0.18**: `AuthnBackend` now uses native async traits (RPITIT) — removed `#[async_trait]` decorator and import from `crates/auth`
- **rand 0.8 → 0.9**: `thread_rng()` → `rng()` in `crates/oauth/src/handlers.rs` (3 occurrences)
- **chrono-tz 0.9 → 0.10**, **fluent-bundle 0.15 → 0.16**, **fluent-syntax 0.11 → 0.12** (no code changes)
- **schemars 0.8 → 1**, **sha2 0.10 → 0.11**, **hmac 0.12 → 0.13** (no code changes)
- **GitHub Actions**: `setup-buildx-action` v3→v4.0.0, `actions/cache` v4→v5, `docker/login-action` v3→v4.1.0, `release-please-action` v4→v5

## Excluded

- **tower-sessions #168** (0.14 → 0.15): `tower-sessions-sqlx-store 0.15.0` still depends on `tower-sessions-core ^0.14`, making the upgrade impossible without a compatible sqlx-store release.

## Test plan

- [x] `cargo check --workspace` — clean, no errors or deprecation warnings
- [x] `cargo test --workspace` — 114 tests pass
- [x] lefthook pre-commit (fmt + clippy) — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)