### PR TITLE
refactor(ci): migrate to native build on persistent self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,14 +82,15 @@ jobs:
 
   test:
     name: Tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux]
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
     needs: check-clippy
+    env:
+      CARGO_TARGET_DIR: /home/github-runner/.cache/kartoteka/target
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: workspace
+      - name: Setup Rust
+        run: |
+          . "$HOME/.cargo/env"
+          rustup show
       - run: cargo test --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,5 +92,6 @@ jobs:
       - name: Setup Rust
         run: |
           . "$HOME/.cargo/env"
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
           rustup show
       - run: cargo test --workspace

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -65,7 +65,7 @@ jobs:
           rm -rf dist && mkdir -p dist/site dist/locales
           PROFILE_DIR=$([ "$CARGO_PROFILE" = "release" ] && echo "release" || echo "debug")
           cp "${CARGO_TARGET_DIR}/${PROFILE_DIR}/kartoteka" dist/kartoteka
-          cp -r "${CARGO_TARGET_DIR}/site/." dist/site/
+          cp -r target/site/. dist/site/
           cp -r locales/. dist/locales/
 
       - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -23,6 +23,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+    env:
+      CARGO_TARGET_DIR: /home/github-runner/.cache/kartoteka/target
     steps:
       - uses: actions/checkout@v6
 
@@ -62,8 +64,8 @@ jobs:
         run: |
           rm -rf dist && mkdir -p dist/site dist/locales
           PROFILE_DIR=$([ "$CARGO_PROFILE" = "release" ] && echo "release" || echo "debug")
-          cp "target/${PROFILE_DIR}/kartoteka" dist/kartoteka
-          cp -r target/site/. dist/site/
+          cp "${CARGO_TARGET_DIR}/${PROFILE_DIR}/kartoteka" dist/kartoteka
+          cp -r "${CARGO_TARGET_DIR}/site/." dist/site/
           cp -r locales/. dist/locales/
 
       - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,9 +1414,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
  "itoa",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "nightly"
 targets = ["wasm32-unknown-unknown"]
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

- Migrate Docker build to persistent self-hosted runner (`[self-hosted, linux]`)
- Replace Docker-based compilation with native `cargo leptos build` — incremental compilation now works across runs
- Add `Dockerfile.runtime`: thin packaging image (no compilation, just COPY from `dist/`)
- Add `rust-toolchain.toml` to pin nightly + wasm32-unknown-unknown target
- Set `CARGO_TARGET_DIR` outside checkout dir so `target/` survives `git clean`
- Block fork PRs from triggering self-hosted runner builds (`if: github.event.pull_request.head.repo.full_name == github.repository`)
- Keep original `Dockerfile` for rollback

## glibc compatibility

Ubuntu 24.04 runner (glibc 2.39) < `debian:trixie-slim` (glibc 2.41) — safe.

## Test plan

- [ ] Push to develop triggers build on self-hosted runner
- [ ] Second run is faster (incremental compilation from cached `target/`)
- [ ] Container starts and `/health` responds
- [ ] WASM hydration works in browser
- [ ] Production release build (`cargo_profile: release`) stages `target/release/kartoteka`

🤖 Generated with [Claude Code](https://claude.com/claude-code)