### PR TITLE
fix(server): reject file-like path segments before Leptos router

### DIFF
--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -4,6 +4,7 @@ pub mod extractors;
 pub mod health;
 pub mod items;
 pub mod lists;
+mod middleware;
 pub mod relations;
 pub mod routes;
 pub mod search;
@@ -215,5 +216,8 @@ pub fn router(
                         .latency_unit(LatencyUnit::Millis),
                 ),
         )
+        .layer(axum::middleware::from_fn(
+            middleware::reject_file_like_paths,
+        ))
         .with_state(state)
 }

--- a/crates/server/src/middleware.rs
+++ b/crates/server/src/middleware.rs
@@ -8,9 +8,13 @@ use axum::{
 /// Paths whose segments legitimately contain dots (e.g. /pkg/app-hash.js).
 const DOTTED_SEGMENT_ALLOWLIST: &[&str] = &["/pkg/"];
 
-/// Rejects requests where any URL path segment looks like a filename (contains a dot
+/// Rejects requests where a nested URL path segment looks like a filename (contains a dot
 /// but does not start with one). App-level IDs are UUIDs and never contain dots;
 /// static-file names always do. Short-circuits before Leptos SSR runs DB queries.
+///
+/// Root-level paths like `/favicon.ico` are left through — only nested segments
+/// (depth ≥ 2) are checked, so `/lists/installHook.js.map` is caught but `/favicon.ico`
+/// is not.
 pub async fn reject_file_like_paths(req: Request<Body>, next: Next) -> Response {
     let path = req.uri().path();
 
@@ -21,7 +25,15 @@ pub async fn reject_file_like_paths(req: Request<Body>, next: Next) -> Response 
         return next.run(req).await;
     }
 
-    if path.split('/').any(is_file_like_segment) {
+    // Skip the first non-empty segment so root-level static files (/favicon.ico,
+    // /robots.txt) pass through to the fallback handler.
+    let has_file_like_nested = path
+        .split('/')
+        .filter(|s| !s.is_empty())
+        .skip(1)
+        .any(is_file_like_segment);
+
+    if has_file_like_nested {
         return StatusCode::NOT_FOUND.into_response();
     }
 
@@ -99,6 +111,23 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .uri("/pkg/app-abc123.js")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+    }
+
+    #[tokio::test]
+    async fn allows_root_level_favicon() {
+        let app = Router::new()
+            .route("/favicon.ico", get(dummy))
+            .layer(axum::middleware::from_fn(reject_file_like_paths));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/favicon.ico")
                     .body(Body::empty())
                     .unwrap(),
             )

--- a/crates/server/src/middleware.rs
+++ b/crates/server/src/middleware.rs
@@ -1,0 +1,126 @@
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+
+/// Paths whose segments legitimately contain dots (e.g. /pkg/app-hash.js).
+const DOTTED_SEGMENT_ALLOWLIST: &[&str] = &["/pkg/"];
+
+/// Rejects requests where any URL path segment looks like a filename (contains a dot
+/// but does not start with one). App-level IDs are UUIDs and never contain dots;
+/// static-file names always do. Short-circuits before Leptos SSR runs DB queries.
+pub async fn reject_file_like_paths(req: Request<Body>, next: Next) -> Response {
+    let path = req.uri().path();
+
+    if DOTTED_SEGMENT_ALLOWLIST
+        .iter()
+        .any(|prefix| path.starts_with(prefix))
+    {
+        return next.run(req).await;
+    }
+
+    if path.split('/').any(is_file_like_segment) {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+
+    next.run(req).await
+}
+
+/// A segment is "file-like" if it contains a dot but does not start with one.
+/// Segments starting with `.` are directory names like `.well-known`, not files.
+fn is_file_like_segment(segment: &str) -> bool {
+    !segment.is_empty() && !segment.starts_with('.') && segment.contains('.')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{Router, body::Body, http::Request, routing::get};
+    use tower::ServiceExt;
+
+    async fn dummy() -> &'static str {
+        "ok"
+    }
+
+    fn app() -> Router {
+        Router::new()
+            .route("/lists/{id}", get(dummy))
+            .route("/pkg/{*file}", get(dummy))
+            .layer(axum::middleware::from_fn(reject_file_like_paths))
+    }
+
+    #[tokio::test]
+    async fn rejects_source_map_path() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .uri("/lists/installHook.js.map")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 404);
+    }
+
+    #[tokio::test]
+    async fn rejects_js_path() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .uri("/lists/app.js")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 404);
+    }
+
+    #[tokio::test]
+    async fn allows_uuid_path() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .uri("/lists/a1b2c3d4-0000-4000-8000-000000000000")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+    }
+
+    #[tokio::test]
+    async fn allows_pkg_assets() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .uri("/pkg/app-abc123.js")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+    }
+
+    #[tokio::test]
+    async fn allows_well_known() {
+        let app = Router::new()
+            .route("/.well-known/openid-configuration", get(dummy))
+            .layer(axum::middleware::from_fn(reject_file_like_paths));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/.well-known/openid-configuration")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `reject_file_like_paths` Axum middleware in `crates/server/src/middleware.rs`
- Any URL path segment that contains a dot (but doesn't start with one) is treated as a static file reference and returns 404 immediately — before the Leptos SSR router runs
- Only allowlisted prefix is `/pkg/` (Leptos bundled JS/WASM assets); `/.well-known/` works naturally since its segment starts with `.`
- Wired as the outermost layer so it runs before `TraceLayer` and `auth_layer`; spurious requests still appear in traces as fast 404s

Fixes #246.

## Test plan

- [ ] 5 unit tests in `middleware::tests` cover: source map rejection, `.js` rejection, UUID passthrough, `/pkg/` allowlist, `/.well-known/` passthrough
- [ ] `cargo test -p kartoteka-server middleware` — all pass
- [ ] `just ci` — fmt, clippy, audit, machete, test all green
- [ ] Manual: start `just dev` with React DevTools active, verify `/lists/installHook.js.map` returns 404 with no DB queries in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)