### PR TITLE
fix(wasm): enable hash-files and fix CSS 404 in SSR

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ bin-features = []
 lib-features = ["hydrate"]
 assets-dir = "crates/frontend/public"
 style-file = "crates/frontend/style/main.css"
-hash-files = false
+hash-files = true
 wasm-opt-features = ["-Oz", "--enable-bulk-memory"]
 
 [workspace.lints.clippy]

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,7 @@ USER app
 
 ENV BIND_ADDR=0.0.0.0:3000 \
     LEPTOS_SITE_ROOT=site \
+    LEPTOS_HASH_FILES=true \
     RUST_LOG=info \
     DATABASE_URL=sqlite:////data/data.db
 

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -19,6 +19,7 @@ USER app
 
 ENV BIND_ADDR=0.0.0.0:3000 \
     LEPTOS_SITE_ROOT=site \
+    LEPTOS_HASH_FILES=true \
     RUST_LOG=info \
     DATABASE_URL=sqlite:////data/data.db
 

--- a/crates/frontend/src/lib.rs
+++ b/crates/frontend/src/lib.rs
@@ -15,6 +15,7 @@ pub use app::App;
 #[cfg(feature = "ssr")]
 pub fn shell(options: leptos::config::LeptosOptions) -> impl leptos::IntoView {
     use leptos::prelude::*;
+    use leptos_meta::HashedStylesheet;
 
     view! {
         <!DOCTYPE html>
@@ -23,8 +24,8 @@ pub fn shell(options: leptos::config::LeptosOptions) -> impl leptos::IntoView {
                 <meta charset="utf-8"/>
                 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover"/>
                 <AutoReload options=options.clone() />
-                <HydrationScripts options/>
-                <link rel="stylesheet" href="/pkg/kartoteka.css"/>
+                <HydrationScripts options=options.clone() />
+                <HashedStylesheet options id="leptos"/>
                 {match (std::env::var("ANALYTICS_URL"), std::env::var("ANALYTICS_SITE_ID")) {
                     (Ok(url), Ok(site_id)) => view! {
                         <script defer src=url data-website-id=site_id></script>


### PR DESCRIPTION
## Summary

- Enable `hash-files = true` in `Cargo.toml` leptos config to prevent WASM/JS cache mismatch on deploy
- Add `LEPTOS_HASH_FILES=true` to Dockerfile runtime ENV so Leptos can find the hash index file at startup
- Switch to `HashedStylesheet` component to serve the CSS with the correct hashed filename

## Why

The `develop` deployment is currently returning 502 because the container has hashed asset filenames but the runtime cannot locate the required `.hash` index file, causing a panic on every tokio worker thread. This PR provides the complete fix.

## Test plan

- [ ] CI builds successfully on the develop branch after merge
- [ ] `kartoteka-develop.palczew.ski` returns 200 (no 502)
- [ ] Assets (JS, WASM, CSS) load correctly in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)