### PR TITLE
chore: add just logs recipe for Coolify log fetching

### DIFF
--- a/justfile
+++ b/justfile
@@ -50,6 +50,10 @@ build:
 deploy-preview:
     bash scripts/deploy-preview.sh
 
+# Pokaż logi z Coolify: just logs [prod|preview|develop] [lines] [filter]
+logs env="preview" lines="100" filter="":
+    bash scripts/coolify-logs.sh {{env}} {{lines}} {{filter}}
+
 # === QUALITY ===
 
 lint:


### PR DESCRIPTION
## Summary

- Add `logs` recipe to justfile wrapping `scripts/coolify-logs.sh`
- `just` already uses `set dotenv-load` so env vars load cleanly (no shell quoting issues with `|` in token values)

Usage:
```
just logs preview 50 list_for_entity
just logs prod 100
just logs develop 200 error
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)