### PR TITLE
fix: fold list tag links into get_list_data to drop a redundant SSR resource

### DIFF
--- a/crates/frontend/src/pages/list/mod.rs
+++ b/crates/frontend/src/pages/list/mod.rs
@@ -30,8 +30,7 @@ use crate::server_fns::lists::{
     reset_list, update_list_features,
 };
 use crate::server_fns::tags::{
-    assign_tag_to_item, assign_tag_to_list, get_all_tags, get_list_tag_links, remove_tag_from_item,
-    remove_tag_from_list,
+    assign_tag_to_item, assign_tag_to_list, remove_tag_from_item, remove_tag_from_list,
 };
 use crate::state::dnd::{
     DndState, EntityKind, ItemDndState, ItemDropPlan, ItemDropTarget, build_item_drop_plan,
@@ -85,26 +84,12 @@ pub fn ListPage() -> impl IntoView {
         |_| get_all_lists(),
     );
 
-    let tag_res = Resource::new(
-        move || (list_id(), refresh.get(), global_refresh.get()),
-        |(lid, _, _)| async move {
-            let tags = get_all_tags().await?;
-            let links = get_list_tag_links().await?;
-            let tag_ids: Vec<String> = links
-                .into_iter()
-                .filter(|l| l.list_id == lid)
-                .map(|l| l.tag_id)
-                .collect();
-            Ok::<(Vec<kartoteka_shared::types::Tag>, Vec<String>), ServerFnError>((tags, tag_ids))
-        },
-    );
-
     let on_tag_toggle = Callback::new(move |tag_id: String| {
         let lid = list_id();
-        let current_tag_ids = tag_res
+        let current_tag_ids = data_res
             .get()
             .and_then(|r| r.ok())
-            .map(|(_, ids)| ids)
+            .map(|data| data.list_tag_ids)
             .unwrap_or_default();
         let has_tag = current_tag_ids.contains(&tag_id);
         leptos::task::spawn_local(async move {
@@ -319,7 +304,9 @@ pub fn ListPage() -> impl IntoView {
                         let item_tag_links_filter = data.item_tag_links.clone();
                         let all_tags_for_filter = data.all_tags.clone();
                         let all_tags_for_rows = data.all_tags.clone();
+                        let all_tags_for_list_tags = data.all_tags.clone();
                         let all_tags_for_selector = data.all_tags.clone();
+                        let list_tag_ids = data.list_tag_ids.clone();
                         let today_date = data.today_date.clone();
                         let breadcrumb_crumbs = if let Some(ref cname) = data.container_name {
                             let cid = data.list.container_id.clone().unwrap_or_default();
@@ -553,15 +540,11 @@ pub fn ListPage() -> impl IntoView {
 
                                 // Tags
                                 <div class="mb-4" data-testid="list-tags-section">
-                                    {move || tag_res.get().and_then(|r| r.ok()).map(|(all_tags, tag_ids)| {
-                                        view! {
-                                            <TagList
-                                                all_tags=all_tags
-                                                selected_tag_ids=tag_ids
-                                                on_toggle=on_tag_toggle
-                                            />
-                                        }
-                                    })}
+                                    <TagList
+                                        all_tags=all_tags_for_list_tags
+                                        selected_tag_ids=list_tag_ids
+                                        on_toggle=on_tag_toggle
+                                    />
                                 </div>
 
                                 // Tag filter bar (shown only when items have tags)

--- a/crates/frontend/src/server_fns/items.rs
+++ b/crates/frontend/src/server_fns/items.rs
@@ -56,7 +56,15 @@ pub async fn get_list_data(list_id: String) -> Result<ListData, ServerFnError> {
             ServerFnError::new($e.to_string())
         };
     }
-    let (list_res, items_res, sublists_res, settings_res, tag_links_res, all_tags_res) = tokio::join!(
+    let (
+        list_res,
+        items_res,
+        sublists_res,
+        settings_res,
+        item_tag_links_res,
+        all_tags_res,
+        list_tag_links_res,
+    ) = tokio::join!(
         async {
             domain::lists::get_one(&pool, &list_id, &user.id)
                 .await
@@ -87,13 +95,19 @@ pub async fn get_list_data(list_id: String) -> Result<ListData, ServerFnError> {
                 .await
                 .map_err(|e| sfn_err!(e))
         },
+        async {
+            db::tags::get_all_list_tag_links(&pool, &user.id)
+                .await
+                .map_err(|e| sfn_err!(e))
+        },
     );
     let list = list_res?.ok_or_else(|| ServerFnError::new("list not found".to_string()))?;
     let items = items_res?;
     let sublists = sublists_res?;
     let settings = settings_res?;
-    let raw_tag_links: Vec<(String, String)> = tag_links_res?;
+    let raw_item_tag_links: Vec<(String, String)> = item_tag_links_res?;
     let all_domain_tags: Vec<domain::tags::Tag> = all_tags_res?;
+    let raw_list_tag_links: Vec<(String, String)> = list_tag_links_res?;
 
     let tz = settings
         .iter()
@@ -119,13 +133,17 @@ pub async fn get_list_data(list_id: String) -> Result<ListData, ServerFnError> {
         items: items.into_iter().map(domain_item_to_shared).collect(),
         sublists: sublists.into_iter().map(domain_list_to_shared).collect(),
         created_at_local,
-        item_tag_links: raw_tag_links
+        item_tag_links: raw_item_tag_links
             .into_iter()
             .map(|(item_id, tag_id)| ItemTagLink { item_id, tag_id })
             .collect(),
         all_tags: all_domain_tags
             .into_iter()
             .map(domain_tag_to_shared)
+            .collect(),
+        list_tag_ids: raw_list_tag_links
+            .into_iter()
+            .filter_map(|(linked_list_id, tag_id)| (linked_list_id == list_id).then_some(tag_id))
             .collect(),
         today_date,
         container_name,

--- a/crates/shared/src/types.rs
+++ b/crates/shared/src/types.rs
@@ -302,6 +302,8 @@ pub struct ListData {
     pub item_tag_links: Vec<ItemTagLink>,
     /// All tags for the user. Used to resolve tag names/colors for item rows and the filter bar.
     pub all_tags: Vec<Tag>,
+    /// Tag IDs assigned directly to this list.
+    pub list_tag_ids: Vec<String>,
     /// Today's date as "YYYY-MM-DD" in user's timezone — used for deadline grouping.
     pub today_date: String,
     /// Name of the parent container, if any — used for breadcrumbs.


### PR DESCRIPTION
## What

`ListPage` issued a separate `tag_res` `Resource` that called both
`get_all_tags` and `get_list_tag_links` in addition to the main `data_res`
(`get_list_data`). That second SSR resource is redundant — the current list's
own tag ids are derivable server-side from the data we already fetch.

## Changes

- `get_list_data` now also fetches `list_tags` via the existing
  `db::tags::get_all_list_tag_links` inside its `tokio::join!`, and returns
  the new `ListData.list_tag_ids` (filtered to the current list).
- `ListPage` drops `tag_res` entirely and renders `<TagList>` synchronously
  from `data_res`. The tag-toggle callback now reads `list_tag_ids` from the
  same data instead of a second resource.

## Why

Removes one server round-trip and one streamed SSR resource per list-page
render. `get_list_tag_links` is still used by the home page, so it is kept.

## Verification

- `cargo leptos build` (SSR + WASM hydrate) compiles clean.
- pre-commit `fmt` + `clippy -D warnings` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)