### PR TITLE
fix(ui): sublist title link unblocked from DaisyUI collapse input overlay

### DIFF
--- a/crates/frontend/src/components/lists/sublist_section.rs
+++ b/crates/frontend/src/components/lists/sublist_section.rs
@@ -98,15 +98,14 @@ pub fn SublistSection(
                         <DragHandleButton dnd_state=state kind=EntityKind::List dragged_id=sid aria_label="Przeciągnij podlistę" />
                     }
                 })}
-                <span data-testid="sublist-name">{list_name}</span>
                 <a
                     href=format!("/lists/{}", sublist.id)
-                    class="btn btn-ghost btn-xs ml-1"
-                    title="Otwórz jako widok listy"
+                    class="relative z-[2] font-semibold hover:underline decoration-dotted"
                     data-testid="sublist-open-link"
                     on:click=|ev: leptos::ev::MouseEvent| ev.stop_propagation()
                 >
-                    "↗"
+                    {list_name}
+                    <span class="ml-1 text-xs opacity-50">"↗"</span>
                 </a>
                 {move || {
                     let current = items.get();


### PR DESCRIPTION
## Summary

- DaisyUI v5 `collapse` places a hidden `<input type="checkbox">` with `z-index: 1` in the same CSS Grid cell as `collapse-title`, intercepting all pointer events in that row
- The sublist navigation link (`↗`) had no `position`/`z-index` set, so clicks were silently captured by the invisible input instead of the anchor
- Fix: merge the title `<span>` and open-link `<a>` into a single `<a>` with `relative z-[2]`, placing it above the input in stacking order; `stop_propagation()` still prevents the collapse from toggling on navigation clicks

## Test plan

- [ ] Open a list that has sublists
- [ ] Click on a sublist title — should navigate to the sublist page (previously did nothing)
- [ ] Click outside the title area (e.g. progress counter) — should still toggle collapse
- [ ] E2E: `just test-e2e` — `sublist-open-link` testid preserved on the `<a>` element

🤖 Generated with [Claude Code](https://claude.com/claude-code)