### PR TITLE
feat(locations): location CRUD management page with domain validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1808,7 +1808,6 @@ name = "kartoteka-i18n"
 version = "0.4.1"
 dependencies = [
  "fluent-syntax",
- "kartoteka-shared",
  "serde_json",
 ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry,sharin
     --mount=type=cache,target=/usr/local/cargo/git,id=cargo-git,sharing=locked \
     --mount=type=cache,target=/app/target,id=cargo-target,sharing=locked \
     set -eu; \
+    export CARGO_INCREMENTAL=0; \
     if [ "$CARGO_PROFILE" = "release" ]; then \
         cargo leptos build --release; \
         cp target/release/kartoteka /out-kartoteka; \

--- a/crates/domain/src/rules/tags.rs
+++ b/crates/domain/src/rules/tags.rs
@@ -80,6 +80,19 @@ pub fn validate_location_hierarchy(
     Ok(())
 }
 
+pub const LOCATION_TYPES: &[&str] = &["country", "city", "address"];
+
+pub fn validate_is_location_type(tag_type: &str) -> Result<(), DomainError> {
+    if !LOCATION_TYPES.contains(&tag_type) {
+        return Err(DomainError::Validation("invalid_location_type"));
+    }
+    Ok(())
+}
+
+pub fn serialize_address_metadata(address: &str) -> String {
+    serde_json::json!({"address": address}).to_string()
+}
+
 const MAX_ADDRESS_LEN: usize = 200;
 
 /// Validate metadata JSON for address-type tags.

--- a/crates/domain/src/rules/tags.rs
+++ b/crates/domain/src/rules/tags.rs
@@ -80,6 +80,24 @@ pub fn validate_location_hierarchy(
     Ok(())
 }
 
+const MAX_ADDRESS_LEN: usize = 200;
+
+/// Validate metadata JSON for address-type tags.
+/// Expected format: `{"address": "..."}` — address field optional, max 200 chars.
+pub fn validate_address_metadata(metadata: Option<&str>) -> Result<(), DomainError> {
+    let Some(raw) = metadata else {
+        return Ok(());
+    };
+    let parsed: serde_json::Value =
+        serde_json::from_str(raw).map_err(|_| DomainError::Validation("metadata_invalid_json"))?;
+    if let Some(addr) = parsed.get("address").and_then(|v| v.as_str()) {
+        if addr.chars().count() > MAX_ADDRESS_LEN {
+            return Err(DomainError::Validation("address_too_long"));
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -139,6 +157,34 @@ mod tests {
     }
 
     // validate_location_hierarchy
+    // validate_address_metadata
+    #[test]
+    fn address_metadata_none_ok() {
+        assert!(validate_address_metadata(None).is_ok());
+    }
+
+    #[test]
+    fn address_metadata_valid_json_ok() {
+        assert!(validate_address_metadata(Some(r#"{"address":"ul. Kowalska 1"}"#)).is_ok());
+    }
+
+    #[test]
+    fn address_metadata_empty_address_ok() {
+        assert!(validate_address_metadata(Some(r#"{"address":""}"#)).is_ok());
+    }
+
+    #[test]
+    fn address_metadata_invalid_json_rejected() {
+        assert!(validate_address_metadata(Some("not-json")).is_err());
+    }
+
+    #[test]
+    fn address_metadata_address_too_long_rejected() {
+        let long = "a".repeat(201);
+        let meta = format!(r#"{{"address":"{}"}}"#, long);
+        assert!(validate_address_metadata(Some(&meta)).is_err());
+    }
+
     #[test]
     fn generic_tag_no_restriction() {
         assert!(validate_location_hierarchy("tag", None).is_ok());

--- a/crates/domain/src/tags.rs
+++ b/crates/domain/src/tags.rs
@@ -46,6 +46,21 @@ pub struct UpdateTagRequest {
     pub metadata: Option<Option<String>>,
 }
 
+#[derive(Debug)]
+pub struct CreateLocationRequest {
+    pub tag_type: String,
+    pub name: String,
+    pub parent_tag_id: Option<String>,
+    pub address: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct UpdateLocationRequest {
+    pub name: Option<String>,
+    pub address: Option<String>,
+    pub clear_address: bool,
+}
+
 // ── Conversion ────────────────────────────────────────────────────────────────
 
 fn row_to_tag(row: db::types::TagRow) -> Tag {
@@ -251,6 +266,72 @@ pub async fn update(
 #[tracing::instrument(skip(pool))]
 pub async fn delete(pool: &SqlitePool, user_id: &str, id: &str) -> Result<bool, DomainError> {
     Ok(db::tags::delete(pool, id, user_id).await?)
+}
+
+#[tracing::instrument(skip(pool))]
+pub async fn create_location(
+    pool: &SqlitePool,
+    user_id: &str,
+    req: &CreateLocationRequest,
+) -> Result<Tag, DomainError> {
+    rules::tags::validate_is_location_type(&req.tag_type)?;
+    let metadata = (req.tag_type == "address")
+        .then(|| {
+            req.address
+                .as_deref()
+                .filter(|a| !a.trim().is_empty())
+                .map(rules::tags::serialize_address_metadata)
+        })
+        .flatten();
+    create(
+        pool,
+        user_id,
+        &CreateTagRequest {
+            name: req.name.clone(),
+            icon: None,
+            color: None,
+            parent_tag_id: req.parent_tag_id.clone(),
+            tag_type: Some(req.tag_type.clone()),
+            metadata,
+        },
+    )
+    .await
+}
+
+#[tracing::instrument(skip(pool))]
+pub async fn update_location(
+    pool: &SqlitePool,
+    user_id: &str,
+    id: &str,
+    req: &UpdateLocationRequest,
+) -> Result<Option<Tag>, DomainError> {
+    let current = match db::tags::get_one(pool, id, user_id).await? {
+        Some(t) => t,
+        None => return Ok(None),
+    };
+    rules::tags::validate_is_location_type(&current.tag_type)?;
+    let metadata_update = if req.clear_address {
+        Some(None)
+    } else {
+        req.address
+            .as_deref()
+            .filter(|a| !a.trim().is_empty())
+            .map(|a| Some(rules::tags::serialize_address_metadata(a)))
+    };
+    update(
+        pool,
+        user_id,
+        id,
+        &UpdateTagRequest {
+            name: req.name.clone(),
+            icon: None,
+            color: None,
+            parent_tag_id: None,
+            tag_type: None,
+            metadata: metadata_update,
+        },
+    )
+    .await
 }
 
 /// Merge `source` into `target`: reassign all links + children, then delete source.

--- a/crates/domain/src/tags.rs
+++ b/crates/domain/src/tags.rs
@@ -122,6 +122,9 @@ pub async fn create(
     // Phase 2: THINK
     let tag_type = req.tag_type.as_deref().unwrap_or("tag");
     rules::tags::validate_location_hierarchy(tag_type, parent_type.as_deref())?;
+    if tag_type == "address" {
+        rules::tags::validate_address_metadata(req.metadata.as_deref())?;
+    }
     DomainError::ensure_unique(
         db::tags::find_id_by_name_in_scope(
             pool,
@@ -195,6 +198,15 @@ pub async fn update(
                 rules::tags::validate_location_hierarchy(effective_type, parent_type.as_deref())?;
             }
         }
+    }
+
+    // Validate address metadata if the effective tag type is address
+    if effective_type == "address" {
+        let effective_meta = req
+            .metadata
+            .as_ref()
+            .map_or(current.metadata.as_deref(), |m| m.as_deref());
+        rules::tags::validate_address_metadata(effective_meta)?;
     }
 
     // Duplicate name check — use effective parent after any parent change

--- a/crates/frontend/src/app.rs
+++ b/crates/frontend/src/app.rs
@@ -15,6 +15,7 @@ use crate::pages::{
     home::HomePage,
     item_detail::ItemDetailPage,
     list::ListPage,
+    locations::LocationsPage,
     login::LoginPage,
     oauth_consent::OAuthConsentPage,
     settings::SettingsPage,
@@ -146,6 +147,7 @@ pub fn App() -> impl IntoView {
                             <Route path=path!("/calendar/:date")            view=CalendarDayPage/>
                             <Route path=path!("/tags")                      view=TagsPage/>
                             <Route path=path!("/tags/:id")                  view=TagDetailPage/>
+                            <Route path=path!("/locations")                 view=LocationsPage/>
                             <Route path=path!("/lists/:list_id/items/:id")  view=ItemDetailPage/>
                             <Route path=path!("/lists/:id")                 view=ListPage/>
                             <Route path=path!("/containers/:id")            view=ContainerPage/>

--- a/crates/frontend/src/components/nav.rs
+++ b/crates/frontend/src/components/nav.rs
@@ -19,6 +19,7 @@ pub fn Nav() -> impl IntoView {
                             <a href="/today" class="btn btn-ghost btn-sm">{move_tr!("nav-today")}</a>
                             <a href="/calendar" class="btn btn-ghost btn-sm">{move_tr!("nav-calendar")}</a>
                             <a href="/tags" class="btn btn-ghost btn-sm" data-testid="nav-tags">{move_tr!("nav-tags")}</a>
+                            <a href="/locations" class="btn btn-ghost btn-sm">{move_tr!("locations-title")}</a>
                             <a href="/all" class="btn btn-ghost btn-sm">{move_tr!("nav-all")}</a>
                             <div class="dropdown dropdown-end">
                                 <div tabindex="0" role="button" class="btn btn-ghost btn-sm">

--- a/crates/frontend/src/pages/locations/mod.rs
+++ b/crates/frontend/src/pages/locations/mod.rs
@@ -198,15 +198,20 @@ fn LocationNode(node: LocNode, depth: usize, on_refresh: Callback<()>) -> impl I
             if name.trim().is_empty() {
                 return;
             }
-            let address = if is_address {
-                Some(edit_address.get_untracked())
+            let (address, clear_address) = if is_address {
+                let addr = edit_address.get_untracked();
+                if addr.trim().is_empty() {
+                    (None, true)
+                } else {
+                    (Some(addr), false)
+                }
             } else {
-                None
+                (None, false)
             };
             set_show_edit.set(false);
             let id = tag_id.clone();
             leptos::task::spawn_local(async move {
-                match update_location_metadata(id, Some(name), address, false).await {
+                match update_location_metadata(id, Some(name), address, clear_address).await {
                     Ok(_) => on_refresh.run(()),
                     Err(e) => toast.push(e.to_string(), ToastKind::Error),
                 }
@@ -372,9 +377,9 @@ fn LocationNode(node: LocNode, depth: usize, on_refresh: Callback<()>) -> impl I
 
             <ConfirmModal
                 open=Signal::from(show_delete)
-                title="Usuń lokalizację".to_string()
+                title=i18n.tr("locations-delete-title")
                 message=i18n.tr("locations-delete-confirm")
-                confirm_label="Usuń".to_string()
+                confirm_label=i18n.tr("locations-delete-action")
                 variant=ConfirmVariant::Danger
                 on_confirm=on_delete_confirm
                 on_close=Callback::new(move |_: ()| show_delete.set(false))

--- a/crates/frontend/src/pages/locations/mod.rs
+++ b/crates/frontend/src/pages/locations/mod.rs
@@ -1,0 +1,395 @@
+use leptos::prelude::*;
+use leptos_fluent::{I18n, move_tr};
+
+use crate::app::{ToastContext, ToastKind};
+use crate::components::common::confirm_modal::{ConfirmModal, ConfirmVariant};
+use crate::components::common::loading::LoadingSpinner;
+use crate::server_fns::tags::{
+    create_location, delete_tag, get_all_tags, update_location_metadata,
+};
+use kartoteka_shared::types::Tag;
+
+const LOCATION_TYPES: &[&str] = &["country", "city", "address"];
+
+fn extract_address(tag: &Tag) -> Option<String> {
+    let meta = tag.metadata.as_deref()?;
+    let v: serde_json::Value = serde_json::from_str(meta).ok()?;
+    v.get("address")?
+        .as_str()
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+}
+
+#[derive(Clone)]
+struct LocNode {
+    tag: Tag,
+    children: Vec<LocNode>,
+}
+
+fn build_location_tree(tags: &[Tag]) -> Vec<LocNode> {
+    fn collect(tags: &[Tag], parent_id: Option<&str>) -> Vec<LocNode> {
+        tags.iter()
+            .filter(|t| {
+                LOCATION_TYPES.contains(&t.tag_type.as_str())
+                    && t.parent_tag_id.as_deref() == parent_id
+            })
+            .map(|t| LocNode {
+                tag: t.clone(),
+                children: collect(tags, Some(&t.id)),
+            })
+            .collect()
+    }
+    collect(tags, None)
+}
+
+#[component]
+pub fn LocationsPage() -> impl IntoView {
+    let toast = use_context::<ToastContext>().expect("ToastContext missing");
+    let (refresh, set_refresh) = signal(0u32);
+    let tags_res = Resource::new(move || refresh.get(), |_| get_all_tags());
+
+    let (new_country, set_new_country) = signal(String::new());
+
+    let on_add_country = Callback::new(move |_: ()| {
+        let name = new_country.get_untracked();
+        if name.trim().is_empty() {
+            return;
+        }
+        set_new_country.set(String::new());
+        leptos::task::spawn_local(async move {
+            match create_location("country".into(), name, None, None).await {
+                Ok(_) => set_refresh.update(|n| *n += 1),
+                Err(e) => toast.push(e.to_string(), ToastKind::Error),
+            }
+        });
+    });
+
+    view! {
+        <div class="container mx-auto max-w-2xl p-4">
+            <h2 class="text-2xl font-bold mb-4">{move_tr!("locations-title")}</h2>
+
+            <div class="flex gap-2 mb-6">
+                <input
+                    type="text"
+                    class="input input-bordered flex-1"
+                    prop:placeholder=move_tr!("locations-country-placeholder")
+                    prop:value=move || new_country.get()
+                    on:input=move |ev| set_new_country.set(event_target_value(&ev))
+                    on:keydown=move |ev| {
+                        if ev.key() == "Enter" {
+                            on_add_country.run(());
+                        }
+                    }
+                />
+                <button
+                    type="button"
+                    class="btn btn-primary"
+                    on:click=move |_| on_add_country.run(())
+                >
+                    {move_tr!("locations-add-country")}
+                </button>
+            </div>
+
+            <Suspense fallback=|| view! { <LoadingSpinner/> }>
+                {move || {
+                    tags_res
+                        .get()
+                        .map(|result| match result {
+                            Err(e) => {
+                                view! { <p class="text-error">"Błąd: " {e.to_string()}</p> }
+                                    .into_any()
+                            }
+                            Ok(tags) => {
+                                let tree = build_location_tree(&tags);
+                                if tree.is_empty() {
+                                    return view! {
+                                        <div class="text-center text-base-content/50 py-8">
+                                            {move_tr!("locations-empty")}
+                                        </div>
+                                    }
+                                        .into_any();
+                                }
+                                view! {
+                                    <div class="flex flex-col gap-1">
+                                        {tree
+                                            .into_iter()
+                                            .map(|node| {
+                                                view! {
+                                                    <LocationNode
+                                                        node=node
+                                                        depth=0
+                                                        on_refresh=Callback::new(move |_: ()| {
+                                                            set_refresh.update(|n| *n += 1)
+                                                        })
+                                                    />
+                                                }
+                                            })
+                                            .collect::<Vec<_>>()}
+                                    </div>
+                                }
+                                    .into_any()
+                            }
+                        })
+                }}
+            </Suspense>
+        </div>
+    }
+}
+
+#[component]
+fn LocationNode(node: LocNode, depth: usize, on_refresh: Callback<()>) -> impl IntoView {
+    let toast = use_context::<ToastContext>().expect("ToastContext missing");
+    let i18n = expect_context::<I18n>();
+    let tag = node.tag.clone();
+    let tag_id = tag.id.clone();
+    let tag_type = tag.tag_type.clone();
+
+    let (show_add_child, set_show_add_child) = signal(false);
+    let (show_edit, set_show_edit) = signal(false);
+    let show_delete = RwSignal::new(false);
+    let (child_name, set_child_name) = signal(String::new());
+    let (child_address, set_child_address) = signal(String::new());
+    let (edit_name, set_edit_name) = signal(tag.name.clone());
+    let (edit_address, set_edit_address) = signal(extract_address(&tag).unwrap_or_default());
+
+    let child_type: Option<&'static str> = match tag_type.as_str() {
+        "country" => Some("city"),
+        "city" => Some("address"),
+        _ => None,
+    };
+
+    let indent_class = match depth {
+        0 => "",
+        1 => "ml-4",
+        _ => "ml-8",
+    };
+
+    let on_add_child = {
+        let tag_id = tag_id.clone();
+        Callback::new(move |_: ()| {
+            let Some(ct) = child_type else { return };
+            let name = child_name.get_untracked();
+            if name.trim().is_empty() {
+                return;
+            }
+            let address = if ct == "address" {
+                Some(child_address.get_untracked())
+            } else {
+                None
+            };
+            set_child_name.set(String::new());
+            set_child_address.set(String::new());
+            set_show_add_child.set(false);
+            let parent_id = tag_id.clone();
+            leptos::task::spawn_local(async move {
+                match create_location(ct.to_string(), name, Some(parent_id), address).await {
+                    Ok(_) => on_refresh.run(()),
+                    Err(e) => toast.push(e.to_string(), ToastKind::Error),
+                }
+            });
+        })
+    };
+
+    let on_save_edit = {
+        let tag_id = tag_id.clone();
+        let is_address = tag_type == "address";
+        Callback::new(move |_: ()| {
+            let name = edit_name.get_untracked();
+            if name.trim().is_empty() {
+                return;
+            }
+            let address = if is_address {
+                Some(edit_address.get_untracked())
+            } else {
+                None
+            };
+            set_show_edit.set(false);
+            let id = tag_id.clone();
+            leptos::task::spawn_local(async move {
+                match update_location_metadata(id, Some(name), address, false).await {
+                    Ok(_) => on_refresh.run(()),
+                    Err(e) => toast.push(e.to_string(), ToastKind::Error),
+                }
+            });
+        })
+    };
+
+    let on_delete_confirm = {
+        let tag_id = tag_id.clone();
+        Callback::new(move |_: ()| {
+            show_delete.set(false);
+            let id = tag_id.clone();
+            leptos::task::spawn_local(async move {
+                match delete_tag(id).await {
+                    Ok(_) => on_refresh.run(()),
+                    Err(e) => toast.push(e.to_string(), ToastKind::Error),
+                }
+            });
+        })
+    };
+
+    let formal_address = extract_address(&tag);
+    let display_name = tag.name.clone();
+    let is_address_type = tag_type == "address";
+
+    view! {
+        <div class=format!("card bg-base-200 p-2 mb-1 {}", indent_class)>
+            {move || {
+                if show_edit.get() {
+                    view! {
+                        <div class="flex gap-2 items-center flex-wrap">
+                            <input
+                                type="text"
+                                class="input input-bordered input-sm flex-1 min-w-32"
+                                prop:value=move || edit_name.get()
+                                on:input=move |ev| set_edit_name.set(event_target_value(&ev))
+                            />
+                            {if is_address_type {
+                                view! {
+                                    <input
+                                        type="text"
+                                        class="input input-bordered input-sm flex-1 min-w-32"
+                                        prop:placeholder=move_tr!(
+                                            "locations-formal-address-placeholder"
+                                        )
+                                        prop:value=move || edit_address.get()
+                                        on:input=move |ev| {
+                                            set_edit_address.set(event_target_value(&ev))
+                                        }
+                                    />
+                                }
+                                    .into_any()
+                            } else {
+                                view! {}.into_any()
+                            }}
+                            <button
+                                class="btn btn-sm btn-primary"
+                                on:click=move |_| on_save_edit.run(())
+                            >
+                                {move_tr!("locations-save")}
+                            </button>
+                            <button
+                                class="btn btn-sm btn-ghost"
+                                on:click=move |_| set_show_edit.set(false)
+                            >
+                                {move_tr!("locations-cancel")}
+                            </button>
+                        </div>
+                    }
+                        .into_any()
+                } else {
+                    view! {
+                        <div class="flex gap-2 items-center">
+                            <span class="flex-1 font-medium">{display_name.clone()}</span>
+                            {formal_address
+                                .as_ref()
+                                .map(|a| {
+                                    view! {
+                                        <span class="text-sm text-base-content/60">{a.clone()}</span>
+                                    }
+                                })}
+                            {if child_type.is_some() {
+                                view! {
+                                    <button
+                                        class="btn btn-xs btn-ghost"
+                                        on:click=move |_| {
+                                            set_show_add_child.update(|v| *v = !*v)
+                                        }
+                                    >
+                                        "+"
+                                    </button>
+                                }
+                                    .into_any()
+                            } else {
+                                view! {}.into_any()
+                            }}
+                            <button
+                                class="btn btn-xs btn-ghost"
+                                on:click=move |_| set_show_edit.set(true)
+                            >
+                                "✎"
+                            </button>
+                            <button
+                                class="btn btn-xs btn-ghost text-error"
+                                on:click=move |_| show_delete.set(true)
+                            >
+                                "✕"
+                            </button>
+                        </div>
+                    }
+                        .into_any()
+                }
+            }}
+
+            <Show when=move || show_add_child.get()>
+                <div class="flex gap-2 mt-2 ml-4 flex-wrap">
+                    <input
+                        type="text"
+                        class="input input-bordered input-sm flex-1 min-w-32"
+                        prop:placeholder=move || match child_type {
+                            Some("city") => i18n.tr("locations-city-placeholder"),
+                            _ => i18n.tr("locations-alias-placeholder"),
+                        }
+                        prop:value=move || child_name.get()
+                        on:input=move |ev| set_child_name.set(event_target_value(&ev))
+                        on:keydown=move |ev| {
+                            if ev.key() == "Enter" {
+                                on_add_child.run(());
+                            }
+                        }
+                    />
+                    {if child_type == Some("address") {
+                        view! {
+                            <input
+                                type="text"
+                                class="input input-bordered input-sm flex-1 min-w-32"
+                                prop:placeholder=move_tr!("locations-formal-address-placeholder")
+                                prop:value=move || child_address.get()
+                                on:input=move |ev| set_child_address.set(event_target_value(&ev))
+                            />
+                        }
+                            .into_any()
+                    } else {
+                        view! {}.into_any()
+                    }}
+                    <button
+                        class="btn btn-sm btn-primary"
+                        on:click=move |_| on_add_child.run(())
+                    >
+                        {move || match child_type {
+                            Some("city") => i18n.tr("locations-add-city"),
+                            _ => i18n.tr("locations-add-address"),
+                        }}
+                    </button>
+                    <button
+                        class="btn btn-sm btn-ghost"
+                        on:click=move |_| set_show_add_child.set(false)
+                    >
+                        {move_tr!("locations-cancel")}
+                    </button>
+                </div>
+            </Show>
+
+            <ConfirmModal
+                open=Signal::from(show_delete)
+                title="Usuń lokalizację".to_string()
+                message=i18n.tr("locations-delete-confirm")
+                confirm_label="Usuń".to_string()
+                variant=ConfirmVariant::Danger
+                on_confirm=on_delete_confirm
+                on_close=Callback::new(move |_: ()| show_delete.set(false))
+            />
+
+            {node
+                .children
+                .into_iter()
+                .map(|child| {
+                    view! {
+                        <LocationNode node=child depth=depth + 1 on_refresh=on_refresh/>
+                    }
+                })
+                .collect_view()}
+        </div>
+    }
+    .into_any()
+}

--- a/crates/frontend/src/pages/locations/mod.rs
+++ b/crates/frontend/src/pages/locations/mod.rs
@@ -96,7 +96,7 @@ pub fn LocationsPage() -> impl IntoView {
                         .get()
                         .map(|result| match result {
                             Err(e) => {
-                                view! { <p class="text-error">"Błąd: " {e.to_string()}</p> }
+                                view! { <p class="text-error">{move_tr!("locations-load-error", {"detail" => e.to_string()})}</p> }
                                     .into_any()
                             }
                             Ok(tags) => {
@@ -157,6 +157,15 @@ fn LocationNode(node: LocNode, depth: usize, on_refresh: Callback<()>) -> impl I
         "city" => Some("address"),
         _ => None,
     };
+
+    let child_placeholder = i18n.tr(match child_type {
+        Some("city") => "locations-city-placeholder",
+        _ => "locations-alias-placeholder",
+    });
+    let add_child_label = i18n.tr(match child_type {
+        Some("city") => "locations-add-city",
+        _ => "locations-add-address",
+    });
 
     let indent_class = match depth {
         0 => "",
@@ -331,10 +340,7 @@ fn LocationNode(node: LocNode, depth: usize, on_refresh: Callback<()>) -> impl I
                     <input
                         type="text"
                         class="input input-bordered input-sm flex-1 min-w-32"
-                        prop:placeholder=move || match child_type {
-                            Some("city") => i18n.tr("locations-city-placeholder"),
-                            _ => i18n.tr("locations-alias-placeholder"),
-                        }
+                        prop:placeholder=child_placeholder.clone()
                         prop:value=move || child_name.get()
                         on:input=move |ev| set_child_name.set(event_target_value(&ev))
                         on:keydown=move |ev| {
@@ -361,10 +367,7 @@ fn LocationNode(node: LocNode, depth: usize, on_refresh: Callback<()>) -> impl I
                         class="btn btn-sm btn-primary"
                         on:click=move |_| on_add_child.run(())
                     >
-                        {move || match child_type {
-                            Some("city") => i18n.tr("locations-add-city"),
-                            _ => i18n.tr("locations-add-address"),
-                        }}
+                        {add_child_label.clone()}
                     </button>
                     <button
                         class="btn btn-sm btn-ghost"
@@ -379,7 +382,7 @@ fn LocationNode(node: LocNode, depth: usize, on_refresh: Callback<()>) -> impl I
                 open=Signal::from(show_delete)
                 title=i18n.tr("locations-delete-title")
                 message=i18n.tr("locations-delete-confirm")
-                confirm_label=i18n.tr("locations-delete-action")
+                confirm_label=i18n.tr("common-delete")
                 variant=ConfirmVariant::Danger
                 on_confirm=on_delete_confirm
                 on_close=Callback::new(move |_: ()| show_delete.set(false))

--- a/crates/frontend/src/pages/mod.rs
+++ b/crates/frontend/src/pages/mod.rs
@@ -5,6 +5,7 @@ pub mod home;
 pub mod item_detail;
 pub mod landing;
 pub mod list;
+pub mod locations;
 pub mod login;
 pub mod oauth_consent;
 pub mod settings;

--- a/crates/frontend/src/server_fns/tags.rs
+++ b/crates/frontend/src/server_fns/tags.rs
@@ -361,7 +361,7 @@ pub async fn create_location(
     let metadata = address
         .as_deref()
         .filter(|a| !a.trim().is_empty())
-        .map(|a| format!(r#"{{"address":"{}"}}"#, a.replace('"', "\\\"")));
+        .map(|a| serde_json::json!({"address": a}).to_string());
 
     let tag = domain::tags::create(
         &pool,
@@ -402,7 +402,7 @@ pub async fn update_location_metadata(
         address
             .as_deref()
             .filter(|a| !a.trim().is_empty())
-            .map(|a| Some(format!(r#"{{"address":"{}"}}"#, a.replace('"', "\\\""))))
+            .map(|a| Some(serde_json::json!({"address": a}).to_string()))
     };
 
     let tag = domain::tags::update(

--- a/crates/frontend/src/server_fns/tags.rs
+++ b/crates/frontend/src/server_fns/tags.rs
@@ -340,6 +340,90 @@ pub async fn update_tag_color(id: String, color: String) -> Result<Tag, ServerFn
     Ok(domain_tag_to_shared(tag))
 }
 
+/// Create a location tag (country / city / address).
+/// `tag_type` must be one of "country", "city", "address".
+/// For address tags, `address` is stored as `{"address": "..."}` in metadata.
+#[server(prefix = "/leptos")]
+pub async fn create_location(
+    tag_type: String,
+    name: String,
+    parent_tag_id: Option<String>,
+    address: Option<String>,
+) -> Result<Tag, ServerFnError> {
+    let pool = expect_context::<SqlitePool>();
+    let auth = leptos_axum::extract::<AuthSession<KartotekaBackend>>()
+        .await
+        .map_err(|_| ServerFnError::new("auth extraction failed".to_string()))?;
+    let user = auth
+        .user
+        .ok_or_else(|| ServerFnError::new("unauthorized".to_string()))?;
+
+    let metadata = address
+        .as_deref()
+        .filter(|a| !a.trim().is_empty())
+        .map(|a| format!(r#"{{"address":"{}"}}"#, a.replace('"', "\\\"")));
+
+    let tag = domain::tags::create(
+        &pool,
+        &user.id,
+        &domain::tags::CreateTagRequest {
+            name,
+            icon: None,
+            color: None,
+            parent_tag_id,
+            tag_type: Some(tag_type),
+            metadata,
+        },
+    )
+    .await
+    .map_err(|e| ServerFnError::new(e.to_string()))?;
+    Ok(domain_tag_to_shared(tag))
+}
+
+/// Update a location tag's alias (name) and/or formal address (metadata).
+#[server(prefix = "/leptos")]
+pub async fn update_location_metadata(
+    id: String,
+    name: Option<String>,
+    address: Option<String>,
+    clear_address: bool,
+) -> Result<Tag, ServerFnError> {
+    let pool = expect_context::<SqlitePool>();
+    let auth = leptos_axum::extract::<AuthSession<KartotekaBackend>>()
+        .await
+        .map_err(|_| ServerFnError::new("auth extraction failed".to_string()))?;
+    let user = auth
+        .user
+        .ok_or_else(|| ServerFnError::new("unauthorized".to_string()))?;
+
+    let metadata_update = if clear_address {
+        Some(None)
+    } else {
+        address
+            .as_deref()
+            .filter(|a| !a.trim().is_empty())
+            .map(|a| Some(format!(r#"{{"address":"{}"}}"#, a.replace('"', "\\\""))))
+    };
+
+    let tag = domain::tags::update(
+        &pool,
+        &user.id,
+        &id,
+        &domain::tags::UpdateTagRequest {
+            name,
+            icon: None,
+            color: None,
+            parent_tag_id: None,
+            tag_type: None,
+            metadata: metadata_update,
+        },
+    )
+    .await
+    .map_err(|e| ServerFnError::new(e.to_string()))?
+    .ok_or_else(|| ServerFnError::new("location not found".to_string()))?;
+    Ok(domain_tag_to_shared(tag))
+}
+
 /// Delete a tag by id.
 #[server(prefix = "/leptos")]
 pub async fn delete_tag(id: String) -> Result<(), ServerFnError> {

--- a/crates/frontend/src/server_fns/tags.rs
+++ b/crates/frontend/src/server_fns/tags.rs
@@ -342,7 +342,6 @@ pub async fn update_tag_color(id: String, color: String) -> Result<Tag, ServerFn
 
 /// Create a location tag (country / city / address).
 /// `tag_type` must be one of "country", "city", "address".
-/// For address tags, `address` is stored as `{"address": "..."}` in metadata.
 #[server(prefix = "/leptos")]
 pub async fn create_location(
     tag_type: String,
@@ -351,28 +350,19 @@ pub async fn create_location(
     address: Option<String>,
 ) -> Result<Tag, ServerFnError> {
     let pool = expect_context::<SqlitePool>();
-    let auth = leptos_axum::extract::<AuthSession<KartotekaBackend>>()
+    let user = leptos_axum::extract::<AuthSession<KartotekaBackend>>()
         .await
-        .map_err(|_| ServerFnError::new("auth extraction failed".to_string()))?;
-    let user = auth
+        .map_err(|_| ServerFnError::new("auth extraction failed".to_string()))?
         .user
         .ok_or_else(|| ServerFnError::new("unauthorized".to_string()))?;
-
-    let metadata = address
-        .as_deref()
-        .filter(|a| !a.trim().is_empty())
-        .map(|a| serde_json::json!({"address": a}).to_string());
-
-    let tag = domain::tags::create(
+    let tag = domain::tags::create_location(
         &pool,
         &user.id,
-        &domain::tags::CreateTagRequest {
+        &domain::tags::CreateLocationRequest {
+            tag_type,
             name,
-            icon: None,
-            color: None,
             parent_tag_id,
-            tag_type: Some(tag_type),
-            metadata,
+            address,
         },
     )
     .await
@@ -380,7 +370,6 @@ pub async fn create_location(
     Ok(domain_tag_to_shared(tag))
 }
 
-/// Update a location tag's alias (name) and/or formal address (metadata).
 #[server(prefix = "/leptos")]
 pub async fn update_location_metadata(
     id: String,
@@ -389,33 +378,19 @@ pub async fn update_location_metadata(
     clear_address: bool,
 ) -> Result<Tag, ServerFnError> {
     let pool = expect_context::<SqlitePool>();
-    let auth = leptos_axum::extract::<AuthSession<KartotekaBackend>>()
+    let user = leptos_axum::extract::<AuthSession<KartotekaBackend>>()
         .await
-        .map_err(|_| ServerFnError::new("auth extraction failed".to_string()))?;
-    let user = auth
+        .map_err(|_| ServerFnError::new("auth extraction failed".to_string()))?
         .user
         .ok_or_else(|| ServerFnError::new("unauthorized".to_string()))?;
-
-    let metadata_update = if clear_address {
-        Some(None)
-    } else {
-        address
-            .as_deref()
-            .filter(|a| !a.trim().is_empty())
-            .map(|a| Some(serde_json::json!({"address": a}).to_string()))
-    };
-
-    let tag = domain::tags::update(
+    let tag = domain::tags::update_location(
         &pool,
         &user.id,
         &id,
-        &domain::tags::UpdateTagRequest {
+        &domain::tags::UpdateLocationRequest {
             name,
-            icon: None,
-            color: None,
-            parent_tag_id: None,
-            tag_type: None,
-            metadata: metadata_update,
+            address,
+            clear_address,
         },
     )
     .await

--- a/locales/en/locations.ftl
+++ b/locales/en/locations.ftl
@@ -9,6 +9,6 @@ locations-formal-address-placeholder = Formal address (e.g. ul. Kowalska 1) — 
 locations-empty = No locations. Add your first country above.
 locations-save = Save
 locations-cancel = Cancel
+locations-load-error = Error: { $detail }
 locations-delete-title = Delete location
-locations-delete-action = Delete
 locations-delete-confirm = Delete this location and all its children?

--- a/locales/en/locations.ftl
+++ b/locales/en/locations.ftl
@@ -1,0 +1,12 @@
+locations-title = Locations
+locations-add-country = Add country
+locations-add-city = Add city
+locations-add-address = Add address
+locations-country-placeholder = Country name (e.g. Poland)
+locations-city-placeholder = City name (e.g. Kraków)
+locations-alias-placeholder = Alias (e.g. Work, Home)
+locations-formal-address-placeholder = Formal address (e.g. ul. Kowalska 1) — optional
+locations-empty = No locations. Add your first country above.
+locations-save = Save
+locations-cancel = Cancel
+locations-delete-confirm = Delete this location and all its children?

--- a/locales/en/locations.ftl
+++ b/locales/en/locations.ftl
@@ -9,4 +9,6 @@ locations-formal-address-placeholder = Formal address (e.g. ul. Kowalska 1) — 
 locations-empty = No locations. Add your first country above.
 locations-save = Save
 locations-cancel = Cancel
+locations-delete-title = Delete location
+locations-delete-action = Delete
 locations-delete-confirm = Delete this location and all its children?

--- a/locales/pl/locations.ftl
+++ b/locales/pl/locations.ftl
@@ -9,6 +9,6 @@ locations-formal-address-placeholder = Formalny adres (np. ul. Kowalska 1) — o
 locations-empty = Brak lokalizacji. Dodaj pierwszy kraj powyżej.
 locations-save = Zapisz
 locations-cancel = Anuluj
+locations-load-error = Błąd: { $detail }
 locations-delete-title = Usuń lokalizację
-locations-delete-action = Usuń
 locations-delete-confirm = Usunąć tę lokalizację i wszystkie potomne?

--- a/locales/pl/locations.ftl
+++ b/locales/pl/locations.ftl
@@ -1,0 +1,12 @@
+locations-title = Lokalizacje
+locations-add-country = Dodaj kraj
+locations-add-city = Dodaj miasto
+locations-add-address = Dodaj adres
+locations-country-placeholder = Nazwa kraju (np. Polska)
+locations-city-placeholder = Nazwa miasta (np. Kraków)
+locations-alias-placeholder = Alias (np. Praca, Dom)
+locations-formal-address-placeholder = Formalny adres (np. ul. Kowalska 1) — opcjonalny
+locations-empty = Brak lokalizacji. Dodaj pierwszy kraj powyżej.
+locations-save = Zapisz
+locations-cancel = Anuluj
+locations-delete-confirm = Usunąć tę lokalizację i wszystkie potomne?

--- a/locales/pl/locations.ftl
+++ b/locales/pl/locations.ftl
@@ -9,4 +9,6 @@ locations-formal-address-placeholder = Formalny adres (np. ul. Kowalska 1) — o
 locations-empty = Brak lokalizacji. Dodaj pierwszy kraj powyżej.
 locations-save = Zapisz
 locations-cancel = Anuluj
+locations-delete-title = Usuń lokalizację
+locations-delete-action = Usuń
 locations-delete-confirm = Usunąć tę lokalizację i wszystkie potomne?


### PR DESCRIPTION
## Summary

- Adds `/locations` page for managing a country→city→address location hierarchy
- Locations are stored as tags with `tag_type ∈ {country, city, address}`; formal address serialized as JSON in `metadata`
- Domain layer enforces location type allowlist, address metadata validation, and hierarchy rules (city needs country parent, address needs city parent)
- Server functions delegate entirely to new `domain::tags::create_location` and `domain::tags::update_location` which also verify the target tag is a location type before updating

## Changes

- `crates/domain/src/rules/tags.rs` — `validate_is_location_type`, `serialize_address_metadata`, `validate_address_metadata`
- `crates/domain/src/tags.rs` — `create_location`, `update_location` domain functions with `CreateLocationRequest` / `UpdateLocationRequest`
- `crates/frontend/src/server_fns/tags.rs` — `create_location` and `update_location_metadata` server functions (thin wrappers over domain)
- `crates/frontend/src/pages/locations/mod.rs` — `LocationsPage` + `LocationNode` components with add/edit/delete UI
- `crates/frontend/src/app.rs` + `nav.rs` — route and nav link for `/locations`
- `locales/en/locations.ftl` + `locales/pl/locations.ftl` — i18n keys
- `Dockerfile` — `CARGO_INCREMENTAL=0` to prevent disk-full on CI WASM incremental cache

## Test plan

- [ ] Navigate to `/locations`, add a country
- [ ] Add a city under the country, add an address under the city
- [ ] Edit an address alias and formal address field; save — verify changes persist
- [ ] Clear the formal address field and save — verify metadata is removed (not silently retained)
- [ ] Delete an address, city, country via the confirmation modal
- [ ] Attempt direct POST to `/leptos/create_location` with invalid `tag_type` — expect error
- [ ] `cargo test -p kartoteka-domain` — all domain tests pass
- [ ] `cargo test -p kartoteka-i18n` — EN/PL key parity passes

## Known limitations

Locations are currently stored as tags (MVP). Once location-based queries are needed (e.g. "items in Kraków"), a dedicated `locations` table with a `item_locations` join table will be required — tracked in #185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)