### PR TITLE
feat(observability): add TraceLayer, per-env log levels, and parser action fix

### DIFF
--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -15,6 +15,8 @@ pub mod time_entries;
 pub use error::AppError;
 pub use extractors::UserId;
 
+use std::sync::Arc;
+
 use axum::{
     Router,
     body::Body,
@@ -27,7 +29,11 @@ use kartoteka_mcp::McpI18n;
 use kartoteka_oauth::OAuthState;
 use leptos::prelude::*;
 use leptos_axum::{AxumRouteListing, LeptosRoutes, generate_route_list};
-use std::sync::Arc;
+use tower_http::{
+    LatencyUnit,
+    trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer},
+};
+use tracing::Level;
 
 /// Application state shared across all handlers.
 /// `axum_macros::FromRef` allows individual fields to be extracted as `State<T>`.
@@ -200,5 +206,14 @@ pub fn router(
         // Static asset serving from target/site
         .fallback(leptos_axum::file_and_error_handler::<AppState, _>(shell))
         .layer(auth_layer)
+        .layer(
+            TraceLayer::new_for_http()
+                .make_span_with(DefaultMakeSpan::new().level(Level::INFO))
+                .on_response(
+                    DefaultOnResponse::new()
+                        .level(Level::INFO)
+                        .latency_unit(LatencyUnit::Millis),
+                ),
+        )
         .with_state(state)
 }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -5,21 +5,28 @@ use tower_sessions_sqlx_store::SqliteStore;
 
 #[tokio::main]
 async fn main() {
-    let default_filter =
-        "kartoteka_server=debug,kartoteka_domain=debug,kartoteka_db=debug,tower_http=debug";
+    let app_env = std::env::var("APP_ENV").unwrap_or_default();
+    let default_filter = match app_env.as_str() {
+        "production" => "kartoteka_server=info,tower_http=info,sqlx=warn",
+        "preview" => "kartoteka_server=trace,tower_http=trace,sqlx=debug",
+        _ => "kartoteka_server=debug,tower_http=debug,sqlx=debug",
+    };
     let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| default_filter.into());
 
-    if std::env::var("APP_ENV").as_deref() == Ok("production") {
-        tracing_subscriber::fmt()
-            .with_env_filter(env_filter)
-            .json()
-            .init();
-    } else {
-        tracing_subscriber::fmt()
-            .with_env_filter(env_filter)
-            .pretty()
-            .init();
+    match app_env.as_str() {
+        "production" | "preview" => {
+            tracing_subscriber::fmt()
+                .with_env_filter(env_filter)
+                .json()
+                .init();
+        }
+        _ => {
+            tracing_subscriber::fmt()
+                .with_env_filter(env_filter)
+                .pretty()
+                .init();
+        }
     }
 
     let db_url = std::env::var("DATABASE_URL").unwrap_or_else(|_| "sqlite://data.db".into());


### PR DESCRIPTION
## Summary

- **TraceLayer**: Added as the outermost Axum router layer — every HTTP request (including Leptos SSR/server functions) now emits an INFO log with method, URI, status, and latency in milliseconds. No Cookie/Authorization headers are logged.
- **Log levels per environment**: Split hardcoded default filter into three `APP_ENV`-driven branches — `production` (info/JSON), `preview` (trace/JSON), `develop` (debug/pretty). `RUST_LOG` env var still overrides.
- **Log parser**: `scripts/coolify-parse-logs.py` now surfaces handler `action` fields from ancestor `spans[]`, not just the immediate span (which is typically a sqlx internal).

Closes #242.

## Test Plan

- [ ] Deploy to preview — confirm a page load produces a log line with `method`, `uri`, `status`, and `latency_ms` fields
- [ ] Confirm no `Cookie` or `Authorization` values appear in logs
- [ ] Set `APP_ENV=production` locally, verify JSON format and `tower_http=info` level
- [ ] Run `python3 scripts/coolify-parse-logs.py` against a real Coolify log dump — verify `action=` appears for handler spans

🤖 Generated with [Claude Code](https://claude.com/claude-code)