### PR TITLE
feat(mcp): add list_container_items tool for paginated cross-list browsing

### DIFF
--- a/crates/db/src/items.rs
+++ b/crates/db/src/items.rs
@@ -1,4 +1,7 @@
-use crate::{DbError, types::ItemRow};
+use crate::{
+    DbError,
+    types::{ContainerItemRow, ItemRow},
+};
 use sqlx::{QueryBuilder, Sqlite, SqliteConnection, SqlitePool};
 
 // ── Input types ───────────────────────────────────────────────────────────────
@@ -413,6 +416,62 @@ pub async fn move_item(
     .await
     .map_err(DbError::Sqlx)?;
     Ok(rows.rows_affected() > 0)
+}
+
+#[tracing::instrument(skip(pool))]
+pub async fn list_for_container(
+    pool: &SqlitePool,
+    container_id: &str,
+    user_id: &str,
+    limit: u32,
+    offset: usize,
+    recursive: bool,
+) -> Result<Vec<ContainerItemRow>, DbError> {
+    if recursive {
+        sqlx::query_as::<_, ContainerItemRow>(&format!(
+            "WITH RECURSIVE sub AS ( \
+               SELECT id, name, printf('%06d', position) AS sort_path \
+               FROM containers WHERE id = ? AND user_id = ? \
+               UNION ALL \
+               SELECT c.id, c.name, sub.sort_path || '/' || printf('%06d', c.position) \
+               FROM containers c JOIN sub ON c.parent_container_id = sub.id \
+               WHERE c.user_id = ? \
+             ) \
+             SELECT {ITEM_COLUMNS}, l.name AS list_name, l.container_id, sub.name AS container_name \
+             FROM items i \
+             JOIN lists l ON l.id = i.list_id \
+             JOIN sub ON sub.id = l.container_id \
+             WHERE l.user_id = ? AND l.archived = 0 \
+             ORDER BY sub.sort_path, l.position, i.position \
+             LIMIT ? OFFSET ?"
+        ))
+        .bind(container_id)
+        .bind(user_id)
+        .bind(user_id) // RECURSIVE sub: c.user_id filter
+        .bind(user_id) // outer WHERE l.user_id
+        .bind(limit as i64)
+        .bind(offset as i64)
+        .fetch_all(pool)
+        .await
+        .map_err(DbError::Sqlx)
+    } else {
+        sqlx::query_as::<_, ContainerItemRow>(&format!(
+            "SELECT {ITEM_COLUMNS}, l.name AS list_name, l.container_id, c.name AS container_name \
+             FROM items i \
+             JOIN lists l ON l.id = i.list_id \
+             JOIN containers c ON c.id = l.container_id \
+             WHERE l.container_id = ? AND l.user_id = ? AND l.archived = 0 \
+             ORDER BY l.position, i.position \
+             LIMIT ? OFFSET ?"
+        ))
+        .bind(container_id)
+        .bind(user_id)
+        .bind(limit as i64)
+        .bind(offset as i64)
+        .fetch_all(pool)
+        .await
+        .map_err(DbError::Sqlx)
+    }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/crates/db/src/types.rs
+++ b/crates/db/src/types.rs
@@ -140,6 +140,15 @@ pub struct ItemRow {
 }
 
 #[derive(Debug, sqlx::FromRow)]
+pub struct ContainerItemRow {
+    #[sqlx(flatten)]
+    pub item: ItemRow,
+    pub list_name: String,
+    pub container_id: String,
+    pub container_name: String,
+}
+
+#[derive(Debug, sqlx::FromRow)]
 pub struct TagRow {
     pub id: String,
     pub user_id: String,

--- a/crates/domain/src/items.rs
+++ b/crates/domain/src/items.rs
@@ -70,6 +70,16 @@ pub struct MoveItemRequest {
     pub list_id: Option<String>, // move to different list
 }
 
+// ── Container item type ───────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ContainerItem {
+    pub item: Item,
+    pub list_name: String,
+    pub container_id: String,
+    pub container_name: String,
+}
+
 // ── Conversion from db row ────────────────────────────────────────────────────
 
 fn row_to_item(row: db::types::ItemRow) -> Item {
@@ -129,6 +139,28 @@ pub async fn list_for_list(
 ) -> Result<Vec<Item>, DomainError> {
     let rows = db::items::list_for_list(pool, list_id, user_id).await?;
     Ok(rows.into_iter().map(row_to_item).collect())
+}
+
+#[tracing::instrument(skip(pool))]
+pub async fn list_for_container(
+    pool: &SqlitePool,
+    container_id: &str,
+    user_id: &str,
+    limit: u32,
+    offset: usize,
+    recursive: bool,
+) -> Result<Vec<ContainerItem>, DomainError> {
+    let rows = db::items::list_for_container(pool, container_id, user_id, limit, offset, recursive)
+        .await?;
+    Ok(rows
+        .into_iter()
+        .map(|r| ContainerItem {
+            item: row_to_item(r.item),
+            list_name: r.list_name,
+            container_id: r.container_id,
+            container_name: r.container_name,
+        })
+        .collect())
 }
 
 #[tracing::instrument(skip(pool))]

--- a/crates/mcp/src/server.rs
+++ b/crates/mcp/src/server.rs
@@ -35,7 +35,9 @@ use crate::tools::{
         CreateContainerParams, CreateContainersParams, CreateItemParams, CreateItemsParams,
         CreateListParams, CreateListsParams, UpdateItemParams,
     },
-    read::{GetContainerParams, GetItemParams, GetListParams, ListItemsParams},
+    read::{
+        GetContainerParams, GetItemParams, GetListParams, ListContainerItemsParams, ListItemsParams,
+    },
     relations::{AddRelationParams, RemoveRelationParams},
     search::SearchItemsParams,
     tags::{
@@ -474,6 +476,49 @@ impl KartotekaServer {
         self.json_result(
             domain::paging::Paged {
                 data: page,
+                next_cursor,
+                limit,
+            },
+            &locale,
+        )
+    }
+
+    #[rmcp::tool(
+        name = "list_container_items",
+        description = "mcp-tool-list_container_items-desc"
+    )]
+    async fn list_container_items(
+        &self,
+        Extension(parts): Extension<Parts>,
+        Parameters(p): Parameters<ListContainerItemsParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let (uid, locale) = self.auth(&parts)?;
+        let limit = domain::paging::clamp_limit(p.limit);
+        let offset: usize = p
+            .cursor
+            .as_deref()
+            .and_then(|c| c.parse().ok())
+            .unwrap_or(0);
+        let recursive = p.recursive.unwrap_or(false);
+        let mut rows = domain::items::list_for_container(
+            &self.pool,
+            &p.container_id,
+            &uid,
+            limit + 1,
+            offset,
+            recursive,
+        )
+        .await
+        .map_err(self.domain_err(&locale))?;
+        let next_cursor = if rows.len() > limit as usize {
+            rows.truncate(limit as usize);
+            Some((offset + limit as usize).to_string())
+        } else {
+            None
+        };
+        self.json_result(
+            domain::paging::Paged {
+                data: rows,
                 next_cursor,
                 limit,
             },

--- a/crates/mcp/src/server/annotations.rs
+++ b/crates/mcp/src/server/annotations.rs
@@ -10,6 +10,7 @@ const READ_ONLY: &[&str] = &[
     "list_lists",
     "get_list",
     "list_items",
+    "list_container_items",
     "list_containers",
     "get_container",
     "list_tags",

--- a/crates/mcp/src/tools/read.rs
+++ b/crates/mcp/src/tools/read.rs
@@ -24,3 +24,14 @@ pub struct GetContainerParams {
 pub struct GetItemParams {
     pub item_id: String,
 }
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ListContainerItemsParams {
+    pub container_id: String,
+    /// Include items from nested sub-containers (default false)
+    pub recursive: Option<bool>,
+    /// Opaque cursor from previous response; omit for first page
+    pub cursor: Option<String>,
+    /// Max items to return (1–500, default 100)
+    pub limit: Option<u32>,
+}

--- a/locales/en/mcp.ftl
+++ b/locales/en/mcp.ftl
@@ -83,6 +83,7 @@ mcp-err-bad-uri = Invalid resource URI: { $uri }.
 mcp-tool-list_lists-desc = List all your lists.
 mcp-tool-get_list-desc = Get details of a specific list by ID.
 mcp-tool-list_items-desc = List items in a list, with optional cursor-based pagination.
+mcp-tool-list_container_items-desc = List all items inside a container (folder/project) across all its lists, with cursor-based pagination. Use this to browse the full contents of a container in one call instead of fetching each list separately. Set recursive=true to also include items from nested sub-containers, traversed depth-first.
 mcp-tool-list_containers-desc = List all your containers.
 mcp-tool-get_container-desc = Get details of a specific container by ID.
 mcp-tool-list_tags-desc = List all your tags.

--- a/locales/pl/mcp.ftl
+++ b/locales/pl/mcp.ftl
@@ -83,6 +83,7 @@ mcp-err-bad-uri = Nieprawidłowy URI zasobu: { $uri }.
 mcp-tool-list_lists-desc = Pobierz wszystkie listy.
 mcp-tool-get_list-desc = Pobierz szczegóły konkretnej listy po ID.
 mcp-tool-list_items-desc = Pobierz elementy listy z opcjonalną paginacją kursorową.
+mcp-tool-list_container_items-desc = Pobierz wszystkie elementy z kontenera (folderu/projektu) ze wszystkich jego list z paginacją kursorową. Używaj tego narzędzia, gdy chcesz przejrzeć całą zawartość kontenera jednym wywołaniem zamiast pobierać każdą listę osobno. Ustaw recursive=true, aby uwzględnić również elementy z zagnieżdżonych podkontenerów (przeszukiwanie depth-first).
 mcp-tool-list_containers-desc = Pobierz wszystkie kontenery.
 mcp-tool-get_container-desc = Pobierz szczegóły konkretnego kontenera po ID.
 mcp-tool-list_tags-desc = Pobierz wszystkie tagi.


### PR DESCRIPTION
## Summary

- Adds `list_container_items` MCP tool that returns all items across a container's lists in a single paginated call, eliminating the N+1 pattern (previously: `get_container` + `list_items` × N)
- Each result item is nested as `{ item, list_name, container_id, container_name }` providing full location context
- Supports `recursive=true` to traverse nested sub-containers depth-first via `WITH RECURSIVE` CTE with `sort_path`-based ordering

## Implementation

- **`crates/db/src/types.rs`** — new `ContainerItemRow` with `#[sqlx(flatten)]` over `ItemRow`
- **`crates/db/src/items.rs`** — new `list_for_container` with two SQL paths (simple JOIN vs CTE); uses `LIMIT`/`OFFSET` at DB level with `limit+1` fetch to determine `next_cursor` without a separate COUNT query
- **`crates/domain/src/items.rs`** — new `ContainerItem` type and `list_for_container` wrapper
- **`crates/mcp/src/server.rs`** — new `list_container_items` handler reusing `clamp_limit` and `Paged<T>`
- **`locales/{en,pl}/mcp.ftl`** — i18n descriptions for the new tool

## Test plan

- [ ] `just ci` passes (fmt + clippy + audit + machete + tests)
- [ ] `cargo test -p kartoteka-i18n` — all FTL completeness and MCP coverage tests pass
- [ ] Manual MCP call: `list_container_items(container_id)` returns items from all non-archived lists
- [ ] Pagination: `next_cursor` present when items exceed limit; second page returns correct items
- [ ] `recursive=true`: items from nested sub-containers appear in depth-first order

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)