### PR TITLE
fix(mcp): allow deployment host for streamable-http transport; bump rmcp to 1.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1964,7 +1964,6 @@ dependencies = [
  "kartoteka-shared",
  "leptos",
  "leptos_axum",
- "rmcp",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -3132,9 +3131,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
 dependencies = [
  "async-trait",
  "base64",
@@ -3163,9 +3162,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -12,7 +12,7 @@ kartoteka-shared = { path = "../shared" }
 kartoteka-domain = { path = "../domain" }
 kartoteka-db     = { path = "../db" }
 
-rmcp = { version = "1.6", features = ["server", "transport-streamable-http-server", "transport-worker", "macros"] }
+rmcp = { version = "1.7", features = ["server", "transport-streamable-http-server", "transport-worker", "macros"] }
 schemars = "1"
 sqlx = { workspace = true }
 serde = { version = "1", features = ["derive"] }

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -9,6 +9,12 @@ pub mod tools;
 pub use i18n::McpI18n;
 pub use server::KartotekaServer;
 
+/// rmcp streamable-HTTP transport types, re-exported so `crates/server` can mount
+/// the MCP service without taking a direct dependency on `rmcp`.
+pub use rmcp::transport::streamable_http_server::{
+    StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
+};
+
 use http::request::Parts;
 use kartoteka_shared::auth_ctx::{UserId, UserLocale};
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -18,7 +18,6 @@ kartoteka-domain = { path = "../domain" }
 kartoteka-auth = { path = "../auth" }
 kartoteka-mcp = { path = "../mcp" }
 kartoteka-oauth = { path = "../oauth" }
-rmcp = { version = "1.6", features = ["server", "transport-streamable-http-server"] }
 tower.workspace = true
 kartoteka-jobs = { path = "../jobs" }
 kartoteka-frontend = { path = "../frontend", features = ["ssr"] }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -107,6 +107,35 @@ pub fn test_router(pool: SqlitePool, auth_layer: AuthLayer, signing_secret: Stri
     )
 }
 
+/// `Host` allowlist for the MCP streamable-HTTP transport: loopback for local dev,
+/// the deployment's own public host (derived from `PUBLIC_BASE_URL`), and any extra
+/// virtual hosts from `MCP_ALLOWED_HOSTS` (comma-separated — e.g. an edge gateway or
+/// preview domain). rmcp's DNS-rebinding guard rejects any `Host` not on this list,
+/// so the production host must be present or every `/mcp` request returns 403.
+fn mcp_allowed_hosts(public_base_url: &str) -> Vec<String> {
+    let mut hosts = vec![
+        "localhost".to_string(),
+        "127.0.0.1".to_string(),
+        "::1".to_string(),
+    ];
+    if let Ok(uri) = public_base_url.parse::<axum::http::Uri>() {
+        if let Some(authority) = uri.authority() {
+            hosts.push(authority.host().to_string());
+            hosts.push(authority.as_str().to_string());
+        }
+    }
+    if let Ok(extra) = std::env::var("MCP_ALLOWED_HOSTS") {
+        hosts.extend(
+            extra
+                .split(',')
+                .map(str::trim)
+                .filter(|h| !h.is_empty())
+                .map(String::from),
+        );
+    }
+    hosts
+}
+
 pub fn router(
     pool: SqlitePool,
     auth_layer: AuthLayer,
@@ -115,11 +144,10 @@ pub fn router(
     leptos_options: leptos::config::LeptosOptions,
     mcp_i18n: Arc<McpI18n>,
 ) -> Router {
-    use rmcp::transport::streamable_http_server::{
-        StreamableHttpService, session::local::LocalSessionManager,
-    };
+    use kartoteka_mcp::{LocalSessionManager, StreamableHttpServerConfig, StreamableHttpService};
 
     let routes = generate_route_list(App);
+    let mcp_allowed_hosts = mcp_allowed_hosts(&public_base_url);
     let oauth_state = OAuthState {
         pool: pool.clone(),
         signing_secret: signing_secret.clone(),
@@ -138,7 +166,7 @@ pub fn router(
     let mcp_service = StreamableHttpService::new(
         move || Ok(mcp_server.clone()),
         Arc::new(LocalSessionManager::default()),
-        Default::default(),
+        StreamableHttpServerConfig::default().with_allowed_hosts(mcp_allowed_hosts),
     );
 
     Router::new()

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -15,12 +15,7 @@ pub mod time_entries;
 pub use error::AppError;
 pub use extractors::UserId;
 
-use axum::{
-    Router,
-    body::Body,
-    extract::{Request, State},
-    response::{IntoResponse, Response},
-};
+use axum::Router;
 use kartoteka_db::SqlitePool;
 use kartoteka_frontend::{App, shell};
 use kartoteka_mcp::McpI18n;
@@ -34,7 +29,7 @@ use std::sync::Arc;
 #[derive(Clone, axum_macros::FromRef)]
 pub struct AppState {
     pub leptos_options: leptos::config::LeptosOptions,
-    /// Pre-generated Leptos route list (reused per request by leptos_routes_handler).
+    /// Pre-generated Leptos route list.
     pub routes: Vec<AxumRouteListing>,
     pub pool: SqlitePool,
     /// HMAC-SHA256 signing secret for JWT bearer tokens (min 32 chars).
@@ -48,47 +43,6 @@ pub type AuthLayer = axum_login::AuthManagerLayer<
     kartoteka_auth::KartotekaBackend,
     tower_sessions_sqlx_store::SqliteStore,
 >;
-
-/// Handles Leptos server function calls at `/leptos/{*fn_name}`.
-/// All `#[server]` functions in frontend must use `#[server(prefix = "/leptos")]`.
-pub async fn server_fn_handler(
-    State(state): State<AppState>,
-    req: Request<Body>,
-) -> impl IntoResponse {
-    leptos_axum::handle_server_fns_with_context(
-        move || {
-            provide_context(state.pool.clone());
-            provide_context(state.clone());
-            provide_context(kartoteka_frontend::server_fns::settings::SigningSecret(
-                state.signing_secret.clone(),
-            ));
-        },
-        req,
-    )
-    .await
-}
-
-/// Renders Leptos SSR pages for all frontend routes.
-pub async fn leptos_routes_handler(State(state): State<AppState>, req: Request<Body>) -> Response {
-    let options = state.leptos_options.clone();
-    let pool = state.pool.clone();
-    let s = state.clone();
-    let signing_secret = state.signing_secret.clone();
-    let handler = leptos_axum::render_route_with_context(
-        state.routes.clone(),
-        move || {
-            provide_context(pool.clone());
-            provide_context(s.clone());
-            provide_context(kartoteka_frontend::server_fns::settings::SigningSecret(
-                signing_secret.clone(),
-            ));
-        },
-        move || shell(options.clone()),
-    );
-    handler(axum::extract::State(state), req)
-        .await
-        .into_response()
-}
 
 /// Convenience wrapper for integration tests: creates a router with default LeptosOptions.
 #[doc(hidden)]
@@ -161,14 +115,22 @@ pub fn router(
         )
         .nest("/auth", auth::auth_router())
         .nest("/api", routes::routes(state.clone()))
-        // Server functions: /leptos/{fn_name} (avoids conflict with /api/* REST routes)
-        .route(
-            "/leptos/{*fn_name}",
-            axum::routing::get(server_fn_handler).post(server_fn_handler),
-        )
         .route("/health", axum::routing::get(health::health))
-        // SSR page rendering for all Leptos routes (/, /today, /lists/:id, etc.)
-        .leptos_routes_with_handler(routes, axum::routing::get(leptos_routes_handler))
+        .leptos_routes_with_context(
+            &state,
+            routes,
+            {
+                let state = state.clone();
+                move || {
+                    provide_context(state.pool.clone());
+                    provide_context(state.clone());
+                    provide_context(kartoteka_frontend::server_fns::settings::SigningSecret(
+                        state.signing_secret.clone(),
+                    ));
+                }
+            },
+            move || shell(leptos_options.clone()),
+        )
         // Static asset serving from target/site
         .fallback(leptos_axum::file_and_error_handler::<AppState, _>(shell))
         .layer(auth_layer)

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -15,7 +15,12 @@ pub mod time_entries;
 pub use error::AppError;
 pub use extractors::UserId;
 
-use axum::Router;
+use axum::{
+    Router,
+    body::Body,
+    extract::{Request, State},
+    response::{IntoResponse, Response},
+};
 use kartoteka_db::SqlitePool;
 use kartoteka_frontend::{App, shell};
 use kartoteka_mcp::McpI18n;
@@ -29,7 +34,7 @@ use std::sync::Arc;
 #[derive(Clone, axum_macros::FromRef)]
 pub struct AppState {
     pub leptos_options: leptos::config::LeptosOptions,
-    /// Pre-generated Leptos route list.
+    /// Pre-generated Leptos route list (reused per request by leptos_routes_handler).
     pub routes: Vec<AxumRouteListing>,
     pub pool: SqlitePool,
     /// HMAC-SHA256 signing secret for JWT bearer tokens (min 32 chars).
@@ -43,6 +48,47 @@ pub type AuthLayer = axum_login::AuthManagerLayer<
     kartoteka_auth::KartotekaBackend,
     tower_sessions_sqlx_store::SqliteStore,
 >;
+
+/// Handles Leptos server function calls at `/leptos/{*fn_name}`.
+/// All `#[server]` functions in frontend must use `#[server(prefix = "/leptos")]`.
+pub async fn server_fn_handler(
+    State(state): State<AppState>,
+    req: Request<Body>,
+) -> impl IntoResponse {
+    leptos_axum::handle_server_fns_with_context(
+        move || {
+            provide_context(state.pool.clone());
+            provide_context(state.clone());
+            provide_context(kartoteka_frontend::server_fns::settings::SigningSecret(
+                state.signing_secret.clone(),
+            ));
+        },
+        req,
+    )
+    .await
+}
+
+/// Renders Leptos SSR pages for all frontend routes.
+pub async fn leptos_routes_handler(State(state): State<AppState>, req: Request<Body>) -> Response {
+    let options = state.leptos_options.clone();
+    let pool = state.pool.clone();
+    let s = state.clone();
+    let signing_secret = state.signing_secret.clone();
+    let handler = leptos_axum::render_route_with_context(
+        state.routes.clone(),
+        move || {
+            provide_context(pool.clone());
+            provide_context(s.clone());
+            provide_context(kartoteka_frontend::server_fns::settings::SigningSecret(
+                signing_secret.clone(),
+            ));
+        },
+        move || shell(options.clone()),
+    );
+    handler(axum::extract::State(state), req)
+        .await
+        .into_response()
+}
 
 /// Convenience wrapper for integration tests: creates a router with default LeptosOptions.
 #[doc(hidden)]
@@ -115,22 +161,14 @@ pub fn router(
         )
         .nest("/auth", auth::auth_router())
         .nest("/api", routes::routes(state.clone()))
-        .route("/health", axum::routing::get(health::health))
-        .leptos_routes_with_context(
-            &state,
-            routes,
-            {
-                let state = state.clone();
-                move || {
-                    provide_context(state.pool.clone());
-                    provide_context(state.clone());
-                    provide_context(kartoteka_frontend::server_fns::settings::SigningSecret(
-                        state.signing_secret.clone(),
-                    ));
-                }
-            },
-            move || shell(leptos_options.clone()),
+        // Server functions: /leptos/{fn_name} (avoids conflict with /api/* REST routes)
+        .route(
+            "/leptos/{*fn_name}",
+            axum::routing::get(server_fn_handler).post(server_fn_handler),
         )
+        .route("/health", axum::routing::get(health::health))
+        // SSR page rendering for all Leptos routes (/, /today, /lists/:id, etc.)
+        .leptos_routes_with_handler(routes, axum::routing::get(leptos_routes_handler))
         // Static asset serving from target/site
         .fallback(leptos_axum::file_and_error_handler::<AppState, _>(shell))
         .layer(auth_layer)


### PR DESCRIPTION
## Problem

rmcp's streamable-HTTP transport ships a DNS-rebinding guard whose default
`allowed_hosts` is loopback only (`localhost`, `127.0.0.1`, `::1`). The server
mounted the MCP service with `Default::default()`, so every `/mcp` request addressed
to a non-loopback (production/preview) host was rejected with **403** at the transport
layer.

Symptom: the OAuth flow completed successfully (authorization code + refresh token
persisted, session saved), but the connector's follow-up `/mcp` calls were refused —
surfacing to the user as an "integration rejected the credentials" error. Server logs
showed `rejected request with disallowed Host header (possible DNS rebinding attempt)`.

## Fix

Build the `Host` allowlist explicitly in `router()`:

- loopback (`localhost` / `127.0.0.1` / `::1`) for local dev,
- the deployment's own public host **derived from `PUBLIC_BASE_URL`** — per-env, no
  hardcoding,
- optional extra virtual hosts from a new **`MCP_ALLOWED_HOSTS`** env (comma-separated),
  for cases where the request `Host` differs from `PUBLIC_BASE_URL` (e.g. an edge
  gateway that preserves the original Host, or a vanity domain).

## Dependency consolidation

`crates/server` used `rmcp` in exactly one place (the transport types). Re-export
`StreamableHttpService`, `StreamableHttpServerConfig` and `LocalSessionManager` from
`kartoteka_mcp` and drop the direct `rmcp` dependency from `crates/server`. `rmcp` now
lives only in the MCP crate.

## rmcp bump

`rmcp` 1.6 → 1.7 in both manifests and the lockfile.

## Verification

- `cargo leptos build` (SSR + WASM hydrate) compiles clean.
- pre-commit `fmt` + `clippy --workspace -D warnings` pass.
- Post-deploy check: with `PUBLIC_BASE_URL` set to the public origin, `/mcp` requests
  from that host no longer 403; the connector completes its session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)