### PR TITLE
feat(domain): enforce unique names within parent for lists, items, and tags

### DIFF
--- a/crates/db/src/items.rs
+++ b/crates/db/src/items.rs
@@ -165,6 +165,27 @@ pub async fn list_all_for_user(pool: &SqlitePool, user_id: &str) -> Result<Vec<I
     .map_err(DbError::Sqlx)
 }
 
+pub async fn find_id_by_title_in_list(
+    pool: &SqlitePool,
+    list_id: &str,
+    title: &str,
+    exclude_id: Option<&str>,
+) -> Result<Option<String>, DbError> {
+    let row: Option<(String,)> = sqlx::query_as(
+        "SELECT id FROM items \
+         WHERE list_id = ? \
+           AND LOWER(TRIM(title)) = LOWER(TRIM(?)) \
+           AND id != COALESCE(?, '')",
+    )
+    .bind(list_id)
+    .bind(title)
+    .bind(exclude_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(DbError::Sqlx)?;
+    Ok(row.map(|(id,)| id))
+}
+
 // ── Write queries ─────────────────────────────────────────────────────────────
 
 #[tracing::instrument(skip(pool))]
@@ -878,5 +899,54 @@ mod tests {
 
         let rows = list_for_list(&pool, &list_id, &uid).await.unwrap();
         assert!(rows.is_empty());
+    }
+
+    #[tokio::test]
+    async fn find_by_title_exact_match() {
+        let pool = test_pool().await;
+        let uid = create_test_user(&pool).await;
+        let list_id = setup_list(&pool, &uid).await;
+        let item = make_item(&pool, &list_id, "Buy milk", 0).await;
+        let found = find_id_by_title_in_list(&pool, &list_id, "Buy milk", None)
+            .await
+            .unwrap();
+        assert_eq!(found, Some(item.id));
+    }
+
+    #[tokio::test]
+    async fn find_by_title_case_insensitive() {
+        let pool = test_pool().await;
+        let uid = create_test_user(&pool).await;
+        let list_id = setup_list(&pool, &uid).await;
+        let item = make_item(&pool, &list_id, "Buy Milk", 0).await;
+        let found = find_id_by_title_in_list(&pool, &list_id, "buy milk", None)
+            .await
+            .unwrap();
+        assert_eq!(found, Some(item.id));
+    }
+
+    #[tokio::test]
+    async fn find_by_title_excludes_self() {
+        let pool = test_pool().await;
+        let uid = create_test_user(&pool).await;
+        let list_id = setup_list(&pool, &uid).await;
+        let item = make_item(&pool, &list_id, "Buy milk", 0).await;
+        let found = find_id_by_title_in_list(&pool, &list_id, "Buy milk", Some(&item.id))
+            .await
+            .unwrap();
+        assert!(found.is_none());
+    }
+
+    #[tokio::test]
+    async fn find_by_title_different_list_not_found() {
+        let pool = test_pool().await;
+        let uid = create_test_user(&pool).await;
+        let list1 = setup_list(&pool, &uid).await;
+        let list2 = setup_list(&pool, &uid).await;
+        make_item(&pool, &list1, "Buy milk", 0).await;
+        let found = find_id_by_title_in_list(&pool, &list2, "Buy milk", None)
+            .await
+            .unwrap();
+        assert!(found.is_none());
     }
 }

--- a/crates/db/src/lists.rs
+++ b/crates/db/src/lists.rs
@@ -219,6 +219,33 @@ pub async fn get_create_item_context(
     }
 }
 
+pub async fn find_id_by_name_in_scope(
+    pool: &SqlitePool,
+    user_id: &str,
+    name: &str,
+    container_id: Option<&str>,
+    parent_list_id: Option<&str>,
+    exclude_id: Option<&str>,
+) -> Result<Option<String>, DbError> {
+    let row: Option<(String,)> = sqlx::query_as(
+        "SELECT id FROM lists \
+         WHERE user_id = ? \
+           AND LOWER(TRIM(name)) = LOWER(TRIM(?)) \
+           AND container_id IS ? \
+           AND parent_list_id IS ? \
+           AND id != COALESCE(?, '')",
+    )
+    .bind(user_id)
+    .bind(name)
+    .bind(container_id)
+    .bind(parent_list_id)
+    .bind(exclude_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(DbError::Sqlx)?;
+    Ok(row.map(|(id,)| id))
+}
+
 pub async fn find_owned_ids(
     pool: &SqlitePool,
     user_id: &str,
@@ -636,5 +663,72 @@ mod tests {
 
         let names = get_feature_names(&pool, &id).await.unwrap();
         assert!(names.is_empty());
+    }
+
+    #[tokio::test]
+    async fn find_by_name_exact_match() {
+        let pool = test_pool().await;
+        let uid = create_test_user(&pool).await;
+        let id = insert_test_list(&pool, &uid, "Zakupy").await;
+        let found = find_id_by_name_in_scope(&pool, &uid, "Zakupy", None, None, None)
+            .await
+            .unwrap();
+        assert_eq!(found, Some(id));
+    }
+
+    #[tokio::test]
+    async fn find_by_name_case_insensitive() {
+        let pool = test_pool().await;
+        let uid = create_test_user(&pool).await;
+        let id = insert_test_list(&pool, &uid, "Zakupy").await;
+        let found = find_id_by_name_in_scope(&pool, &uid, "zakupy", None, None, None)
+            .await
+            .unwrap();
+        assert_eq!(found, Some(id));
+    }
+
+    #[tokio::test]
+    async fn find_by_name_trim() {
+        let pool = test_pool().await;
+        let uid = create_test_user(&pool).await;
+        let id = insert_test_list(&pool, &uid, "  Zakupy  ").await;
+        let found = find_id_by_name_in_scope(&pool, &uid, "Zakupy", None, None, None)
+            .await
+            .unwrap();
+        assert_eq!(found, Some(id));
+    }
+
+    #[tokio::test]
+    async fn find_by_name_excludes_self() {
+        let pool = test_pool().await;
+        let uid = create_test_user(&pool).await;
+        let id = insert_test_list(&pool, &uid, "Zakupy").await;
+        let found = find_id_by_name_in_scope(&pool, &uid, "Zakupy", None, None, Some(&id))
+            .await
+            .unwrap();
+        assert!(found.is_none());
+    }
+
+    #[tokio::test]
+    async fn find_by_name_different_user_not_found() {
+        let pool = test_pool().await;
+        let uid1 = create_test_user(&pool).await;
+        let uid2 = create_test_user(&pool).await;
+        insert_test_list(&pool, &uid1, "Zakupy").await;
+        let found = find_id_by_name_in_scope(&pool, &uid2, "Zakupy", None, None, None)
+            .await
+            .unwrap();
+        assert!(found.is_none());
+    }
+
+    #[tokio::test]
+    async fn find_by_name_no_match_returns_none() {
+        let pool = test_pool().await;
+        let uid = create_test_user(&pool).await;
+        insert_test_list(&pool, &uid, "Zakupy").await;
+        let found = find_id_by_name_in_scope(&pool, &uid, "Praca", None, None, None)
+            .await
+            .unwrap();
+        assert!(found.is_none());
     }
 }

--- a/crates/db/src/tags.rs
+++ b/crates/db/src/tags.rs
@@ -198,6 +198,30 @@ pub async fn get_exclusive_type_tag_for_item(
 
 // ── Write queries ─────────────────────────────────────────────────────────────
 
+pub async fn find_id_by_name_in_scope(
+    pool: &SqlitePool,
+    user_id: &str,
+    name: &str,
+    parent_tag_id: Option<&str>,
+    exclude_id: Option<&str>,
+) -> Result<Option<String>, DbError> {
+    let row: Option<(String,)> = sqlx::query_as(
+        "SELECT id FROM tags \
+         WHERE user_id = ? \
+           AND LOWER(TRIM(name)) = LOWER(TRIM(?)) \
+           AND parent_tag_id IS ? \
+           AND id != COALESCE(?, '')",
+    )
+    .bind(user_id)
+    .bind(name)
+    .bind(parent_tag_id)
+    .bind(exclude_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(DbError::Sqlx)?;
+    Ok(row.map(|(id,)| id))
+}
+
 #[tracing::instrument(skip(pool))]
 pub async fn insert(pool: &SqlitePool, input: &InsertTagInput) -> Result<TagRow, DbError> {
     sqlx::query_as::<_, TagRow>(&format!(
@@ -997,5 +1021,63 @@ mod tests {
             .await
             .unwrap();
         assert!(none.is_none());
+    }
+
+    #[tokio::test]
+    async fn find_by_name_exact_match() {
+        let pool = test_pool().await;
+        let uid = create_test_user(&pool).await;
+        let tag = insert_tag(&pool, &uid, "Work", None, "tag").await;
+        let found = find_id_by_name_in_scope(&pool, &uid, "Work", None, None)
+            .await
+            .unwrap();
+        assert_eq!(found, Some(tag.id));
+    }
+
+    #[tokio::test]
+    async fn find_by_name_case_insensitive() {
+        let pool = test_pool().await;
+        let uid = create_test_user(&pool).await;
+        let tag = insert_tag(&pool, &uid, "Work", None, "tag").await;
+        let found = find_id_by_name_in_scope(&pool, &uid, "work", None, None)
+            .await
+            .unwrap();
+        assert_eq!(found, Some(tag.id));
+    }
+
+    #[tokio::test]
+    async fn find_by_name_excludes_self() {
+        let pool = test_pool().await;
+        let uid = create_test_user(&pool).await;
+        let tag = insert_tag(&pool, &uid, "Work", None, "tag").await;
+        let found = find_id_by_name_in_scope(&pool, &uid, "Work", None, Some(&tag.id))
+            .await
+            .unwrap();
+        assert!(found.is_none());
+    }
+
+    #[tokio::test]
+    async fn find_by_name_different_parent_not_found() {
+        let pool = test_pool().await;
+        let uid = create_test_user(&pool).await;
+        let parent = insert_tag(&pool, &uid, "Parent", None, "tag").await;
+        insert_tag(&pool, &uid, "Child", Some(&parent.id), "tag").await;
+        // same name at root level — should not find the child
+        let found = find_id_by_name_in_scope(&pool, &uid, "Child", None, None)
+            .await
+            .unwrap();
+        assert!(found.is_none());
+    }
+
+    #[tokio::test]
+    async fn find_by_name_under_parent_found() {
+        let pool = test_pool().await;
+        let uid = create_test_user(&pool).await;
+        let parent = insert_tag(&pool, &uid, "Parent", None, "tag").await;
+        let child = insert_tag(&pool, &uid, "Child", Some(&parent.id), "tag").await;
+        let found = find_id_by_name_in_scope(&pool, &uid, "child", Some(&parent.id), None)
+            .await
+            .unwrap();
+        assert_eq!(found, Some(child.id));
     }
 }

--- a/crates/domain/src/items.rs
+++ b/crates/domain/src/items.rs
@@ -153,6 +153,10 @@ pub async fn create(
 
     // Phase 2: THINK
     rules::items::validate_title(&req.title)?;
+    DomainError::ensure_unique(
+        db::items::find_id_by_title_in_list(pool, list_id, &req.title, None).await?,
+        "item",
+    )?;
     rules::items::validate_item_dates(
         req.start_date.as_deref(),
         req.start_time.as_deref(),
@@ -209,6 +213,10 @@ pub async fn update(
     // Phase 2: THINK
     if let Some(title) = &req.title {
         rules::items::validate_title(title)?;
+        DomainError::ensure_unique(
+            db::items::find_id_by_title_in_list(pool, &current.list_id, title, Some(id)).await?,
+            "item",
+        )?;
     }
     let eff_start_date = effective_date_field(&current.start_date, req.start_date.as_ref());
     let eff_start_time =
@@ -312,7 +320,14 @@ pub async fn move_item(
     id: &str,
     req: &MoveItemRequest,
 ) -> Result<Option<Item>, DomainError> {
-    // Phase 1 READ: validate target list if provided
+    // Phase 1 READ: get current item + validate target list if provided
+    let current = match db::items::get_one(pool, id, user_id)
+        .await?
+        .map(row_to_item)
+    {
+        Some(i) => i,
+        None => return Ok(None),
+    };
     if let Some(target_list_id) = &req.list_id {
         if db::lists::get_one(pool, target_list_id, user_id)
             .await?
@@ -321,6 +336,12 @@ pub async fn move_item(
             return Err(DomainError::NotFound("list"));
         }
     }
+    // Phase 2 THINK: duplicate check in target list
+    let target_list = req.list_id.as_deref().unwrap_or(&current.list_id);
+    DomainError::ensure_unique(
+        db::items::find_id_by_title_in_list(pool, target_list, &current.title, Some(id)).await?,
+        "item",
+    )?;
     // Phase 3 WRITE
     let found =
         db::items::move_item(pool, id, user_id, req.position, req.list_id.as_deref()).await?;
@@ -1065,5 +1086,112 @@ mod tests {
             err,
             DomainError::Validation("start_date_after_deadline")
         ));
+    }
+
+    #[tokio::test]
+    async fn create_duplicate_title_returns_already_exists_with_id() {
+        let pool = test_pool().await;
+        let uid = create_test_user(&pool).await;
+        let list_id = create_list(&pool, &uid, &[]).await;
+        let first = create(&pool, &uid, &list_id, &basic_req("Buy milk"))
+            .await
+            .unwrap();
+        let err = create(&pool, &uid, &list_id, &basic_req("buy milk"))
+            .await
+            .unwrap_err();
+        match err {
+            DomainError::AlreadyExists { kind, id } => {
+                assert_eq!(kind, "item");
+                assert_eq!(id, first.id);
+            }
+            _ => panic!("expected AlreadyExists, got {err:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_same_title_different_list_ok() {
+        let pool = test_pool().await;
+        let uid = create_test_user(&pool).await;
+        let list1 = create_list(&pool, &uid, &[]).await;
+        let list2 = create_list(&pool, &uid, &[]).await;
+        create(&pool, &uid, &list1, &basic_req("Buy milk"))
+            .await
+            .unwrap();
+        assert!(
+            create(&pool, &uid, &list2, &basic_req("Buy milk"))
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn update_title_to_existing_rejected() {
+        let pool = test_pool().await;
+        let uid = create_test_user(&pool).await;
+        let list_id = create_list(&pool, &uid, &[]).await;
+        let first = create(&pool, &uid, &list_id, &basic_req("Buy milk"))
+            .await
+            .unwrap();
+        let second = create(&pool, &uid, &list_id, &basic_req("Eggs"))
+            .await
+            .unwrap();
+        let err = update(
+            &pool,
+            &uid,
+            &second.id,
+            &UpdateItemRequest {
+                title: Some("buy milk".into()),
+                description: None,
+                completed: None,
+                quantity: None,
+                actual_quantity: None,
+                unit: None,
+                start_date: None,
+                start_time: None,
+                deadline: None,
+                deadline_time: None,
+                hard_deadline: None,
+                estimated_duration: None,
+            },
+        )
+        .await
+        .unwrap_err();
+        match err {
+            DomainError::AlreadyExists { id, .. } => assert_eq!(id, first.id),
+            _ => panic!("expected AlreadyExists, got {err:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn update_same_title_as_self_ok() {
+        let pool = test_pool().await;
+        let uid = create_test_user(&pool).await;
+        let list_id = create_list(&pool, &uid, &[]).await;
+        let item = create(&pool, &uid, &list_id, &basic_req("Buy milk"))
+            .await
+            .unwrap();
+        assert!(
+            update(
+                &pool,
+                &uid,
+                &item.id,
+                &UpdateItemRequest {
+                    title: Some("Buy milk".into()),
+                    description: None,
+                    completed: None,
+                    quantity: None,
+                    actual_quantity: None,
+                    unit: None,
+                    start_date: None,
+                    start_time: None,
+                    deadline: None,
+                    deadline_time: None,
+                    hard_deadline: None,
+                    estimated_duration: None,
+                },
+            )
+            .await
+            .is_ok()
+        );
     }
 }

--- a/crates/domain/src/lib.rs
+++ b/crates/domain/src/lib.rs
@@ -22,12 +22,23 @@ pub enum DomainError {
     Validation(&'static str),
     #[error("feature required: {0}")]
     FeatureRequired(&'static str),
+    #[error("already exists: {kind} id={id}")]
+    AlreadyExists { kind: &'static str, id: String },
     #[error("forbidden")]
     Forbidden,
     #[error("{0}")]
     Internal(String),
     #[error(transparent)]
     Db(#[from] kartoteka_db::DbError),
+}
+
+impl DomainError {
+    pub fn ensure_unique(found: Option<String>, kind: &'static str) -> Result<(), Self> {
+        match found {
+            Some(id) => Err(Self::AlreadyExists { kind, id }),
+            None => Ok(()),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/domain/src/lists.rs
+++ b/crates/domain/src/lists.rs
@@ -195,6 +195,19 @@ pub async fn create(
     user_id: &str,
     req: &CreateListRequest,
 ) -> Result<List, DomainError> {
+    DomainError::ensure_unique(
+        db::lists::find_id_by_name_in_scope(
+            pool,
+            user_id,
+            &req.name,
+            req.container_id.as_deref(),
+            req.parent_list_id.as_deref(),
+            None,
+        )
+        .await?,
+        "list",
+    )?;
+
     let list_type_str = req.list_type.as_deref().unwrap_or("checklist");
     let list_type = ListType::try_from(list_type_str)?;
 
@@ -253,8 +266,25 @@ pub async fn update(
     req: &UpdateListRequest,
 ) -> Result<Option<List>, DomainError> {
     // Phase 1: READ — need current list to check it exists before update
-    if db::lists::get_one(pool, id, user_id).await?.is_none() {
-        return Ok(None);
+    let current = match db::lists::get_one(pool, id, user_id).await? {
+        Some(c) => c,
+        None => return Ok(None),
+    };
+
+    // Phase 2: THINK — duplicate name check
+    if let Some(ref new_name) = req.name {
+        DomainError::ensure_unique(
+            db::lists::find_id_by_name_in_scope(
+                pool,
+                user_id,
+                new_name,
+                current.container_id.as_deref(),
+                current.parent_list_id.as_deref(),
+                Some(id),
+            )
+            .await?,
+            "list",
+        )?;
     }
 
     // Phase 3: WRITE
@@ -332,6 +362,22 @@ pub async fn move_list(
     user_id: &str,
     req: &MoveListRequest,
 ) -> Result<Option<List>, DomainError> {
+    let current = match db::lists::get_one(pool, id, user_id).await? {
+        Some(c) => c,
+        None => return Ok(None),
+    };
+    DomainError::ensure_unique(
+        db::lists::find_id_by_name_in_scope(
+            pool,
+            user_id,
+            &current.name,
+            req.container_id.as_deref(),
+            req.parent_list_id.as_deref(),
+            Some(id),
+        )
+        .await?,
+        "list",
+    )?;
     let moved = db::lists::move_list(
         pool,
         id,
@@ -658,5 +704,78 @@ mod tests {
         let l2 = create(&pool, &uid, &checklist_req("Second")).await.unwrap();
         assert_eq!(l1.position, 0);
         assert_eq!(l2.position, 1);
+    }
+
+    #[tokio::test]
+    async fn create_duplicate_name_returns_already_exists_with_id() {
+        let pool = test_pool().await;
+        let uid = create_test_user(&pool).await;
+        let first = create(&pool, &uid, &checklist_req("Zakupy")).await.unwrap();
+        let err = create(&pool, &uid, &checklist_req("zakupy"))
+            .await
+            .unwrap_err();
+        match err {
+            DomainError::AlreadyExists { kind, id } => {
+                assert_eq!(kind, "list");
+                assert_eq!(id, first.id);
+            }
+            _ => panic!("expected AlreadyExists, got {err:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_same_name_different_user_ok() {
+        let pool = test_pool().await;
+        let uid1 = create_test_user(&pool).await;
+        let uid2 = create_test_user(&pool).await;
+        create(&pool, &uid1, &checklist_req("Praca")).await.unwrap();
+        assert!(create(&pool, &uid2, &checklist_req("Praca")).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn update_rename_to_existing_name_rejected() {
+        let pool = test_pool().await;
+        let uid = create_test_user(&pool).await;
+        let first = create(&pool, &uid, &checklist_req("Zakupy")).await.unwrap();
+        let second = create(&pool, &uid, &checklist_req("Praca")).await.unwrap();
+        let err = update(
+            &pool,
+            &second.id,
+            &uid,
+            &UpdateListRequest {
+                name: Some("zakupy".into()),
+                icon: None,
+                description: None,
+                list_type: None,
+            },
+        )
+        .await
+        .unwrap_err();
+        match err {
+            DomainError::AlreadyExists { id, .. } => assert_eq!(id, first.id),
+            _ => panic!("expected AlreadyExists, got {err:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn update_same_name_as_self_ok() {
+        let pool = test_pool().await;
+        let uid = create_test_user(&pool).await;
+        let list = create(&pool, &uid, &checklist_req("Zakupy")).await.unwrap();
+        assert!(
+            update(
+                &pool,
+                &list.id,
+                &uid,
+                &UpdateListRequest {
+                    name: Some("Zakupy".into()),
+                    icon: None,
+                    description: None,
+                    list_type: None,
+                },
+            )
+            .await
+            .is_ok()
+        );
     }
 }

--- a/crates/domain/src/tags.rs
+++ b/crates/domain/src/tags.rs
@@ -122,6 +122,17 @@ pub async fn create(
     // Phase 2: THINK
     let tag_type = req.tag_type.as_deref().unwrap_or("tag");
     rules::tags::validate_location_hierarchy(tag_type, parent_type.as_deref())?;
+    DomainError::ensure_unique(
+        db::tags::find_id_by_name_in_scope(
+            pool,
+            user_id,
+            &req.name,
+            req.parent_tag_id.as_deref(),
+            None,
+        )
+        .await?,
+        "tag",
+    )?;
 
     // Phase 3: WRITE
     let row = db::tags::insert(
@@ -184,6 +195,19 @@ pub async fn update(
                 rules::tags::validate_location_hierarchy(effective_type, parent_type.as_deref())?;
             }
         }
+    }
+
+    // Duplicate name check — use effective parent after any parent change
+    if let Some(ref new_name) = req.name {
+        let effective_parent = match &req.parent_tag_id {
+            Some(p) => p.as_deref(),
+            None => current.parent_tag_id.as_deref(),
+        };
+        DomainError::ensure_unique(
+            db::tags::find_id_by_name_in_scope(pool, user_id, new_name, effective_parent, Some(id))
+                .await?,
+            "tag",
+        )?;
     }
 
     // Phase 3: WRITE
@@ -702,5 +726,122 @@ mod tests {
         .await;
 
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn create_duplicate_tag_name_returns_already_exists_with_id() {
+        let pool = test_pool().await;
+        let uid = create_test_user(&pool).await;
+        let first = make_tag(&pool, &uid, "Work").await;
+        let err = create(
+            &pool,
+            &uid,
+            &CreateTagRequest {
+                name: "work".into(),
+                icon: None,
+                color: None,
+                parent_tag_id: None,
+                tag_type: None,
+                metadata: None,
+            },
+        )
+        .await
+        .unwrap_err();
+        match err {
+            DomainError::AlreadyExists { kind, id } => {
+                assert_eq!(kind, "tag");
+                assert_eq!(id, first.id);
+            }
+            _ => panic!("expected AlreadyExists, got {err:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_same_name_under_different_parent_ok() {
+        let pool = test_pool().await;
+        let uid = create_test_user(&pool).await;
+        let parent1 = make_tag(&pool, &uid, "Parent1").await;
+        let parent2 = make_tag(&pool, &uid, "Parent2").await;
+        create(
+            &pool,
+            &uid,
+            &CreateTagRequest {
+                name: "Child".into(),
+                parent_tag_id: Some(parent1.id.clone()),
+                tag_type: None,
+                icon: None,
+                color: None,
+                metadata: None,
+            },
+        )
+        .await
+        .unwrap();
+        assert!(
+            create(
+                &pool,
+                &uid,
+                &CreateTagRequest {
+                    name: "Child".into(),
+                    parent_tag_id: Some(parent2.id.clone()),
+                    tag_type: None,
+                    icon: None,
+                    color: None,
+                    metadata: None,
+                },
+            )
+            .await
+            .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn update_tag_name_to_existing_rejected() {
+        let pool = test_pool().await;
+        let uid = create_test_user(&pool).await;
+        let first = make_tag(&pool, &uid, "Work").await;
+        let second = make_tag(&pool, &uid, "Personal").await;
+        let err = update(
+            &pool,
+            &uid,
+            &second.id,
+            &UpdateTagRequest {
+                name: Some("work".into()),
+                icon: None,
+                color: None,
+                parent_tag_id: None,
+                tag_type: None,
+                metadata: None,
+            },
+        )
+        .await
+        .unwrap_err();
+        match err {
+            DomainError::AlreadyExists { id, .. } => assert_eq!(id, first.id),
+            _ => panic!("expected AlreadyExists, got {err:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn update_same_name_as_self_ok() {
+        let pool = test_pool().await;
+        let uid = create_test_user(&pool).await;
+        let tag = make_tag(&pool, &uid, "Work").await;
+        assert!(
+            update(
+                &pool,
+                &uid,
+                &tag.id,
+                &UpdateTagRequest {
+                    name: Some("Work".into()),
+                    icon: None,
+                    color: None,
+                    parent_tag_id: None,
+                    tag_type: None,
+                    metadata: None,
+                },
+            )
+            .await
+            .is_ok()
+        );
     }
 }

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -32,5 +32,9 @@ fluent-bundle = "0.16"
 fluent-syntax = "0.12"
 unic-langid = "0.9"
 
+[dev-dependencies]
+kartoteka-db = { path = "../db", features = ["test-helpers"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+
 [package.metadata.cargo-machete]
 ignored = ["async-trait", "chrono", "chrono-tz", "fluent-syntax", "tokio"]

--- a/crates/mcp/src/server.rs
+++ b/crates/mcp/src/server.rs
@@ -129,6 +129,22 @@ impl KartotekaServer {
         move |e| self.map_err(McpError::Domain(db::DbError::Sqlx(e).into()), locale)
     }
 
+    /// Like `domain_err` but intercepts `AlreadyExists` and returns
+    /// `{"id": "<existing_id>", "existed": true}` instead of an error.
+    fn domain_or_existing<T: serde::Serialize>(
+        &self,
+        result: Result<T, domain::DomainError>,
+        locale: &str,
+    ) -> Result<CallToolResult, ErrorData> {
+        match result {
+            Ok(v) => self.json_result(v, locale),
+            Err(domain::DomainError::AlreadyExists { id, .. }) => {
+                self.json_result(serde_json::json!({"id": id, "existed": true}), locale)
+            }
+            Err(e) => Err(self.domain_err(locale)(e)),
+        }
+    }
+
     fn json_result<T: serde::Serialize>(
         &self,
         value: T,
@@ -192,10 +208,10 @@ impl KartotekaServer {
             unit: p.unit,
             estimated_duration: p.estimated_duration,
         };
-        let item = domain::items::create(&self.pool, &uid, &p.list_id, &req)
-            .await
-            .map_err(self.domain_err(&locale))?;
-        self.json_result(item, &locale)
+        self.domain_or_existing(
+            domain::items::create(&self.pool, &uid, &p.list_id, &req).await,
+            &locale,
+        )
     }
 
     #[rmcp::tool(name = "update_item", description = "mcp-tool-update_item-desc")]
@@ -241,10 +257,7 @@ impl KartotekaServer {
             parent_list_id: p.parent_list_id,
             features: p.features.unwrap_or_default(),
         };
-        let list = domain::lists::create(&self.pool, &uid, &req)
-            .await
-            .map_err(self.domain_err(&locale))?;
-        self.json_result(list, &locale)
+        self.domain_or_existing(domain::lists::create(&self.pool, &uid, &req).await, &locale)
     }
 
     #[rmcp::tool(name = "search_items", description = "mcp-tool-search_items-desc")]
@@ -522,10 +535,7 @@ impl KartotekaServer {
             icon: None,
             metadata: None,
         };
-        let tag = domain::tags::create(&self.pool, &uid, &req)
-            .await
-            .map_err(self.domain_err(&locale))?;
-        self.json_result(tag, &locale)
+        self.domain_or_existing(domain::tags::create(&self.pool, &uid, &req).await, &locale)
     }
 
     #[rmcp::tool(name = "assign_tag", description = "mcp-tool-assign_tag-desc")]
@@ -637,6 +647,23 @@ impl KartotekaServer {
                 )
                 .map_err(|e| self.map_err(McpError::BadRequest(e.to_string()), &locale))?
                 .map(str::to_owned);
+
+            if let Some(eid) = db::tags::find_id_by_name_in_scope(
+                &self.pool,
+                &uid,
+                &tag.name,
+                parent_id.as_deref(),
+                None,
+            )
+            .await
+            .map_err(self.db_err(&locale))?
+            {
+                resolver
+                    .register(tag.client_ref.as_deref(), &eid)
+                    .map_err(|e| self.map_err(McpError::BadRequest(e.to_string()), &locale))?;
+                result.push(serde_json::json!({"id": eid, "name": tag.name, "existed": true}));
+                continue;
+            }
 
             let new_id = Uuid::new_v4().to_string();
             db::tags::insert_in_tx(
@@ -839,15 +866,23 @@ impl KartotekaServer {
                 )
             })?;
 
-        let start_pos = ctx.next_position as i32;
-        let inputs: Vec<db::items::InsertItemInput> = p
-            .items
-            .iter()
-            .enumerate()
-            .map(|(i, item)| db::items::InsertItemInput {
+        let mut tx = self.pool.begin().await.map_err(self.sqlx_err(&locale))?;
+        let mut result = Vec::with_capacity(p.items.len());
+        let mut next_pos = ctx.next_position as i32;
+
+        for item in &p.items {
+            if let Some(eid) =
+                db::items::find_id_by_title_in_list(&self.pool, &p.list_id, &item.title, None)
+                    .await
+                    .map_err(self.db_err(&locale))?
+            {
+                result.push(serde_json::json!({"id": eid, "title": item.title, "existed": true}));
+                continue;
+            }
+            let input = db::items::InsertItemInput {
                 id: Uuid::new_v4().to_string(),
                 list_id: p.list_id.clone(),
-                position: start_pos + i as i32,
+                position: next_pos,
                 title: item.title.clone(),
                 description: item.description.clone(),
                 start_date: item.start_date.clone(),
@@ -859,19 +894,15 @@ impl KartotekaServer {
                 actual_quantity: item.actual_quantity,
                 unit: item.unit.clone(),
                 estimated_duration: item.estimated_duration,
-            })
-            .collect();
+            };
+            db::items::insert_in_tx(&mut tx, &input)
+                .await
+                .map_err(self.db_err(&locale))?;
+            result.push(serde_json::json!({"id": input.id, "title": input.title}));
+            next_pos += 1;
+        }
 
-        let mut tx = self.pool.begin().await.map_err(self.sqlx_err(&locale))?;
-        db::items::insert_many_in_tx(&mut tx, &inputs)
-            .await
-            .map_err(self.db_err(&locale))?;
         tx.commit().await.map_err(self.sqlx_err(&locale))?;
-
-        let result: Vec<_> = inputs
-            .iter()
-            .map(|i| serde_json::json!({"id": i.id, "title": i.title}))
-            .collect();
         self.json_result(result, &locale)
     }
 
@@ -943,6 +974,24 @@ impl KartotekaServer {
                 container_id.map(str::to_owned),
                 parent_list_id.map(str::to_owned),
             ));
+
+            if let Some(eid) = db::lists::find_id_by_name_in_scope(
+                &self.pool,
+                &uid,
+                &list.name,
+                container_id,
+                parent_list_id,
+                None,
+            )
+            .await
+            .map_err(self.db_err(&locale))?
+            {
+                resolver
+                    .register(list.client_ref.as_deref(), &eid)
+                    .map_err(|e| self.map_err(McpError::BadRequest(e.to_string()), &locale))?;
+                result.push(serde_json::json!({"id": eid, "name": list.name, "existed": true}));
+                continue;
+            }
 
             let list_type = list.list_type.as_deref().unwrap_or("custom");
             let new_id = Uuid::new_v4().to_string();

--- a/crates/mcp/src/server.rs
+++ b/crates/mcp/src/server.rs
@@ -1337,12 +1337,67 @@ impl ServerHandler for KartotekaServer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tools::items::CreateItemsInput;
+    use kartoteka_db::lists::{InsertListInput, insert as insert_list};
+    use kartoteka_db::test_helpers::create_test_user;
+    use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+    use std::str::FromStr;
+
+    /// Multi-connection in-memory pool for tests that hold a transaction while also
+    /// querying the pool (which deadlocks on a single-connection pool).
+    async fn multi_conn_pool() -> SqlitePool {
+        let name = uuid::Uuid::new_v4().simple().to_string();
+        let url = format!("file:{name}?mode=memory&cache=shared");
+        let options = SqliteConnectOptions::from_str(&url)
+            .unwrap()
+            .create_if_missing(true)
+            .foreign_keys(true);
+        let pool = SqlitePoolOptions::new()
+            .max_connections(4)
+            .connect_with(options)
+            .await
+            .unwrap();
+        kartoteka_db::run_migrations(&pool).await.unwrap();
+        pool
+    }
 
     fn parts_with_extensions(extensions: http::Extensions) -> Parts {
         let mut req = http::Request::new(());
         *req.extensions_mut() = extensions;
         let (parts, _) = req.into_parts();
         parts
+    }
+
+    fn test_server(pool: SqlitePool) -> KartotekaServer {
+        let manifest = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let locales = manifest.parent().unwrap().parent().unwrap().join("locales");
+        KartotekaServer::new(pool, Arc::new(McpI18n::load_from(&locales)))
+    }
+
+    fn parts_for_user(user_id: &str) -> Parts {
+        let mut ext = http::Extensions::new();
+        ext.insert(UserId(user_id.into()));
+        parts_with_extensions(ext)
+    }
+
+    async fn insert_test_list(pool: &SqlitePool, user_id: &str) -> String {
+        let id = uuid::Uuid::new_v4().to_string();
+        let mut tx = pool.begin().await.unwrap();
+        insert_list(
+            &mut tx,
+            &InsertListInput {
+                id: id.clone(),
+                user_id: user_id.to_owned(),
+                position: 0,
+                name: "Test List".to_owned(),
+                list_type: "checklist".to_owned(),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        tx.commit().await.unwrap();
+        id
     }
 
     #[test]
@@ -1373,5 +1428,86 @@ mod tests {
         let parts = parts_with_extensions(http::Extensions::new());
         let err = KartotekaServer::extract_user_id_and_locale(&parts).unwrap_err();
         assert!(matches!(err, McpError::Unauthorized));
+    }
+
+    #[tokio::test]
+    async fn create_items_within_batch_duplicate_returns_existed() {
+        let pool = multi_conn_pool().await;
+        let uid = create_test_user(&pool).await;
+        let list_id = insert_test_list(&pool, &uid).await;
+        let server = test_server(pool);
+
+        let params = CreateItemsParams {
+            list_id: list_id.clone(),
+            items: vec![
+                CreateItemsInput {
+                    title: "Buy milk".to_owned(),
+                    description: None,
+                    start_date: None,
+                    deadline: None,
+                    hard_deadline: None,
+                    start_time: None,
+                    deadline_time: None,
+                    quantity: None,
+                    actual_quantity: None,
+                    unit: None,
+                    estimated_duration: None,
+                },
+                CreateItemsInput {
+                    title: "BUY MILK".to_owned(), // same title, different case
+                    description: None,
+                    start_date: None,
+                    deadline: None,
+                    hard_deadline: None,
+                    start_time: None,
+                    deadline_time: None,
+                    quantity: None,
+                    actual_quantity: None,
+                    unit: None,
+                    estimated_duration: None,
+                },
+            ],
+        };
+
+        let result = server
+            .create_items(Extension(parts_for_user(&uid)), Parameters(params))
+            .await
+            .unwrap();
+
+        let text = result
+            .content
+            .into_iter()
+            .find_map(|c| match c.raw {
+                rmcp::model::RawContent::Text(t) => Some(t.text),
+                _ => None,
+            })
+            .expect("text content");
+        let items: Vec<serde_json::Value> = serde_json::from_str(&text).unwrap();
+
+        assert_eq!(items.len(), 2, "both inputs must produce an output");
+
+        let first_id = items[0]["id"].as_str().unwrap();
+        assert!(
+            items[0].get("existed").is_none(),
+            "first item should be a new insert"
+        );
+        assert_eq!(
+            items[1]["id"].as_str().unwrap(),
+            first_id,
+            "duplicate should reference the first item's id"
+        );
+        assert_eq!(
+            items[1]["existed"].as_bool(),
+            Some(true),
+            "duplicate must carry existed=true"
+        );
+
+        // Only one row inserted
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM items WHERE list_id = ?")
+            .bind(&list_id)
+            .fetch_one(&server.pool)
+            .await
+            .unwrap();
+        assert_eq!(count.0, 1, "only one item row should exist in the DB");
     }
 }

--- a/crates/mcp/src/server.rs
+++ b/crates/mcp/src/server.rs
@@ -637,6 +637,9 @@ impl KartotekaServer {
         let mut tx = self.pool.begin().await.map_err(self.sqlx_err(&locale))?;
         let mut resolver = RefResolver::new();
         let mut result = Vec::with_capacity(p.tags.len());
+        // (parent_tag_id, normalized_name) → id
+        let mut seen: std::collections::HashMap<(Option<String>, String), String> =
+            std::collections::HashMap::new();
 
         for tag in &p.tags {
             let parent_id: Option<String> = resolver
@@ -648,6 +651,14 @@ impl KartotekaServer {
                 .map_err(|e| self.map_err(McpError::BadRequest(e.to_string()), &locale))?
                 .map(str::to_owned);
 
+            let norm_key = (parent_id.clone(), tag.name.trim().to_lowercase());
+            if let Some(eid) = seen.get(&norm_key) {
+                resolver
+                    .register(tag.client_ref.as_deref(), eid)
+                    .map_err(|e| self.map_err(McpError::BadRequest(e.to_string()), &locale))?;
+                result.push(serde_json::json!({"id": eid, "name": tag.name, "existed": true}));
+                continue;
+            }
             if let Some(eid) = db::tags::find_id_by_name_in_scope(
                 &self.pool,
                 &uid,
@@ -658,6 +669,7 @@ impl KartotekaServer {
             .await
             .map_err(self.db_err(&locale))?
             {
+                seen.insert(norm_key, eid.clone());
                 resolver
                     .register(tag.client_ref.as_deref(), &eid)
                     .map_err(|e| self.map_err(McpError::BadRequest(e.to_string()), &locale))?;
@@ -682,6 +694,7 @@ impl KartotekaServer {
             .await
             .map_err(self.db_err(&locale))?;
 
+            seen.insert(norm_key, new_id.clone());
             resolver
                 .register(tag.client_ref.as_deref(), &new_id)
                 .map_err(|e| self.map_err(McpError::BadRequest(e.to_string()), &locale))?;
@@ -869,13 +882,20 @@ impl KartotekaServer {
         let mut tx = self.pool.begin().await.map_err(self.sqlx_err(&locale))?;
         let mut result = Vec::with_capacity(p.items.len());
         let mut next_pos = ctx.next_position as i32;
+        let mut seen: std::collections::HashMap<String, String> = std::collections::HashMap::new();
 
         for item in &p.items {
+            let norm = item.title.trim().to_lowercase();
+            if let Some(eid) = seen.get(&norm) {
+                result.push(serde_json::json!({"id": eid, "title": item.title, "existed": true}));
+                continue;
+            }
             if let Some(eid) =
                 db::items::find_id_by_title_in_list(&self.pool, &p.list_id, &item.title, None)
                     .await
                     .map_err(self.db_err(&locale))?
             {
+                seen.insert(norm, eid.clone());
                 result.push(serde_json::json!({"id": eid, "title": item.title, "existed": true}));
                 continue;
             }
@@ -898,6 +918,7 @@ impl KartotekaServer {
             db::items::insert_in_tx(&mut tx, &input)
                 .await
                 .map_err(self.db_err(&locale))?;
+            seen.insert(norm, input.id.clone());
             result.push(serde_json::json!({"id": input.id, "title": input.title}));
             next_pos += 1;
         }
@@ -953,6 +974,9 @@ impl KartotekaServer {
         let mut tx = self.pool.begin().await.map_err(self.sqlx_err(&locale))?;
         let mut resolver = RefResolver::new();
         let mut result = Vec::with_capacity(p.lists.len());
+        // (container_id, parent_list_id, normalized_name) → id
+        let mut seen: std::collections::HashMap<(Option<String>, Option<String>, String), String> =
+            std::collections::HashMap::new();
 
         for list in &p.lists {
             let container_id = resolver
@@ -975,6 +999,18 @@ impl KartotekaServer {
                 parent_list_id.map(str::to_owned),
             ));
 
+            let norm_key = (
+                container_id.map(str::to_owned),
+                parent_list_id.map(str::to_owned),
+                list.name.trim().to_lowercase(),
+            );
+            if let Some(eid) = seen.get(&norm_key) {
+                resolver
+                    .register(list.client_ref.as_deref(), eid)
+                    .map_err(|e| self.map_err(McpError::BadRequest(e.to_string()), &locale))?;
+                result.push(serde_json::json!({"id": eid, "name": list.name, "existed": true}));
+                continue;
+            }
             if let Some(eid) = db::lists::find_id_by_name_in_scope(
                 &self.pool,
                 &uid,
@@ -986,6 +1022,7 @@ impl KartotekaServer {
             .await
             .map_err(self.db_err(&locale))?
             {
+                seen.insert(norm_key, eid.clone());
                 resolver
                     .register(list.client_ref.as_deref(), &eid)
                     .map_err(|e| self.map_err(McpError::BadRequest(e.to_string()), &locale))?;
@@ -1022,6 +1059,7 @@ impl KartotekaServer {
                 }
             }
 
+            seen.insert(norm_key, new_id.clone());
             resolver
                 .register(list.client_ref.as_deref(), &new_id)
                 .map_err(|e| self.map_err(McpError::BadRequest(e.to_string()), &locale))?;

--- a/crates/server/src/error.rs
+++ b/crates/server/src/error.rs
@@ -8,6 +8,7 @@ use kartoteka_domain::DomainError;
 pub enum AppError {
     NotFound(&'static str),
     Validation(String),
+    Conflict(String),
     Forbidden,
     Unauthorized,
     Internal(String),
@@ -17,6 +18,7 @@ impl IntoResponse for AppError {
     fn into_response(self) -> Response {
         match self {
             AppError::NotFound(msg) => (StatusCode::NOT_FOUND, msg).into_response(),
+            AppError::Conflict(id) => (StatusCode::CONFLICT, id).into_response(),
             AppError::Validation(msg) => (StatusCode::UNPROCESSABLE_ENTITY, msg).into_response(),
             AppError::Forbidden => StatusCode::FORBIDDEN.into_response(),
             AppError::Unauthorized => StatusCode::UNAUTHORIZED.into_response(),
@@ -32,6 +34,7 @@ impl From<DomainError> for AppError {
     fn from(e: DomainError) -> Self {
         match e {
             DomainError::NotFound(msg) => AppError::NotFound(msg),
+            DomainError::AlreadyExists { id, .. } => AppError::Conflict(id),
             DomainError::Validation(msg) => AppError::Validation(msg.to_string()),
             DomainError::FeatureRequired(f) => {
                 AppError::Validation(format!("feature required: {f}"))


### PR DESCRIPTION
## Summary

- Adds `DomainError::AlreadyExists { kind, id }` for duplicate name conflicts
- DB-level helpers: `find_id_by_name_in_scope` (lists, tags) and `find_id_by_title_in_list` (items) — case-insensitive + trimmed comparison via `LOWER(TRIM(...))`; NULL-safe scope matching via `IS ?`
- Domain-level checks in `create`, `update` (rename), and `move_*` for all three entity types (lists, items, tags)
- Server: `AppError::Conflict(id)` → HTTP 409 with existing entity ID in body
- MCP single handlers (`create_list`, `create_item`, `create_tag`): duplicate → `{"id": "...", "existed": true}` instead of error
- MCP batch handlers (`create_lists`, `create_items`, `create_tags`): per-entry duplicate check, non-failing entries continue; duplicate entries return `{id, existed: true}`
- `DomainError::ensure_unique` helper collapses the 9 repeated check patterns to one-liners
- Unit tests at DB and domain integration levels for all entity types

## Test plan

- [ ] `cargo test --workspace` — all green
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] MCP: `create_tag` with duplicate name → `{"id": "...", "existed": true}`
- [ ] MCP: `create_list` with duplicate → `{"id": "...", "existed": true}`
- [ ] MCP: `create_item` with duplicate → `{"id": "...", "existed": true}`
- [ ] HTTP `POST /lists` with duplicate name → 409 with existing list ID in body
- [ ] Batch MCP tools: mix of new and duplicate entries — duplicates get `existed: true`, new ones get created

🤖 Generated with [Claude Code](https://claude.com/claude-code)