### PR TITLE
fix(wasm): enable hash-files to prevent WASM/JS cache mismatch on deploy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ bin-features = []
 lib-features = ["hydrate"]
 assets-dir = "crates/frontend/public"
 style-file = "crates/frontend/style/main.css"
-hash-files = false
+hash-files = true
 wasm-opt-features = ["-Oz", "--enable-bulk-memory"]
 
 [workspace.lints.clippy]

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,7 @@ USER app
 
 ENV BIND_ADDR=0.0.0.0:3000 \
     LEPTOS_SITE_ROOT=site \
+    LEPTOS_HASH_FILES=true \
     RUST_LOG=info \
     DATABASE_URL=sqlite:////data/data.db
 

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -19,6 +19,7 @@ USER app
 
 ENV BIND_ADDR=0.0.0.0:3000 \
     LEPTOS_SITE_ROOT=site \
+    LEPTOS_HASH_FILES=true \
     RUST_LOG=info \
     DATABASE_URL=sqlite:////data/data.db
 

--- a/crates/frontend/src/lib.rs
+++ b/crates/frontend/src/lib.rs
@@ -15,6 +15,7 @@ pub use app::App;
 #[cfg(feature = "ssr")]
 pub fn shell(options: leptos::config::LeptosOptions) -> impl leptos::IntoView {
     use leptos::prelude::*;
+    use leptos_meta::HashedStylesheet;
 
     view! {
         <!DOCTYPE html>
@@ -23,8 +24,8 @@ pub fn shell(options: leptos::config::LeptosOptions) -> impl leptos::IntoView {
                 <meta charset="utf-8"/>
                 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover"/>
                 <AutoReload options=options.clone() />
-                <HydrationScripts options/>
-                <link rel="stylesheet" href="/pkg/kartoteka.css"/>
+                <HydrationScripts options=options.clone() />
+                <HashedStylesheet options id="leptos"/>
                 {match (std::env::var("ANALYTICS_URL"), std::env::var("ANALYTICS_SITE_ID")) {
                     (Ok(url), Ok(site_id)) => view! {
                         <script defer src=url data-website-id=site_id></script>


### PR DESCRIPTION
## Summary

- Set `hash-files = true` in cargo-leptos config (`Cargo.toml`)
- Add `LEPTOS_HASH_FILES=true` to runtime Docker image (`Dockerfile.runtime`)

## Problem

Without content hashing, `kartoteka.js` and `kartoteka.wasm` keep the same filenames across deploys. After a redeploy, browsers serving stale `kartoteka.js` from cache against a new `kartoteka.wasm` (or vice versa) cause a `WebAssembly LinkError` — the WASM imports a cast function the old JS doesn't provide.

## Fix

`hash-files = true` makes cargo-leptos append a content hash to every asset filename (e.g. `kartoteka-abc123.wasm`). The SSR HTML always references the current hashed URLs, so any cached version of the JS/WASM pair is immediately invalidated on deploy.

The `LEPTOS_HASH_FILES=true` runtime env var is required alongside the build-time setting — without it the server won't construct the correct hashed asset URLs.

## Test plan

- [ ] `just ci` passes
- [ ] After deploy, browser network tab shows hashed filenames (`kartoteka-<hash>.wasm`, `kartoteka-<hash>.js`)
- [ ] Hard-refresh no longer triggers WASM LinkError

🤖 Generated with [Claude Code](https://claude.com/claude-code)