### PR TITLE
feat: landing page for unauthenticated users

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,11 +22,9 @@ Kartoteka — aplikacja todo/listy. Leptos 0.8 SSR (Axum) + SQLite + `axum-login
 - `OAUTH_SIGNING_SECRET` — wymagany do dev (min 32 znaków), zarządzane przez `.env` + `set dotenv-load` w justfile
 
 ### Frontend (Leptos 0.8 SSR)
-- Używaj `Resource::new`, nie `LocalResource` — SSR futures muszą być `Send`
-- `Resource::get()` zwraca `Option<T>` — pattern: `if let Some(Ok(data)) = resource.get()`
-- Server functions przez `#[server]` makro w `crates/frontend-v2/src/server_fns/`
-- `use_context` tylko w ciele komponentu — nie w closures
-- Non-Copy typy w `Fn` closure → `StoredValue::new()` lub `.clone()` przed wejściem
+Szczegółowe reguły w `crates/frontend/CLAUDE.md`. Skrót:
+- Build: **zawsze** przez `cargo leptos build` / `just dev` — nigdy `cargo build -p kartoteka-server`
+- Server functions: `#[server(prefix = "/leptos")]` w `src/server_fns/`
 
 ### Shared crate (`crates/shared/`)
 - `models/`, `dto/` (requests/responses), `deserializers.rs` (pub(crate)), `constants.rs`, `date_utils.rs`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1799,6 +1799,7 @@ dependencies = [
  "sqlx",
  "tokio",
  "tower-sessions",
+ "urlencoding",
  "wasm-bindgen",
  "web-sys",
 ]

--- a/crates/frontend/CLAUDE.md
+++ b/crates/frontend/CLAUDE.md
@@ -1,0 +1,61 @@
+# Frontend — Leptos 0.8 SSR
+
+Crate `kartoteka-frontend` — komponenty, server functions, routing, i18n.
+
+## Leptos 0.8 — kluczowe wzorce
+
+### Resources
+- Używaj `Resource::new`, nie `LocalResource` — SSR futures muszą być `Send`
+- `Resource::new(key_fn, async_fn)` — refetch gdy `key_fn` zwróci nową wartość; do statycznych danych użyj `|| ()` jako klucza
+- `resource.get()` zwraca `Option<Result<T, _>>` — wzorzec: `if let Some(Ok(data)) = resource.get()`
+- `resource.get_untracked()` — odczyt bez subskrypcji reaktywności (np. w `spawn_local`)
+
+### Suspense vs Transition
+- `<Suspense>` — pokazuje fallback przy każdym ładowaniu (pierwsze i kolejne)
+- `<Transition>` — pokazuje fallback tylko przy pierwszym ładowaniu; przy odświeżeniu trzyma stare dzieci
+
+### Children
+- `Children` — przekazywane raz; `ChildrenFn` (`Arc<dyn Fn() -> AnyView>`) — gdy children wołane wielokrotnie (np. w reactive closure `move ||`)
+- `ChildrenFn` wymagane w komponentach które renderują children wewnątrz `move ||` lub `Suspense`
+
+### Closures i sygnały
+- Sygnały (`ReadSignal`, `WriteSignal`, `RwSignal`, `Memo`) są `Copy` — można je przenosić do wielu `move` closures
+- Struktury z `use_location()`, `use_context()` itp. **nie są** `Copy` — wyciągnij potrzebne pola przed closurem:
+  ```rust
+  let location = use_location();
+  let pathname = location.pathname; // Memo<String> — Copy
+  let search = location.search;    // Memo<String> — Copy
+  let full_path = move || { /* używa pathname i search */ };
+  ```
+- Non-Copy typy w `Fn` closure → `StoredValue::new()` lub `.clone()` przed wejściem
+- `use_context` tylko w ciele komponentu — nie w closures ani `spawn_local`
+
+### Server functions
+- `#[server(prefix = "/leptos")]` w `src/server_fns/`
+- Ekstrakcja Axum danych: `leptos_axum::extract::<T>().await`
+- SSR redirect: `leptos_axum::redirect("/path")` — ustawia header `Location` przed HTML
+- Callbacki z async: `leptos::task::spawn_local(async move { ... })`
+- Capture `i18n.tr("key")` **przed** `spawn_local` — `I18n` nie jest `Send`
+
+### Routing (leptos_router)
+- Layout routes z `<Outlet>`: używaj `<ParentRoute>`, nie `<Route children=...>`
+- `<Outlet>` renderuje dopasowane child route w miejscu wywołania
+
+## i18n (leptos-fluent + Fluent)
+
+### Użycie
+- `move_tr!("key")` — reaktywna wartość (zwraca closure `impl Fn() -> String`); używaj w `view!`
+- `move_tr!("key", { "param" => value })` — z parametrami Fluent (`{ $param }` w .ftl)
+- `i18n.tr("key")` — one-shot `String`; używaj w `spawn_local` / callbackach gdzie `move_tr!` nie działa
+- `expect_context::<I18n>()` na początku komponentu, przed closurami
+
+### Pliki .ftl
+- Wszystkie `.ftl` w katalogu locale (`locales/en/`, `locales/pl/`) **mergowane w jeden bundle** przez `fluent-templates`
+- **Duplikat klucza w dwóch plikach → runtime panic**: `Failed to add FTL resources: Overriding { kind: Message, id: "..." }`
+- Każdy klucz musi istnieć w dokładnie jednym pliku na locale
+- Pliki FTL embedowane **w compile time** — zmiana `.ftl` wymaga przebudowania (nie hot-reload)
+- Parametry Fluent: `key = Tekst z { $param }` → `move_tr!("key", { "param" => value })`
+
+### Testy i18n
+- `cargo test -p kartoteka-i18n` — sprawdza parzystość kluczy EN/PL, parsowanie FTL, pokrycie MCP
+- Uruchamiaj po każdej zmianie w `locales/`

--- a/crates/frontend/Cargo.toml
+++ b/crates/frontend/Cargo.toml
@@ -17,6 +17,7 @@ leptos = { workspace = true }
 leptos_router = { workspace = true }
 leptos_meta = { workspace = true, optional = true }
 leptos-fluent = { workspace = true }
+urlencoding = "2.1"
 serde = { workspace = true }
 serde_json = "1"
 chrono = { workspace = true }

--- a/crates/frontend/src/app.rs
+++ b/crates/frontend/src/app.rs
@@ -1,10 +1,11 @@
 use leptos::prelude::*;
 use leptos_fluent::leptos_fluent;
 use leptos_router::{
-    components::{Route, Router, Routes},
+    components::{Outlet, ParentRoute, Route, Router, Routes},
     path,
 };
 
+use crate::components::common::require_auth::RequireAuth;
 use crate::components::nav::Nav;
 use crate::components::toast_container::ToastContainer;
 use crate::pages::{
@@ -92,6 +93,13 @@ fn I18nProvider(children: Children) -> impl IntoView {
     }
 }
 
+// ── AuthGuardLayout ────────────────────────────────────────────────────────────
+
+#[component]
+fn AuthGuardLayout() -> impl IntoView {
+    view! { <RequireAuth><Outlet/></RequireAuth> }
+}
+
 // ── App ────────────────────────────────────────────────────────────────────────
 
 #[component]
@@ -122,21 +130,23 @@ pub fn App() -> impl IntoView {
                 <ToastContainer/>
                 <main class="container mx-auto px-4">
                     <Routes fallback=|| view! { <p class="p-4">"404 — Nie znaleziono strony"</p> }>
-                        <Route path=path!("/") view=HomePage/>
-                        <Route path=path!("/all") view=AllPage/>
-                        <Route path=path!("/today") view=TodayPage/>
-                        <Route path=path!("/time") view=TimePage/>
-                        <Route path=path!("/login") view=LoginPage/>
-                        <Route path=path!("/signup") view=SignupPage/>
-                        <Route path=path!("/settings") view=SettingsPage/>
+                        <Route path=path!("/")        view=HomePage/>
+                        <Route path=path!("/login")   view=LoginPage/>
+                        <Route path=path!("/signup")  view=SignupPage/>
                         <Route path=path!("/consent") view=OAuthConsentPage/>
-                        <Route path=path!("/calendar") view=CalendarPage/>
-                        <Route path=path!("/calendar/:date") view=CalendarDayPage/>
-                        <Route path=path!("/tags") view=TagsPage/>
-                        <Route path=path!("/tags/:id") view=TagDetailPage/>
-                        <Route path=path!("/lists/:list_id/items/:id") view=ItemDetailPage/>
-                        <Route path=path!("/lists/:id") view=ListPage/>
-                        <Route path=path!("/containers/:id") view=ContainerPage/>
+                        <ParentRoute path=path!("") view=AuthGuardLayout>
+                            <Route path=path!("/all")                       view=AllPage/>
+                            <Route path=path!("/today")                     view=TodayPage/>
+                            <Route path=path!("/time")                      view=TimePage/>
+                            <Route path=path!("/settings")                  view=SettingsPage/>
+                            <Route path=path!("/calendar")                  view=CalendarPage/>
+                            <Route path=path!("/calendar/:date")            view=CalendarDayPage/>
+                            <Route path=path!("/tags")                      view=TagsPage/>
+                            <Route path=path!("/tags/:id")                  view=TagDetailPage/>
+                            <Route path=path!("/lists/:list_id/items/:id")  view=ItemDetailPage/>
+                            <Route path=path!("/lists/:id")                 view=ListPage/>
+                            <Route path=path!("/containers/:id")            view=ContainerPage/>
+                        </ParentRoute>
                     </Routes>
                 </main>
             </Router>

--- a/crates/frontend/src/components/common/mod.rs
+++ b/crates/frontend/src/components/common/mod.rs
@@ -4,3 +4,4 @@ pub mod dnd;
 pub mod editable_text;
 pub mod list_filter_chips;
 pub mod loading;
+pub mod require_auth;

--- a/crates/frontend/src/components/common/require_auth.rs
+++ b/crates/frontend/src/components/common/require_auth.rs
@@ -19,10 +19,30 @@ pub fn RequireAuth(children: ChildrenFn) -> impl IntoView {
             format!("{}{}", p, s)
         }
     };
-    let check = Resource::new(full_path, require_auth);
+    let check = Resource::new(
+        || (),
+        move |_| {
+            let path = full_path();
+            require_auth(path)
+        },
+    );
     view! {
         <Suspense fallback=|| view! { <LoadingSpinner/> }>
-            {move || check.get().and_then(|r| r.ok()).map(|_| children())}
+            {move || match check.get() {
+                None => ().into_any(),
+                Some(Ok(_)) => children().into_any(),
+                Some(Err(_)) => {
+                    #[cfg(target_arch = "wasm32")]
+                    {
+                        let path = full_path();
+                        let encoded = urlencoding::encode(&path);
+                        if let Some(win) = web_sys::window() {
+                            let _ = win.location().set_href(&format!("/login?return_to={}", encoded));
+                        }
+                    }
+                    view! { <LoadingSpinner/> }.into_any()
+                }
+            }}
         </Suspense>
     }
 }

--- a/crates/frontend/src/components/common/require_auth.rs
+++ b/crates/frontend/src/components/common/require_auth.rs
@@ -10,9 +10,11 @@ use crate::server_fns::auth::require_auth;
 #[component]
 pub fn RequireAuth(children: ChildrenFn) -> impl IntoView {
     let location = use_location();
+    let pathname = location.pathname;
+    let search = location.search;
     let full_path = move || {
-        let p = location.pathname.get();
-        let s = location.search.get();
+        let p = pathname.get();
+        let s = search.get();
         if s.is_empty() {
             p
         } else {

--- a/crates/frontend/src/components/common/require_auth.rs
+++ b/crates/frontend/src/components/common/require_auth.rs
@@ -1,0 +1,28 @@
+use leptos::prelude::*;
+use leptos_router::hooks::use_location;
+
+use crate::components::common::loading::LoadingSpinner;
+use crate::server_fns::auth::require_auth;
+
+/// Wraps protected routes. During SSR: if not authenticated, `require_auth` sets
+/// the Location header and redirects before HTML is sent. After hydration: the
+/// resource re-runs; unauthenticated users see a spinner until the redirect fires.
+#[component]
+pub fn RequireAuth(children: ChildrenFn) -> impl IntoView {
+    let location = use_location();
+    let full_path = move || {
+        let p = location.pathname.get();
+        let s = location.search.get();
+        if s.is_empty() {
+            p
+        } else {
+            format!("{}{}", p, s)
+        }
+    };
+    let check = Resource::new(full_path, require_auth);
+    view! {
+        <Suspense fallback=|| view! { <LoadingSpinner/> }>
+            {move || check.get().and_then(|r| r.ok()).map(|_| children())}
+        </Suspense>
+    }
+}

--- a/crates/frontend/src/components/nav.rs
+++ b/crates/frontend/src/components/nav.rs
@@ -16,16 +16,16 @@ pub fn Nav() -> impl IntoView {
                 <Suspense>
                     {move || match nav.get().and_then(|r| r.ok()) {
                         Some(name) => view! {
-                            <a href="/today" class="btn btn-ghost btn-sm">"Dziś"</a>
-                            <a href="/calendar" class="btn btn-ghost btn-sm">"Terminarz"</a>
-                            <a href="/tags" class="btn btn-ghost btn-sm" data-testid="nav-tags">"Tagi"</a>
-                            <a href="/all" class="btn btn-ghost btn-sm">"Wszystkie"</a>
+                            <a href="/today" class="btn btn-ghost btn-sm">{move_tr!("nav-today")}</a>
+                            <a href="/calendar" class="btn btn-ghost btn-sm">{move_tr!("nav-calendar")}</a>
+                            <a href="/tags" class="btn btn-ghost btn-sm" data-testid="nav-tags">{move_tr!("nav-tags")}</a>
+                            <a href="/all" class="btn btn-ghost btn-sm">{move_tr!("nav-all")}</a>
                             <div class="dropdown dropdown-end">
                                 <div tabindex="0" role="button" class="btn btn-ghost btn-sm">
                                     {name} " ▾"
                                 </div>
                                 <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-50 w-52 p-2 shadow-lg border border-base-300">
-                                    <li><a href="/settings">"⚙ Ustawienia"</a></li>
+                                    <li><a href="/settings">"⚙ " {move_tr!("nav-settings")}</a></li>
                                     <li>
                                         <button
                                             type="button"
@@ -35,7 +35,7 @@ pub fn Nav() -> impl IntoView {
                                                 });
                                             }
                                         >
-                                            "⏻ Wyloguj"
+                                            "⏻ " {move_tr!("nav-logout")}
                                         </button>
                                     </li>
                                 </ul>

--- a/crates/frontend/src/components/nav.rs
+++ b/crates/frontend/src/components/nav.rs
@@ -1,4 +1,5 @@
 use leptos::prelude::*;
+use leptos_fluent::move_tr;
 
 use crate::server_fns::auth::{do_logout, get_nav_data};
 
@@ -12,13 +13,13 @@ pub fn Nav() -> impl IntoView {
                 <a href="/" class="btn btn-ghost text-xl">"Kartoteka"</a>
             </div>
             <div class="navbar-end">
-                <a href="/today" class="btn btn-ghost btn-sm">"Dziś"</a>
-                <a href="/calendar" class="btn btn-ghost btn-sm">"Terminarz"</a>
-                <a href="/tags" class="btn btn-ghost btn-sm" data-testid="nav-tags">"Tagi"</a>
-                <a href="/all" class="btn btn-ghost btn-sm">"Wszystkie"</a>
                 <Suspense>
-                    {move || nav.get().and_then(|r| r.ok()).map(|name| {
-                        view! {
+                    {move || match nav.get().and_then(|r| r.ok()) {
+                        Some(name) => view! {
+                            <a href="/today" class="btn btn-ghost btn-sm">"Dziś"</a>
+                            <a href="/calendar" class="btn btn-ghost btn-sm">"Terminarz"</a>
+                            <a href="/tags" class="btn btn-ghost btn-sm" data-testid="nav-tags">"Tagi"</a>
+                            <a href="/all" class="btn btn-ghost btn-sm">"Wszystkie"</a>
                             <div class="dropdown dropdown-end">
                                 <div tabindex="0" role="button" class="btn btn-ghost btn-sm">
                                     {name} " ▾"
@@ -39,8 +40,13 @@ pub fn Nav() -> impl IntoView {
                                     </li>
                                 </ul>
                             </div>
-                        }
-                    })}
+                        }.into_any(),
+                        None => view! {
+                            <a href="/login" class="btn btn-primary btn-sm">
+                                {move_tr!("nav-login")}
+                            </a>
+                        }.into_any(),
+                    }}
                 </Suspense>
             </div>
         </nav>

--- a/crates/frontend/src/pages/home.rs
+++ b/crates/frontend/src/pages/home.rs
@@ -12,6 +12,8 @@ use crate::components::home::{
 use crate::components::lists::create_entity_input::CreateEntityInput;
 use crate::components::tags::tag_badge::TagBadge;
 use crate::context::GlobalRefresh;
+use crate::pages::landing::LandingPage;
+use crate::server_fns::auth::get_auth_status;
 use crate::server_fns::{
     containers::{create_container, delete_container, toggle_container_pin},
     home::{get_archived_lists, get_home_data},
@@ -21,6 +23,19 @@ use crate::server_fns::{
 
 #[component]
 pub fn HomePage() -> impl IntoView {
+    let auth = Resource::new(|| (), |_| get_auth_status());
+    view! {
+        <Suspense fallback=|| view! { <LoadingSpinner/> }>
+            {move || auth.get().map(|r| match r {
+                Ok(true) => view! { <HomeContent/> }.into_any(),
+                _ => view! { <LandingPage/> }.into_any(),
+            })}
+        </Suspense>
+    }
+}
+
+#[component]
+fn HomeContent() -> impl IntoView {
     let toast = use_context::<ToastContext>().expect("ToastContext missing");
 
     // Refresh trigger — incrementing causes all Resources to refetch

--- a/crates/frontend/src/pages/home.rs
+++ b/crates/frontend/src/pages/home.rs
@@ -28,7 +28,12 @@ pub fn HomePage() -> impl IntoView {
         <Suspense fallback=|| view! { <LoadingSpinner/> }>
             {move || auth.get().map(|r| match r {
                 Ok(true) => view! { <HomeContent/> }.into_any(),
-                _ => view! { <LandingPage/> }.into_any(),
+                Ok(false) => view! { <LandingPage/> }.into_any(),
+                Err(_) => view! {
+                    <div class="flex min-h-[70vh] items-center justify-center">
+                        <p class="text-base-content/70">"Błąd połączenia. "<a href="/" class="link">"Odśwież stronę."</a></p>
+                    </div>
+                }.into_any(),
             })}
         </Suspense>
     }

--- a/crates/frontend/src/pages/home.rs
+++ b/crates/frontend/src/pages/home.rs
@@ -1,5 +1,6 @@
 use kartoteka_shared::types::{CreateContainerRequest, CreateListRequest};
 use leptos::prelude::*;
+use leptos_fluent::{I18n, move_tr};
 
 use crate::app::{ToastContext, ToastKind};
 use crate::components::common::{
@@ -41,6 +42,7 @@ pub fn HomePage() -> impl IntoView {
 
 #[component]
 fn HomeContent() -> impl IntoView {
+    let i18n = expect_context::<I18n>();
     let toast = use_context::<ToastContext>().expect("ToastContext missing");
 
     // Refresh trigger — incrementing causes all Resources to refetch
@@ -89,12 +91,13 @@ fn HomeContent() -> impl IntoView {
     });
 
     let on_delete_list_confirmed = Callback::new(move |list_id: String| {
+        let msg = i18n.tr("home-list-deleted");
         leptos::task::spawn_local(async move {
             match delete_list(list_id).await {
                 Ok(_) => {
                     pending_delete.set(None);
                     set_refresh.update(|n| *n += 1);
-                    toast.push("Lista usunięta.".to_string(), ToastKind::Success);
+                    toast.push(msg, ToastKind::Success);
                 }
                 Err(e) => toast.push(e.to_string(), ToastKind::Error),
             }
@@ -102,11 +105,12 @@ fn HomeContent() -> impl IntoView {
     });
 
     let on_delete_container = Callback::new(move |container_id: String| {
+        let msg = i18n.tr("home-container-deleted");
         leptos::task::spawn_local(async move {
             match delete_container(container_id).await {
                 Ok(_) => {
                     set_refresh.update(|n| *n += 1);
-                    toast.push("Folder usunięty.".to_string(), ToastKind::Success);
+                    toast.push(msg, ToastKind::Success);
                 }
                 Err(e) => toast.push(e.to_string(), ToastKind::Error),
             }
@@ -143,11 +147,12 @@ fn HomeContent() -> impl IntoView {
     });
 
     let on_restore_list = Callback::new(move |list_id: String| {
+        let msg = i18n.tr("home-list-restored");
         leptos::task::spawn_local(async move {
             match archive_list(list_id).await {
                 Ok(_) => {
                     set_refresh.update(|n| *n += 1);
-                    toast.push("Lista przywrócona.".to_string(), ToastKind::Success);
+                    toast.push(msg, ToastKind::Success);
                 }
                 Err(e) => toast.push(e.to_string(), ToastKind::Error),
             }
@@ -156,16 +161,16 @@ fn HomeContent() -> impl IntoView {
 
     view! {
         <div class="container mx-auto max-w-2xl p-4">
-            <h2 class="text-2xl font-bold mb-4">"Strona główna"</h2>
+            <h2 class="text-2xl font-bold mb-4">{move_tr!("home-heading")}</h2>
 
             {move || pending_delete.get().map(|(lid, lname)| {
                 let lid_confirm = lid.clone();
                 view! {
                     <ConfirmModal
                         open=Signal::derive(move || pending_delete.get().is_some())
-                        title="Usuń listę".to_string()
-                        message=format!("Czy na pewno chcesz usunąć listę \"{}\"?", lname)
-                        confirm_label="Usuń".to_string()
+                        title=i18n.tr("home-delete-list-title")
+                        message=i18n.tr("home-delete-list-confirm").replace("{ $name }", &lname)
+                        confirm_label=i18n.tr("common-delete")
                         variant=ConfirmVariant::Danger
                         on_close=Callback::new(move |_| pending_delete.set(None))
                         on_confirm=Callback::new(move |_| {
@@ -287,7 +292,7 @@ fn HomeContent() -> impl IntoView {
                             <div class="collapse collapse-arrow bg-base-200 mt-6">
                                 <input type="checkbox" />
                                 <div class="collapse-title font-semibold">
-                                    "📦 Zarchiwizowane (" {count} ")"
+                                    {move_tr!("home-archive", { "count" => count })}
                                 </div>
                                 <div class="collapse-content">
                                     <div class="flex flex-col gap-2 pt-2">
@@ -303,7 +308,7 @@ fn HomeContent() -> impl IntoView {
                                                         class="btn btn-ghost btn-sm"
                                                         on:click=move |_| on_restore_list.run(lid.clone())
                                                     >
-                                                        "Przywróć"
+                                                        {move_tr!("home-restore-button")}
                                                     </button>
                                                 </div>
                                             }

--- a/crates/frontend/src/pages/landing.rs
+++ b/crates/frontend/src/pages/landing.rs
@@ -1,0 +1,16 @@
+use leptos::prelude::*;
+use leptos_fluent::move_tr;
+
+#[component]
+pub fn LandingPage() -> impl IntoView {
+    view! {
+        <div class="flex min-h-[70vh] flex-col items-center justify-center gap-6 text-center px-4">
+            <h1 class="text-4xl font-bold">{move_tr!("app-title")}</h1>
+            <p class="text-lg text-base-content/70 max-w-sm">{move_tr!("landing-tagline")}</p>
+            <div class="flex gap-3">
+                <a href="/login" class="btn btn-primary">{move_tr!("nav-login")}</a>
+                <a href="/signup" class="btn btn-ghost">{move_tr!("auth-login-create-account")}</a>
+            </div>
+        </div>
+    }
+}

--- a/crates/frontend/src/pages/mod.rs
+++ b/crates/frontend/src/pages/mod.rs
@@ -3,6 +3,7 @@ pub mod calendar;
 pub mod container;
 pub mod home;
 pub mod item_detail;
+pub mod landing;
 pub mod list;
 pub mod login;
 pub mod oauth_consent;

--- a/crates/frontend/src/server_fns/auth.rs
+++ b/crates/frontend/src/server_fns/auth.rs
@@ -201,7 +201,11 @@ pub async fn require_auth(return_to: String) -> Result<(), ServerFnError> {
         .await
         .map_err(|_| ServerFnError::new("auth extraction failed".to_string()))?;
     if auth.user.is_none() {
-        let safe = if return_to.starts_with('/') && !return_to.starts_with("//") {
+        let safe = if return_to.starts_with('/')
+            && !return_to.starts_with("//")
+            && !return_to.contains('\\')
+            && !return_to.contains(['\r', '\n', '\t'])
+        {
             return_to
         } else {
             "/".to_string()

--- a/crates/frontend/src/server_fns/auth.rs
+++ b/crates/frontend/src/server_fns/auth.rs
@@ -12,6 +12,7 @@ use {
     },
     sqlx::SqlitePool,
     tower_sessions::Session,
+    urlencoding,
 };
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -180,5 +181,33 @@ pub async fn do_register(
         .map_err(|e| ServerFnError::new(e.to_string()))?;
 
     leptos_axum::redirect("/login");
+    Ok(())
+}
+
+/// Returns true if the current session has an authenticated user.
+#[server(prefix = "/leptos")]
+pub async fn get_auth_status() -> Result<bool, ServerFnError> {
+    let auth = leptos_axum::extract::<AuthSession<KartotekaBackend>>()
+        .await
+        .map_err(|_| ServerFnError::new("auth extraction failed".to_string()))?;
+    Ok(auth.user.is_some())
+}
+
+/// Checks auth and issues a server-side redirect to /login?return_to=<path> if not
+/// authenticated. During SSR the redirect header is set before any HTML is sent.
+#[server(prefix = "/leptos")]
+pub async fn require_auth(return_to: String) -> Result<(), ServerFnError> {
+    let auth = leptos_axum::extract::<AuthSession<KartotekaBackend>>()
+        .await
+        .map_err(|_| ServerFnError::new("auth extraction failed".to_string()))?;
+    if auth.user.is_none() {
+        let safe = if return_to.starts_with('/') && !return_to.starts_with("//") {
+            return_to
+        } else {
+            "/".to_string()
+        };
+        leptos_axum::redirect(&format!("/login?return_to={}", urlencoding::encode(&safe)));
+        return Err(ServerFnError::new("unauthorized".to_string()));
+    }
     Ok(())
 }

--- a/locales/en/auth.ftl
+++ b/locales/en/auth.ftl
@@ -27,3 +27,6 @@ auth-consent-login-and-authorize = Log in and authorize
 # Error messages
 auth-error-prefix = Error: { $detail }
 auth-error-signup-failed = Registration error ({ $status })
+
+# Landing page
+landing-tagline = Your lists and tasks — always at hand.

--- a/locales/en/home.ftl
+++ b/locales/en/home.ftl
@@ -10,3 +10,6 @@ home-list-deleted = List deleted
 home-list-restored = List restored
 home-container-deleted = Container deleted
 home-restore-button = Restore
+home-heading = Home
+home-delete-list-title = Delete list
+home-delete-list-confirm = Are you sure you want to delete "{ $name }"?

--- a/locales/en/home.ftl
+++ b/locales/en/home.ftl
@@ -1,5 +1,4 @@
 home-title = Kartoteka
-landing-tagline = Your lists and tasks
 home-pinned = Pinned
 home-recent = Recently opened
 home-folders-and-projects = Folders and projects

--- a/locales/en/nav.ftl
+++ b/locales/en/nav.ftl
@@ -8,3 +8,4 @@ nav-settings = Settings
 nav-logout = Log out
 nav-login = Log in
 nav-admin = Admin
+nav-all = All

--- a/locales/pl/auth.ftl
+++ b/locales/pl/auth.ftl
@@ -27,3 +27,6 @@ auth-consent-login-and-authorize = Zaloguj i autoryzuj
 # Komunikaty błędów
 auth-error-prefix = Błąd: { $detail }
 auth-error-signup-failed = Błąd rejestracji ({ $status })
+
+# Strona startowa
+landing-tagline = Twoje listy i zadania — zawsze pod ręką.

--- a/locales/pl/home.ftl
+++ b/locales/pl/home.ftl
@@ -10,3 +10,6 @@ home-list-deleted = Lista usunięta
 home-list-restored = Lista przywrócona
 home-container-deleted = Kontener usunięty
 home-restore-button = Przywróć
+home-heading = Strona główna
+home-delete-list-title = Usuń listę
+home-delete-list-confirm = Czy na pewno chcesz usunąć listę „{ $name }"?

--- a/locales/pl/home.ftl
+++ b/locales/pl/home.ftl
@@ -1,5 +1,4 @@
 home-title = Kartoteka
-landing-tagline = Twoje listy i zadania
 home-pinned = Przypięte
 home-recent = Ostatnio otwierane
 home-folders-and-projects = Foldery i projekty

--- a/locales/pl/nav.ftl
+++ b/locales/pl/nav.ftl
@@ -8,3 +8,4 @@ nav-settings = Ustawienia
 nav-logout = Wyloguj
 nav-login = Zaloguj
 nav-admin = Admin
+nav-all = Wszystkie


### PR DESCRIPTION
## Summary

- Add minimal landing page at `/` for unauthenticated users (i18n-aware, Leptos 0.8 SSR)
- Add `RequireAuth` guard component using `ParentRoute` — server-side redirect to `/login?return_to=<path>` before HTML is sent
- Update `Nav` to show only logo + login button when unauthenticated, full nav when authenticated
- Split `HomePage` into thin auth-gate wrapper + private `HomeContent` component
- Harden `return_to` validation: reject backslash paths, add CSR redirect fallback

## Changes

- `locales/en/auth.ftl`, `locales/pl/auth.ftl` — `landing-tagline` i18n key
- `crates/frontend/src/pages/landing.rs` — new `LandingPage` component
- `crates/frontend/src/components/common/require_auth.rs` — new `RequireAuth` guard
- `crates/frontend/src/server_fns/auth.rs` — `require_auth()` + `get_auth_status()` server fns
- `crates/frontend/src/components/nav.rs` — auth-aware navbar
- `crates/frontend/src/pages/home.rs` — `HomePage` / `HomeContent` split
- `crates/frontend/src/app.rs` — `AuthGuardLayout` + `ParentRoute` routing

## Test plan

- [ ] Open `/` in incognito — landing page with tagline and login/signup buttons
- [ ] Open `/today` in incognito — redirect to `/login?return_to=%2Ftoday`, return to `/today` after login
- [ ] Log in — navbar shows Dziś / Terminarz / Tagi / Wszystkie + user dropdown
- [ ] Log out — navbar shows only logo + Zaloguj się
- [ ] `just ci` — 369 tests pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)