### PR TITLE
feat(ui+mcp): add explicit move/detach UI for lists and containers

### DIFF
--- a/crates/frontend/src/components/common/container_selector_dropdown.rs
+++ b/crates/frontend/src/components/common/container_selector_dropdown.rs
@@ -1,0 +1,38 @@
+use kartoteka_shared::types::ContainerOption;
+use leptos::prelude::*;
+
+/// Floating dropdown list for selecting a move target container.
+///
+/// Caller controls visibility via `open` signal and provides pre-fetched `options`.
+/// The trigger button and "Detach" button live inline on each page — they differ per context.
+#[component]
+pub fn ContainerSelectorDropdown(
+    open: RwSignal<bool>,
+    options: Vec<ContainerOption>,
+    on_select: Callback<String>,
+) -> impl IntoView {
+    let opts = StoredValue::new(options);
+
+    view! {
+        <div
+            class="absolute right-0 top-full mt-1 bg-base-200 border border-base-300 rounded-box min-w-56 max-h-64 overflow-y-auto z-50 p-2 shadow-lg"
+            style:display=move || if open.get() { "block" } else { "none" }
+        >
+            {move || opts.get_value().into_iter().map(|opt| {
+                let cid = opt.id.clone();
+                view! {
+                    <button
+                        type="button"
+                        class="flex items-center px-2 py-1.5 text-sm rounded cursor-pointer hover:bg-base-300 w-full text-left"
+                        on:click=move |_| {
+                            open.set(false);
+                            on_select.run(cid.clone());
+                        }
+                    >
+                        {opt.path_label.clone()}
+                    </button>
+                }
+            }).collect::<Vec<_>>()}
+        </div>
+    }
+}

--- a/crates/frontend/src/components/common/mod.rs
+++ b/crates/frontend/src/components/common/mod.rs
@@ -1,5 +1,6 @@
 pub mod breadcrumbs;
 pub mod confirm_modal;
+pub mod container_selector_dropdown;
 pub mod dnd;
 pub mod editable_text;
 pub mod list_filter_chips;

--- a/crates/frontend/src/pages/container.rs
+++ b/crates/frontend/src/pages/container.rs
@@ -1,5 +1,5 @@
 use leptos::prelude::*;
-use leptos_fluent::I18n;
+use leptos_fluent::{I18n, move_tr};
 use leptos_router::hooks::{use_navigate, use_params_map};
 
 use crate::app::{ToastContext, ToastKind};
@@ -391,7 +391,7 @@ pub fn ContainerPage() -> impl IntoView {
                                                         <button
                                                             type="button"
                                                             class="btn btn-ghost btn-xs btn-circle text-error"
-                                                            title="Odepnij od rodzica"
+                                                            title=move_tr!("lists-detach-from-parent")
                                                             on:click=move |_| {
                                                                 let cid = current_id_for_move_sv.get_value();
                                                                 leptos::task::spawn_local(async move {
@@ -410,7 +410,7 @@ pub fn ContainerPage() -> impl IntoView {
                                                         <button
                                                             type="button"
                                                             class="btn btn-ghost btn-sm btn-square"
-                                                            title="Wnieś do kontenera"
+                                                            title=move_tr!("lists-move-to-parent")
                                                             on:click=move |_| container_dropdown_open.update(|v| *v = !*v)
                                                         >{"📁"}</button>
                                                         <ContainerSelectorDropdown

--- a/crates/frontend/src/pages/container.rs
+++ b/crates/frontend/src/pages/container.rs
@@ -6,6 +6,7 @@ use crate::app::{ToastContext, ToastKind};
 use crate::components::comments::CommentSection;
 use crate::components::common::breadcrumbs::Breadcrumbs;
 use crate::components::common::confirm_modal::{ConfirmModal, ConfirmVariant};
+use crate::components::common::container_selector_dropdown::ContainerSelectorDropdown;
 use crate::components::common::dnd::{DetachDropZone, ReorderDropTarget};
 use crate::components::common::editable_text::EditableText;
 use crate::components::common::loading::LoadingSpinner;
@@ -15,8 +16,8 @@ use crate::components::lists::{
 };
 use crate::context::GlobalRefresh;
 use crate::server_fns::containers::{
-    archive_container, create_container, delete_container, get_container_data, move_container,
-    rename_container, reorder_containers,
+    archive_container, create_container, delete_container, get_container_data,
+    get_containers_for_move, move_container, rename_container, reorder_containers,
 };
 use crate::server_fns::lists::{archive_list, create_list, delete_list, move_list, reorder_lists};
 use crate::state::dnd::{DndState, DropTarget, EntityKind};
@@ -45,6 +46,29 @@ pub fn ContainerPage() -> impl IntoView {
     let (refresh, set_refresh) = signal(0u32);
     let (expand_all, set_expand_all) = signal(false);
 
+    let container_dropdown_open = RwSignal::new(false);
+    // container_id in key_fn — Leptos tracks reactivity only in key_fn, not in the async block.
+    let containers_res = Resource::new(
+        move || (container_dropdown_open.get(), container_id.get()),
+        |(open, cid)| async move {
+            if open {
+                get_containers_for_move(Some(cid), true).await
+            } else {
+                Ok(vec![])
+            }
+        },
+    );
+    let on_move_container_to_parent = Callback::new(move |pid: String| {
+        let cid = container_id.get();
+        leptos::task::spawn_local(async move {
+            match move_container(cid, Some(pid)).await {
+                Ok(_) => global_refresh.bump(),
+                Err(e) => toast.push(e.to_string(), ToastKind::Error),
+            }
+            container_dropdown_open.set(false);
+        });
+    });
+
     let data_res = Resource::new(
         move || (container_id.get(), global_refresh.get(), refresh.get()),
         |(id, _, _)| get_container_data(id),
@@ -69,6 +93,10 @@ pub fn ContainerPage() -> impl IntoView {
                         let children = data.children.clone();
                         let parent_id = data.container.parent_container_id.clone();
                         let current_id = data.container.id.clone();
+                        let parent_name_sv = StoredValue::new(
+                            data.ancestors.last().map(|(_, n)| n.clone()),
+                        );
+                        let current_id_for_move_sv = StoredValue::new(data.container.id.clone());
                         let container_id_for_rename = data.container.id.clone();
                         let container_id_for_desc = data.container.id.clone();
                         let desc_for_rename = data.container.description.clone();
@@ -349,7 +377,51 @@ pub fn ContainerPage() -> impl IntoView {
                                             class="text-base-content/60 text-sm cursor-pointer hover:underline decoration-dotted"
                                         />
                                     </div>
-                                    <div class="flex gap-1">
+                                    <div class="flex gap-1 items-center">
+                                        // Reparent/detach UI
+                                        {move || {
+                                            let opts = containers_res.get().and_then(|r| r.ok()).unwrap_or_default();
+                                            if let Some(pname) = parent_name_sv.get_value() {
+                                                view! {
+                                                    <div class="flex items-center gap-1">
+                                                        <span class="text-xs text-base-content/60 flex items-center gap-1">
+                                                            "📁 "
+                                                            <span class="max-w-24 truncate">{pname}</span>
+                                                        </span>
+                                                        <button
+                                                            type="button"
+                                                            class="btn btn-ghost btn-xs btn-circle text-error"
+                                                            title="Odepnij od rodzica"
+                                                            on:click=move |_| {
+                                                                let cid = current_id_for_move_sv.get_value();
+                                                                leptos::task::spawn_local(async move {
+                                                                    match move_container(cid, None).await {
+                                                                        Ok(_) => global_refresh.bump(),
+                                                                        Err(e) => toast.push(e.to_string(), ToastKind::Error),
+                                                                    }
+                                                                });
+                                                            }
+                                                        >{"✕"}</button>
+                                                    </div>
+                                                }.into_any()
+                                            } else {
+                                                view! {
+                                                    <div class="relative">
+                                                        <button
+                                                            type="button"
+                                                            class="btn btn-ghost btn-sm btn-square"
+                                                            title="Wnieś do kontenera"
+                                                            on:click=move |_| container_dropdown_open.update(|v| *v = !*v)
+                                                        >{"📁"}</button>
+                                                        <ContainerSelectorDropdown
+                                                            open=container_dropdown_open
+                                                            options=opts
+                                                            on_select=on_move_container_to_parent
+                                                        />
+                                                    </div>
+                                                }.into_any()
+                                            }
+                                        }}
                                         <button
                                             type="button"
                                             class="btn btn-ghost btn-sm"

--- a/crates/frontend/src/pages/list/mod.rs
+++ b/crates/frontend/src/pages/list/mod.rs
@@ -10,6 +10,7 @@ use crate::app::{ToastContext, ToastKind};
 use crate::components::comments::CommentSection;
 use crate::components::common::breadcrumbs::Breadcrumbs;
 use crate::components::common::confirm_modal::{ConfirmModal, ConfirmVariant};
+use crate::components::common::container_selector_dropdown::ContainerSelectorDropdown;
 use crate::components::common::dnd::{DetachDropZone, ItemDropTargetMarker};
 use crate::components::common::editable_text::EditableText;
 use crate::components::common::loading::LoadingSpinner;
@@ -21,6 +22,7 @@ use crate::components::lists::{
 use crate::components::tags::tag_filter_bar::TagFilterBar;
 use crate::components::tags::tag_list::TagList;
 use crate::context::GlobalRefresh;
+use crate::server_fns::containers::get_containers_for_move;
 use crate::server_fns::items::{
     delete_item, get_list_data, move_item, reorder_items, set_item_placement, toggle_item,
     update_actual_quantity, update_item_dates, update_item_description,
@@ -83,6 +85,31 @@ pub fn ListPage() -> impl IntoView {
         move || (refresh.get(), global_refresh.get()),
         |_| get_all_lists(),
     );
+
+    let container_dropdown_open = RwSignal::new(false);
+    let containers_res = Resource::new(
+        move || container_dropdown_open.get(),
+        |open| async move {
+            if open {
+                get_containers_for_move(None, false).await
+            } else {
+                Ok(vec![])
+            }
+        },
+    );
+    let on_move_to_container = Callback::new(move |cid: String| {
+        let lid = list_id();
+        leptos::task::spawn_local(async move {
+            match move_list(lid, Some(cid), None).await {
+                Ok(_) => {
+                    set_refresh.update(|n| *n += 1);
+                    global_refresh.bump();
+                }
+                Err(e) => toast.push(e.to_string(), ToastKind::Error),
+            }
+            container_dropdown_open.set(false);
+        });
+    });
 
     let on_tag_toggle = Callback::new(move |tag_id: String| {
         let lid = list_id();
@@ -308,6 +335,7 @@ pub fn ListPage() -> impl IntoView {
                         let all_tags_for_selector = data.all_tags.clone();
                         let list_tag_ids = data.list_tag_ids.clone();
                         let today_date = data.today_date.clone();
+                        let container_name_sv = StoredValue::new(data.container_name.clone());
                         let breadcrumb_crumbs = if let Some(ref cname) = data.container_name {
                             let cid = data.list.container_id.clone().unwrap_or_default();
                             vec![(format!("/containers/{cid}"), cname.clone())]
@@ -356,6 +384,50 @@ pub fn ListPage() -> impl IntoView {
                                         class="text-2xl font-bold cursor-pointer hover:underline decoration-dotted"
                                         testid="list-name-heading"
                                     />
+                                    // Container move/detach
+                                    {move || {
+                                        let opts = containers_res.get().and_then(|r| r.ok()).unwrap_or_default();
+                                        if let Some(cname) = container_name_sv.get_value() {
+                                            view! {
+                                                <div class="flex items-center gap-1 shrink-0">
+                                                    <span class="text-xs text-base-content/60 flex items-center gap-1">
+                                                        "📦 "
+                                                        <span class="max-w-28 truncate">{cname}</span>
+                                                    </span>
+                                                    <button
+                                                        type="button"
+                                                        class="btn btn-ghost btn-xs btn-circle text-error"
+                                                        title="Odepnij od kontenera"
+                                                        on:click=move |_| {
+                                                            let lid = list_id();
+                                                            leptos::task::spawn_local(async move {
+                                                                match move_list(lid, None, None).await {
+                                                                    Ok(_) => { set_refresh.update(|n| *n += 1); global_refresh.bump(); }
+                                                                    Err(e) => toast.push(e.to_string(), ToastKind::Error),
+                                                                }
+                                                            });
+                                                        }
+                                                    >{"✕"}</button>
+                                                </div>
+                                            }.into_any()
+                                        } else {
+                                            view! {
+                                                <div class="relative shrink-0">
+                                                    <button
+                                                        type="button"
+                                                        class="btn btn-ghost btn-xs btn-square"
+                                                        title="Przenieś do kontenera"
+                                                        on:click=move |_| container_dropdown_open.update(|v| *v = !*v)
+                                                    >{"📦"}</button>
+                                                    <ContainerSelectorDropdown
+                                                        open=container_dropdown_open
+                                                        options=opts
+                                                        on_select=on_move_to_container
+                                                    />
+                                                </div>
+                                            }.into_any()
+                                        }
+                                    }}
                                     // Dropdown at the end, pushed right via ml-auto
                                     <div class="dropdown dropdown-end ml-auto">
                                         <div tabindex="0" role="button" class="btn btn-ghost btn-sm btn-circle" data-testid="list-actions-btn">

--- a/crates/frontend/src/pages/list/mod.rs
+++ b/crates/frontend/src/pages/list/mod.rs
@@ -397,7 +397,7 @@ pub fn ListPage() -> impl IntoView {
                                                     <button
                                                         type="button"
                                                         class="btn btn-ghost btn-xs btn-circle text-error"
-                                                        title="Odepnij od kontenera"
+                                                        title=move_tr!("lists-detach-from-container")
                                                         on:click=move |_| {
                                                             let lid = list_id();
                                                             leptos::task::spawn_local(async move {
@@ -416,7 +416,7 @@ pub fn ListPage() -> impl IntoView {
                                                     <button
                                                         type="button"
                                                         class="btn btn-ghost btn-xs btn-square"
-                                                        title="Przenieś do kontenera"
+                                                        title=move_tr!("lists-move-to-container")
                                                         on:click=move |_| container_dropdown_open.update(|v| *v = !*v)
                                                     >{"📦"}</button>
                                                     <ContainerSelectorDropdown

--- a/crates/frontend/src/server_fns/containers.rs
+++ b/crates/frontend/src/server_fns/containers.rs
@@ -1,8 +1,8 @@
 #[cfg(not(feature = "ssr"))]
-use kartoteka_shared::types::{Container, ContainerData, CreateContainerRequest};
+use kartoteka_shared::types::{Container, ContainerData, ContainerOption, CreateContainerRequest};
 #[cfg(feature = "ssr")]
 use kartoteka_shared::types::{
-    Container, ContainerData, CreateContainerRequest, List, UpdateContainerRequest,
+    Container, ContainerData, ContainerOption, CreateContainerRequest, List, UpdateContainerRequest,
 };
 use leptos::prelude::*;
 
@@ -185,6 +185,87 @@ pub async fn get_container_data(container_id: String) -> Result<ContainerData, S
         children,
         ancestors,
     })
+}
+
+/// Returns containers available as move targets, with pre-built path labels.
+///
+/// - `exclude_subtree_of`: exclude this container and all its descendants (used when moving a
+///   container to avoid self-reference or cycles).
+/// - `folders_only`: when true, only return containers with `status IS NULL` (folders). Containers
+///   with a status are projects and cannot be parents of other containers per hierarchy rules.
+#[server(prefix = "/leptos")]
+pub async fn get_containers_for_move(
+    exclude_subtree_of: Option<String>,
+    folders_only: bool,
+) -> Result<Vec<ContainerOption>, ServerFnError> {
+    let pool = expect_context::<SqlitePool>();
+    let auth = leptos_axum::extract::<AuthSession<KartotekaBackend>>()
+        .await
+        .map_err(|_| ServerFnError::new("auth extraction failed".to_string()))?;
+    let user = auth
+        .user
+        .ok_or_else(|| ServerFnError::new("unauthorized".to_string()))?;
+
+    let all = domain::containers::list_all(&pool, &user.id)
+        .await
+        .map_err(|e| ServerFnError::new(e.to_string()))?;
+
+    // BFS to collect the excluded subtree (self + all descendants).
+    let excluded: std::collections::HashSet<String> = if let Some(ref root_id) = exclude_subtree_of
+    {
+        let mut set = std::collections::HashSet::new();
+        set.insert(root_id.clone());
+        let mut changed = true;
+        while changed {
+            changed = false;
+            for c in &all {
+                if !set.contains(&c.id) {
+                    if let Some(ref pid) = c.parent_container_id {
+                        if set.contains(pid) {
+                            set.insert(c.id.clone());
+                            changed = true;
+                        }
+                    }
+                }
+            }
+        }
+        set
+    } else {
+        std::collections::HashSet::new()
+    };
+
+    let mut options: Vec<ContainerOption> = all
+        .iter()
+        .filter(|c| !excluded.contains(&c.id))
+        .filter(|c| !folders_only || c.status.is_none())
+        .map(|c| {
+            let path_label = build_path_label(c, &all);
+            ContainerOption {
+                id: c.id.clone(),
+                path_label,
+            }
+        })
+        .collect();
+
+    options.sort_by(|a, b| a.path_label.cmp(&b.path_label));
+    Ok(options)
+}
+
+#[cfg(feature = "ssr")]
+fn build_path_label(container: &Container, all: &[Container]) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    let mut current = container.parent_container_id.as_deref();
+    for _ in 0..10 {
+        let Some(pid) = current else { break };
+        let Some(parent) = all.iter().find(|c| c.id == pid) else {
+            break;
+        };
+        parts.push(parent.name.clone());
+        current = parent.parent_container_id.as_deref();
+    }
+    parts.reverse();
+    parts.push(container.name.clone());
+    parts.join(" / ")
 }
 
 #[cfg(feature = "ssr")]

--- a/crates/mcp/src/server.rs
+++ b/crates/mcp/src/server.rs
@@ -1214,6 +1214,11 @@ impl KartotekaServer {
         Parameters(p): Parameters<MoveListToContainerParams>,
     ) -> Result<CallToolResult, ErrorData> {
         let (uid, locale) = self.auth(&parts)?;
+        if let Some(ref cid) = p.container_id {
+            domain::containers::get_one(&self.pool, cid, &uid)
+                .await
+                .map_err(self.domain_err(&locale))?;
+        }
         let position = db::lists::next_position(&self.pool, &uid, p.container_id.as_deref(), None)
             .await
             .map_err(self.db_err(&locale))?;

--- a/crates/mcp/src/server.rs
+++ b/crates/mcp/src/server.rs
@@ -3,7 +3,7 @@ use kartoteka_db::{self as db, lists::InsertListInput};
 use kartoteka_domain as domain;
 use kartoteka_shared::{
     auth_ctx::{UserId, UserLocale},
-    types::CreateContainerRequest,
+    types::{CreateContainerRequest, MoveContainerRequest},
 };
 use rmcp::{
     ErrorData, RoleServer, ServerHandler,
@@ -35,6 +35,7 @@ use crate::tools::{
         CreateContainerParams, CreateContainersParams, CreateItemParams, CreateItemsParams,
         CreateListParams, CreateListsParams, UpdateItemParams,
     },
+    movement::{MoveContainerToParentParams, MoveListToContainerParams},
     read::{
         GetContainerParams, GetItemParams, GetListParams, ListContainerItemsParams, ListItemsParams,
     },
@@ -1198,6 +1199,60 @@ impl KartotekaServer {
 
         tx.commit().await.map_err(self.sqlx_err(&locale))?;
         self.json_result(result, &locale)
+    }
+
+    // ── Movement tools ────────────────────────────────────────────────────────
+
+    #[rmcp::tool(
+        name = "move_list_to_container",
+        description = "mcp-tool-move_list_to_container-desc"
+    )]
+    #[tracing::instrument(skip(self, parts), fields(action = "mcp_move_list_to_container"))]
+    async fn move_list_to_container(
+        &self,
+        Extension(parts): Extension<Parts>,
+        Parameters(p): Parameters<MoveListToContainerParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let (uid, locale) = self.auth(&parts)?;
+        let position = db::lists::next_position(&self.pool, &uid, p.container_id.as_deref(), None)
+            .await
+            .map_err(self.db_err(&locale))?;
+        let req = domain::lists::MoveListRequest {
+            position,
+            container_id: p.container_id,
+            parent_list_id: None,
+        };
+        let list = domain::lists::move_list(&self.pool, &p.list_id, &uid, &req)
+            .await
+            .map_err(self.domain_err(&locale))?
+            .ok_or_else(|| {
+                self.map_err(
+                    McpError::Domain(domain::DomainError::NotFound("list")),
+                    &locale,
+                )
+            })?;
+        self.json_result(list, &locale)
+    }
+
+    #[rmcp::tool(
+        name = "move_container_to_parent",
+        description = "mcp-tool-move_container_to_parent-desc"
+    )]
+    #[tracing::instrument(skip(self, parts), fields(action = "mcp_move_container_to_parent"))]
+    async fn move_container_to_parent(
+        &self,
+        Extension(parts): Extension<Parts>,
+        Parameters(p): Parameters<MoveContainerToParentParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let (uid, locale) = self.auth(&parts)?;
+        let req = MoveContainerRequest {
+            parent_container_id: p.parent_container_id,
+            position: None,
+        };
+        let container = domain::containers::move_container(&self.pool, &p.container_id, &uid, &req)
+            .await
+            .map_err(self.domain_err(&locale))?;
+        self.json_result(container, &locale)
     }
 }
 

--- a/crates/mcp/src/server/annotations.rs
+++ b/crates/mcp/src/server/annotations.rs
@@ -38,7 +38,13 @@ const ADDITIVE_WRITE: &[&str] = &[
     "save_as_template",
 ];
 
-const DESTRUCTIVE: &[&str] = &["update_item", "remove_relation", "stop_timer"];
+const DESTRUCTIVE: &[&str] = &[
+    "update_item",
+    "remove_relation",
+    "stop_timer",
+    "move_list_to_container",
+    "move_container_to_parent",
+];
 
 pub fn for_tool(name: &str) -> ToolAnnotations {
     let mut ann = ToolAnnotations::default();

--- a/crates/mcp/src/tools/mod.rs
+++ b/crates/mcp/src/tools/mod.rs
@@ -1,5 +1,6 @@
 pub mod comments;
 pub mod items;
+pub mod movement;
 pub mod read;
 pub mod relations;
 pub mod search;

--- a/crates/mcp/src/tools/movement.rs
+++ b/crates/mcp/src/tools/movement.rs
@@ -1,0 +1,16 @@
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct MoveListToContainerParams {
+    pub list_id: String,
+    /// ID of the container to move the list into. Pass null to detach the list from its current container.
+    pub container_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct MoveContainerToParentParams {
+    pub container_id: String,
+    /// ID of the parent container to nest this container under. Pass null to move the container to root level.
+    pub parent_container_id: Option<String>,
+}

--- a/crates/shared/src/types.rs
+++ b/crates/shared/src/types.rs
@@ -505,6 +505,14 @@ pub struct ContainerData {
     pub ancestors: Vec<(String, String)>,
 }
 
+/// A container option for move/reparent dropdowns with a pre-built display path.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContainerOption {
+    pub id: String,
+    /// Human-readable path label, e.g. "Projekty / Kwiecień" — built server-side.
+    pub path_label: String,
+}
+
 // --- Templates ---
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/locales/en/lists.ftl
+++ b/locales/en/lists.ftl
@@ -85,6 +85,12 @@ lists-collapse-all = Collapse all
 lists-preview-open-full = Open full view
 lists-preview-new-item-placeholder = New item...
 
+# Container / parent move-detach UI
+lists-move-to-container = Move to container
+lists-detach-from-container = Detach from container
+lists-move-to-parent = Move to parent
+lists-detach-from-parent = Detach from parent
+
 # Toasts
 lists-toast-container-deleted = Container deleted
 lists-toast-list-deleted = List deleted

--- a/locales/en/mcp.ftl
+++ b/locales/en/mcp.ftl
@@ -103,3 +103,6 @@ mcp-tool-create_container-desc = Create a single folder (omit status) or project
 mcp-tool-create_items-desc = Append multiple items to one list atomically. Provide list_id once at the top level; all items go into that list in the given order.
 mcp-tool-create_lists-desc = Create multiple lists atomically. Use container_ref to reference a container created in a prior create_containers call (set client_ref on it first). Use parent_list_ref to nest under a list created earlier in this same batch. Forward-only references within a batch.
 mcp-tool-create_containers-desc = Create multiple folders/projects atomically. Use parent_container_ref to nest under a container created earlier in this same batch (set client_ref on the parent first). Forward-only: cannot reference an item later in the array.
+
+mcp-tool-move_list_to_container-desc = Move a list into a container, or detach it from its current container (container_id: null).
+mcp-tool-move_container_to_parent-desc = Move a container under a parent folder, or detach to root level (parent_container_id: null). Only folders (status null) are valid parents.

--- a/locales/pl/lists.ftl
+++ b/locales/pl/lists.ftl
@@ -85,6 +85,12 @@ lists-collapse-all = Zwiń wszystkie
 lists-preview-open-full = Otwórz pełny widok
 lists-preview-new-item-placeholder = Nowy element...
 
+# UI przenoszenia listy / kontenera do rodzica
+lists-move-to-container = Przenieś do kontenera
+lists-detach-from-container = Odepnij od kontenera
+lists-move-to-parent = Wnieś do kontenera
+lists-detach-from-parent = Odepnij od rodzica
+
 # Toasty
 lists-toast-container-deleted = Kontener usunięty
 lists-toast-list-deleted = Lista usunięta

--- a/locales/pl/mcp.ftl
+++ b/locales/pl/mcp.ftl
@@ -103,3 +103,6 @@ mcp-tool-create_container-desc = Utwórz pojedynczy folder (bez status) lub proj
 mcp-tool-create_items-desc = Dodaj wiele elementów do jednej listy atomowo. Podaj list_id raz na poziomie głównym; wszystkie elementy trafiają do tej listy w podanej kolejności.
 mcp-tool-create_lists-desc = Utwórz wiele list atomowo. Użyj container_ref aby odwołać się do kontenera z poprzedniego wywołania create_containers (ustaw na nim client_ref). Użyj parent_list_ref aby zagnieździć pod listą z tego samego batcha. Referencje tylko do wcześniejszych elementów.
 mcp-tool-create_containers-desc = Utwórz wiele folderów/projektów atomowo. Użyj parent_container_ref aby zagnieździć pod kontenerem z wcześniej w tym samym batchu (ustaw client_ref na rodzicu). Tylko referencje do wcześniejszych elementów w tablicy.
+
+mcp-tool-move_list_to_container-desc = Przenieś listę do kontenera lub odepnij ją od bieżącego (container_id: null).
+mcp-tool-move_container_to_parent-desc = Wnieś kontener do folderu-rodzica lub odepnij do poziomu głównego (parent_container_id: null). Tylko foldery (bez status) mogą być rodzicem.


### PR DESCRIPTION
Closes #234, closes #235

## Summary

- **List page header** (#234): shows `📦 ContainerName ✕` badge when the list is in a container (click ✕ to detach); shows `📦` move button otherwise — opens a searchable dropdown of containers with server-built path labels (`"Projects / April"`)
- **Container page header** (#235): shows `📁 ParentName ✕` badge when the container is nested (click ✕ to move to root); shows `📁` reparent button otherwise — dropdown filtered to folders only (projects excluded per hierarchy rules)
- **MCP tools**: `move_list_to_container(list_id, container_id?)` and `move_container_to_parent(container_id, parent_container_id?)` — `null` detaches in both cases

## Implementation details

- `ContainerOption { id, path_label }` — new shared type; path labels built server-side for use in both UI and MCP
- `get_containers_for_move(exclude_subtree_of, folders_only)` server fn:
  - BFS in-memory subtree exclusion (no extra DB calls) to prevent cycles
  - `folders_only=true` for container reparenting (enforces `validate_hierarchy`)
  - Fetch-on-open pattern: `Resource::new(|| dropdown_open.get(), ...)` — no eager load
- `ContainerSelectorDropdown` — shared component in `components/common/`; caller passes `open` signal and pre-fetched options
- Container page resource key includes `container_id` signal to preserve Leptos reactivity across navigation

## Test plan

- [ ] List without container → click 📦 → dropdown opens with path-labeled options → select → header shows badge
- [ ] List in container → click ✕ → header reverts to move button
- [ ] Container without parent → click 📁 → dropdown shows only folders (no projects) and excludes self + descendants
- [ ] Container with parent → click ✕ → moves to root
- [ ] MCP: `move_list_to_container(list_id, container_id)` and `move_list_to_container(list_id, null)`
- [ ] MCP: `move_container_to_parent(container_id, parent_id)` and `move_container_to_parent(container_id, null)`
- [ ] `just ci` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)