### PR TITLE
chore: gitignore local ops scripts and debug dumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,13 @@ tests/test-results-debug/
 *.log
 
 CLAUDE.local.md
+
+# Temp debug/analysis dumps (browser console, network, hydration captures)
+console-*.md
+network-*.md
+hydration-*.json
+page-*.json
+
+# Local ops scripts (zawierają URL-e infrastruktury)
+scripts/coolify-*.sh
+scripts/coolify-*.py

--- a/justfile
+++ b/justfile
@@ -50,11 +50,6 @@ build:
 deploy-preview:
     bash scripts/deploy-preview.sh
 
-# Pobierz logi z Coolify. Bez argumentów: lista aplikacji z UUID-ami.
-# Z UUID: just logs <uuid> [liczba-linii]
-logs *args:
-    bash scripts/coolify-logs.sh {{args}}
-
 # === QUALITY ===
 
 lint:

--- a/justfile
+++ b/justfile
@@ -50,6 +50,11 @@ build:
 deploy-preview:
     bash scripts/deploy-preview.sh
 
+# Pobierz logi z Coolify. Bez argumentów: lista aplikacji z UUID-ami.
+# Z UUID: just logs <uuid> [liczba-linii]
+logs *args:
+    bash scripts/coolify-logs.sh {{args}}
+
 # === QUALITY ===
 
 lint:


### PR DESCRIPTION
## Summary

- `.gitignore`: ignores `scripts/coolify-*.sh` / `scripts/coolify-*.py` (local ops tools containing infra URLs, not for the repo) and browser debug dump patterns (`console-*`, `network-*`, `hydration-*`, `page-*.json`)

## Test plan

- [ ] debug dump files are no longer shown in `git status`
- [ ] coolify scripts remain local-only