### PR TITLE
fix(settings): use use_context for SqlitePool to prevent panic on unauthenticated routes

### DIFF
--- a/crates/frontend/src/server_fns/settings.rs
+++ b/crates/frontend/src/server_fns/settings.rs
@@ -17,7 +17,9 @@ pub struct SigningSecret(pub String);
 /// Returns None for unauthenticated requests (landing page, login page).
 #[server(prefix = "/leptos")]
 pub async fn get_user_locale_sf() -> Result<Option<String>, ServerFnError> {
-    let pool = expect_context::<SqlitePool>();
+    let Some(pool) = use_context::<SqlitePool>() else {
+        return Ok(None);
+    };
     let auth = leptos_axum::extract::<AuthSession<KartotekaBackend>>()
         .await
         .map_err(|_| ServerFnError::new("auth extraction failed".to_string()))?;


### PR DESCRIPTION
## Summary

- `get_user_locale_sf` called `expect_context::<SqlitePool>()` which panics when the pool is not in context (e.g. landing page, login page)
- Replaced with `use_context::<SqlitePool>()` and early return `Ok(None)` — safe for unauthenticated callers

## Test plan

- [ ] Start the server and visit the landing page (`/`) without being logged in — should not panic
- [ ] Log in and verify locale is still loaded correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)