### PR TITLE
fix(frontend): reduce CommentSection to single SSR request via CommentsPayload

### DIFF
--- a/crates/frontend/src/components/comments/mod.rs
+++ b/crates/frontend/src/components/comments/mod.rs
@@ -1,46 +1,23 @@
 pub mod add_comment;
 pub mod comment_list;
 
-use kartoteka_shared::types::Comment;
 use leptos::prelude::*;
+use leptos_fluent::move_tr;
 
 use crate::app::{ToastContext, ToastKind};
 use crate::components::comments::add_comment::AddComment;
 use crate::components::comments::comment_list::CommentList;
-use crate::server_fns::comments::{get_comments, get_current_user_id, remove_comment};
+use crate::server_fns::comments::{get_comments, remove_comment};
 
-/// Self-contained comments section: loads, displays, and adds comments for any entity.
-/// Uses spawn_local + signals (not Resource) so SSR renders an empty marker that the
-/// client hydrates cleanly, then fetches data after mount.
 #[component]
 pub fn CommentSection(entity_type: &'static str, entity_id: Signal<String>) -> impl IntoView {
     let toast = use_context::<ToastContext>().expect("ToastContext missing");
     let (refresh, set_refresh) = signal(0u32);
 
-    // None = not yet loaded; Some((comments, uid)) = loaded.
-    // SSR never sets this (Effect is client-only), so SSR and initial client both start at None
-    // → consistent hydration, no marker/element mismatch.
-    let (loaded, set_loaded) = signal(None::<(Vec<Comment>, String)>);
-    let (fetch_error, set_fetch_error) = signal(None::<String>);
-
-    Effect::new(move |_| {
-        let eid = entity_id.get();
-        let _ = refresh.get();
-        set_fetch_error.set(None);
-        leptos::task::spawn_local(async move {
-            let uid = match get_current_user_id().await {
-                Ok(u) => u,
-                Err(e) => {
-                    set_fetch_error.set(Some(e.to_string()));
-                    return;
-                }
-            };
-            match get_comments(entity_type.to_string(), eid).await {
-                Ok(cs) => set_loaded.set(Some((cs, uid))),
-                Err(e) => set_fetch_error.set(Some(e.to_string())),
-            }
-        });
-    });
+    let comments_res = Resource::new(
+        move || (entity_id.get(), refresh.get()),
+        move |(eid, _)| get_comments(entity_type.to_string(), eid),
+    );
 
     let on_added = Callback::new(move |_: ()| set_refresh.update(|n| *n += 1));
 
@@ -56,18 +33,24 @@ pub fn CommentSection(entity_type: &'static str, entity_id: Signal<String>) -> i
     view! {
         <div class="mt-6">
             <h3 class="text-sm font-semibold text-base-content/60 uppercase tracking-wide mb-3">
-                "Komentarze"
+                {move_tr!("comments-section-title")}
             </h3>
 
-            {move || match (fetch_error.get(), loaded.get()) {
-                (Some(e), _) => view! {
-                    <p class="text-error text-sm">"Błąd: " {e}</p>
-                }.into_any(),
-                (_, Some((cs, uid))) => view! {
-                    <CommentList comments=cs current_user_id=uid on_delete=on_delete />
-                }.into_any(),
-                _ => view! {}.into_any(),
-            }}
+            <Suspense fallback=|| view! { <span class="loading loading-dots loading-xs"></span> }>
+                {move || match comments_res.get() {
+                    Some(Ok(payload)) => view! {
+                        <CommentList
+                            comments=payload.comments
+                            current_user_id=payload.current_user_id
+                            on_delete=on_delete
+                        />
+                    }.into_any(),
+                    Some(Err(e)) => view! {
+                        <p class="text-error text-sm">{move_tr!("error-prefix")} " " {e.to_string()}</p>
+                    }.into_any(),
+                    None => view! {}.into_any(),
+                }}
+            </Suspense>
 
             <AddComment
                 entity_type=Signal::derive(move || entity_type.to_string())

--- a/crates/frontend/src/server_fns/comments.rs
+++ b/crates/frontend/src/server_fns/comments.rs
@@ -1,4 +1,4 @@
-use kartoteka_shared::types::Comment;
+use kartoteka_shared::types::{Comment, CommentsPayload};
 use leptos::prelude::*;
 
 #[cfg(feature = "ssr")]
@@ -26,7 +26,7 @@ fn domain_comment_to_shared(c: domain::comments::Comment, tz: &str) -> Comment {
 pub async fn get_comments(
     entity_type: String,
     entity_id: String,
-) -> Result<Vec<Comment>, ServerFnError> {
+) -> Result<CommentsPayload, ServerFnError> {
     let pool = expect_context::<SqlitePool>();
     let auth = leptos_axum::extract::<AuthSession<KartotekaBackend>>()
         .await
@@ -39,10 +39,13 @@ pub async fn get_comments(
         domain::preferences::get(&pool, &user.id),
     )
     .map_err(|e| ServerFnError::new(e.to_string()))?;
-    Ok(comments
-        .into_iter()
-        .map(|c| domain_comment_to_shared(c, &prefs.timezone))
-        .collect())
+    Ok(CommentsPayload {
+        comments: comments
+            .into_iter()
+            .map(|c| domain_comment_to_shared(c, &prefs.timezone))
+            .collect(),
+        current_user_id: user.id,
+    })
 }
 
 #[server(prefix = "/leptos")]
@@ -91,15 +94,4 @@ pub async fn remove_comment(comment_id: String) -> Result<(), ServerFnError> {
         .await
         .map_err(|e| ServerFnError::new(e.to_string()))?;
     Ok(())
-}
-
-#[server(prefix = "/leptos")]
-pub async fn get_current_user_id() -> Result<String, ServerFnError> {
-    let auth = leptos_axum::extract::<AuthSession<KartotekaBackend>>()
-        .await
-        .map_err(|_| ServerFnError::new("auth extraction failed".to_string()))?;
-    let user = auth
-        .user
-        .ok_or_else(|| ServerFnError::new("unauthorized".to_string()))?;
-    Ok(user.id)
 }

--- a/crates/shared/src/types.rs
+++ b/crates/shared/src/types.rs
@@ -417,6 +417,12 @@ pub struct Comment {
     pub updated_at: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommentsPayload {
+    pub comments: Vec<Comment>,
+    pub current_user_id: String,
+}
+
 // --- Relations ---
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/locales/en/common.ftl
+++ b/locales/en/common.ftl
@@ -1,4 +1,5 @@
 common-loading = Loading...
+comments-section-title = Comments
 common-cancel = Cancel
 common-delete = Delete
 common-save = Save

--- a/locales/en/errors.ftl
+++ b/locales/en/errors.ftl
@@ -1,4 +1,5 @@
 error-network = Network error: { $detail }
+error-prefix = Error:
 error-login-failed = Login error ({ $status })
 error-unauthorized = Unauthorized
 error-not-found = Not found

--- a/locales/pl/common.ftl
+++ b/locales/pl/common.ftl
@@ -1,4 +1,5 @@
 common-loading = Wczytywanie...
+comments-section-title = Komentarze
 common-cancel = Anuluj
 common-delete = Usuń
 common-save = Zapisz

--- a/locales/pl/errors.ftl
+++ b/locales/pl/errors.ftl
@@ -1,4 +1,5 @@
 error-network = Błąd sieci: { $detail }
+error-prefix = Błąd:
 error-login-failed = Błąd logowania ({ $status })
 error-unauthorized = Brak dostępu
 error-not-found = Nie znaleziono


### PR DESCRIPTION
## Summary

- Merge `get_current_user_id` into `get_comments` → new `CommentsPayload { comments, current_user_id }` struct in `crates/shared`
- Switch `CommentSection` from two `Resource`s (two HTTP round-trips) to one `Resource` returning `CommentsPayload`
- Comments now rendered SSR via `Resource` + `<Suspense>` (consistent with `RelatedEntities`)
- Remove `get_current_user_id` server fn (was only used in this component)
- Move hardcoded strings through i18n (`comments-section-title`, `error-prefix`)
- Fix pre-existing `clippy::manual_filter` in `items.rs`

## Test Plan

- [ ] `just check` — clean compile
- [ ] `just test` — all pass
- [ ] Manual: open item/list/container detail page — comments visible in View Source (SSR)
- [ ] Server logs show single `db::comments::list_for_entity` per page load
- [ ] Add and delete a comment — refresh works correctly

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)