### PR TITLE
feat(ui): faceted tag filtering with listwise/itemwise/joined modes

### DIFF
--- a/crates/db/src/tags.rs
+++ b/crates/db/src/tags.rs
@@ -198,13 +198,16 @@ pub async fn get_exclusive_type_tag_for_item(
 
 // ── Write queries ─────────────────────────────────────────────────────────────
 
-pub async fn find_id_by_name_in_scope(
-    pool: &SqlitePool,
+pub async fn find_id_by_name_in_scope<'c, E>(
+    executor: E,
     user_id: &str,
     name: &str,
     parent_tag_id: Option<&str>,
     exclude_id: Option<&str>,
-) -> Result<Option<String>, DbError> {
+) -> Result<Option<String>, DbError>
+where
+    E: sqlx::Executor<'c, Database = sqlx::Sqlite>,
+{
     let row: Option<(String,)> = sqlx::query_as(
         "SELECT id FROM tags \
          WHERE user_id = ? \
@@ -216,7 +219,7 @@ pub async fn find_id_by_name_in_scope(
     .bind(name)
     .bind(parent_tag_id)
     .bind(exclude_id)
-    .fetch_optional(pool)
+    .fetch_optional(executor)
     .await
     .map_err(DbError::Sqlx)?;
     Ok(row.map(|(id,)| id))

--- a/crates/domain/src/tags.rs
+++ b/crates/domain/src/tags.rs
@@ -986,7 +986,7 @@ mod tests {
         let result = filter_home_by_tags(
             &pool,
             &uid,
-            &[tag_a.id.clone()],
+            std::slice::from_ref(&tag_a.id),
             kartoteka_shared::FilterMode::Listwise,
         )
         .await
@@ -1038,7 +1038,7 @@ mod tests {
         let result = filter_home_by_tags(
             &pool,
             &uid,
-            &[tag_a.id.clone()],
+            std::slice::from_ref(&tag_a.id),
             kartoteka_shared::FilterMode::Itemwise,
         )
         .await
@@ -1089,7 +1089,7 @@ mod tests {
         let result = filter_home_by_tags(
             &pool,
             &uid,
-            &[tag_a.id.clone()],
+            std::slice::from_ref(&tag_a.id),
             kartoteka_shared::FilterMode::Joined,
         )
         .await

--- a/crates/domain/src/tags.rs
+++ b/crates/domain/src/tags.rs
@@ -3,8 +3,9 @@ use kartoteka_db::{
     self as db,
     tags::{InsertTagInput, UpdateTagInput},
 };
+use kartoteka_shared::{FilterMode, dto::responses::HomeFilterResult};
 use serde::{Deserialize, Serialize};
-use sqlx::SqlitePool;
+use sqlx::{QueryBuilder, SqlitePool};
 use uuid::Uuid;
 
 // ── Public domain types ───────────────────────────────────────────────────────
@@ -63,6 +64,184 @@ fn row_to_tag(row: db::types::TagRow) -> Tag {
 }
 
 // ── Public functions ──────────────────────────────────────────────────────────
+
+async fn listwise_matching(
+    pool: &SqlitePool,
+    user_id: &str,
+    tag_ids: &[String],
+) -> Result<Vec<String>, DomainError> {
+    if tag_ids.is_empty() {
+        return Ok(vec![]);
+    }
+    let mut qb = QueryBuilder::<sqlx::Sqlite>::new(
+        "SELECT lt.list_id FROM list_tags lt \
+         JOIN lists l ON lt.list_id = l.id \
+         WHERE l.user_id = ",
+    );
+    qb.push_bind(user_id);
+    qb.push(" AND lt.tag_id IN (");
+    let mut sep = qb.separated(", ");
+    for tid in tag_ids {
+        sep.push_bind(tid);
+    }
+    qb.push(") GROUP BY lt.list_id HAVING COUNT(DISTINCT lt.tag_id) = ");
+    qb.push_bind(tag_ids.len() as i64);
+    Ok(qb
+        .build_query_scalar()
+        .fetch_all(pool)
+        .await
+        .map_err(db::DbError::Sqlx)?)
+}
+
+async fn list_co_occurring_tags(
+    pool: &SqlitePool,
+    list_ids: &[String],
+    exclude_tag_ids: &[String],
+) -> Result<Vec<String>, DomainError> {
+    if list_ids.is_empty() {
+        return Ok(vec![]);
+    }
+    let mut qb = QueryBuilder::<sqlx::Sqlite>::new(
+        "SELECT DISTINCT tag_id FROM list_tags WHERE list_id IN (",
+    );
+    let mut sep = qb.separated(", ");
+    for lid in list_ids {
+        sep.push_bind(lid);
+    }
+    qb.push(")");
+    if !exclude_tag_ids.is_empty() {
+        qb.push(" AND tag_id NOT IN (");
+        let mut sep2 = qb.separated(", ");
+        for tid in exclude_tag_ids {
+            sep2.push_bind(tid);
+        }
+        qb.push(")");
+    }
+    Ok(qb
+        .build_query_scalar()
+        .fetch_all(pool)
+        .await
+        .map_err(db::DbError::Sqlx)?)
+}
+
+async fn itemwise_matching(
+    pool: &SqlitePool,
+    user_id: &str,
+    tag_ids: &[String],
+) -> Result<Vec<String>, DomainError> {
+    if tag_ids.is_empty() {
+        return Ok(vec![]);
+    }
+    let mut qb = QueryBuilder::<sqlx::Sqlite>::new(
+        "SELECT list_id FROM (\
+            SELECT i.list_id, COUNT(DISTINCT it.tag_id) AS covered \
+            FROM items i \
+            JOIN item_tags it ON i.id = it.item_id \
+            JOIN lists l ON i.list_id = l.id \
+            WHERE l.user_id = ",
+    );
+    qb.push_bind(user_id);
+    qb.push(" AND it.tag_id IN (");
+    let mut sep = qb.separated(", ");
+    for tid in tag_ids {
+        sep.push_bind(tid);
+    }
+    qb.push(") GROUP BY i.list_id) WHERE covered = ");
+    qb.push_bind(tag_ids.len() as i64);
+    Ok(qb
+        .build_query_scalar()
+        .fetch_all(pool)
+        .await
+        .map_err(db::DbError::Sqlx)?)
+}
+
+async fn item_co_occurring_tags(
+    pool: &SqlitePool,
+    list_ids: &[String],
+    exclude_tag_ids: &[String],
+) -> Result<Vec<String>, DomainError> {
+    if list_ids.is_empty() {
+        return Ok(vec![]);
+    }
+    let mut qb = QueryBuilder::<sqlx::Sqlite>::new(
+        "SELECT DISTINCT it.tag_id FROM item_tags it \
+         JOIN items i ON i.id = it.item_id \
+         WHERE i.list_id IN (",
+    );
+    let mut sep = qb.separated(", ");
+    for lid in list_ids {
+        sep.push_bind(lid);
+    }
+    qb.push(")");
+    if !exclude_tag_ids.is_empty() {
+        qb.push(" AND it.tag_id NOT IN (");
+        let mut sep2 = qb.separated(", ");
+        for tid in exclude_tag_ids {
+            sep2.push_bind(tid);
+        }
+        qb.push(")");
+    }
+    Ok(qb
+        .build_query_scalar()
+        .fetch_all(pool)
+        .await
+        .map_err(db::DbError::Sqlx)?)
+}
+
+pub async fn filter_home_by_tags(
+    pool: &SqlitePool,
+    user_id: &str,
+    tag_ids: &[String],
+    mode: FilterMode,
+) -> Result<HomeFilterResult, DomainError> {
+    if tag_ids.is_empty() {
+        return Ok(HomeFilterResult::default());
+    }
+    match mode {
+        FilterMode::Listwise => {
+            let list_ids = listwise_matching(pool, user_id, tag_ids).await?;
+            let related_tag_ids = list_co_occurring_tags(pool, &list_ids, tag_ids).await?;
+            Ok(HomeFilterResult {
+                matching_list_ids: list_ids,
+                related_tag_ids,
+            })
+        }
+        FilterMode::Itemwise => {
+            let list_ids = itemwise_matching(pool, user_id, tag_ids).await?;
+            let related_tag_ids = item_co_occurring_tags(pool, &list_ids, tag_ids).await?;
+            Ok(HomeFilterResult {
+                matching_list_ids: list_ids,
+                related_tag_ids,
+            })
+        }
+        FilterMode::Joined => {
+            let list_ids_l = listwise_matching(pool, user_id, tag_ids).await?;
+            let list_ids_i = itemwise_matching(pool, user_id, tag_ids).await?;
+            let list_ids: Vec<String> = {
+                let mut seen = std::collections::HashSet::new();
+                list_ids_l
+                    .iter()
+                    .chain(list_ids_i.iter())
+                    .filter(|id| seen.insert(id.as_str()))
+                    .cloned()
+                    .collect()
+            };
+            let mut related = list_co_occurring_tags(pool, &list_ids_l, tag_ids).await?;
+            related.extend(item_co_occurring_tags(pool, &list_ids_i, tag_ids).await?);
+            let related_tag_ids: Vec<String> = {
+                let mut seen = std::collections::HashSet::new();
+                related
+                    .into_iter()
+                    .filter(|id| seen.insert(id.clone()))
+                    .collect()
+            };
+            Ok(HomeFilterResult {
+                matching_list_ids: list_ids,
+                related_tag_ids,
+            })
+        }
+    }
+}
 
 #[tracing::instrument(skip(pool))]
 pub async fn list_all(pool: &SqlitePool, user_id: &str) -> Result<Vec<Tag>, DomainError> {
@@ -748,5 +927,178 @@ mod tests {
             .await
             .is_ok()
         );
+    }
+
+    // ── filter_home_by_tags tests ─────────────────────────────────────────
+
+    async fn make_list(pool: &SqlitePool, uid: &str) -> String {
+        let lid = Uuid::new_v4().to_string();
+        sqlx::query("INSERT INTO lists (id, user_id, name) VALUES (?, ?, 'L')")
+            .bind(&lid)
+            .bind(uid)
+            .execute(pool)
+            .await
+            .unwrap();
+        lid
+    }
+
+    async fn tag_list(pool: &SqlitePool, list_id: &str, tag_id: &str) {
+        sqlx::query("INSERT OR IGNORE INTO list_tags (list_id, tag_id) VALUES (?, ?)")
+            .bind(list_id)
+            .bind(tag_id)
+            .execute(pool)
+            .await
+            .unwrap();
+    }
+
+    async fn tag_item(pool: &SqlitePool, item_id: &str, tag_id: &str) {
+        sqlx::query("INSERT OR IGNORE INTO item_tags (item_id, tag_id) VALUES (?, ?)")
+            .bind(item_id)
+            .bind(tag_id)
+            .execute(pool)
+            .await
+            .unwrap();
+    }
+
+    async fn make_item_in_list(pool: &SqlitePool, list_id: &str) -> String {
+        let iid = Uuid::new_v4().to_string();
+        sqlx::query("INSERT INTO items (id, list_id, title) VALUES (?, ?, 'I')")
+            .bind(&iid)
+            .bind(list_id)
+            .execute(pool)
+            .await
+            .unwrap();
+        iid
+    }
+
+    #[tokio::test]
+    async fn test_filter_listwise_single_tag() {
+        let pool = test_pool().await;
+        let uid = create_test_user(&pool).await;
+        let tag_a = make_tag(&pool, &uid, "A").await;
+        let tag_b = make_tag(&pool, &uid, "B").await;
+        let l1 = make_list(&pool, &uid).await;
+        let l2 = make_list(&pool, &uid).await;
+        tag_list(&pool, &l1, &tag_a.id).await;
+        tag_list(&pool, &l1, &tag_b.id).await;
+        tag_list(&pool, &l2, &tag_b.id).await;
+
+        let result = filter_home_by_tags(
+            &pool,
+            &uid,
+            &[tag_a.id.clone()],
+            kartoteka_shared::FilterMode::Listwise,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.matching_list_ids, vec![l1.clone()]);
+        assert!(result.related_tag_ids.contains(&tag_b.id));
+        assert!(!result.related_tag_ids.contains(&tag_a.id));
+    }
+
+    #[tokio::test]
+    async fn test_filter_listwise_multi_tag_and() {
+        let pool = test_pool().await;
+        let uid = create_test_user(&pool).await;
+        let tag_a = make_tag(&pool, &uid, "A").await;
+        let tag_b = make_tag(&pool, &uid, "B").await;
+        let l1 = make_list(&pool, &uid).await;
+        let l2 = make_list(&pool, &uid).await;
+        tag_list(&pool, &l1, &tag_a.id).await;
+        tag_list(&pool, &l1, &tag_b.id).await;
+        tag_list(&pool, &l2, &tag_a.id).await;
+
+        let result = filter_home_by_tags(
+            &pool,
+            &uid,
+            &[tag_a.id.clone(), tag_b.id.clone()],
+            kartoteka_shared::FilterMode::Listwise,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.matching_list_ids, vec![l1]);
+    }
+
+    #[tokio::test]
+    async fn test_filter_itemwise_single_tag() {
+        let pool = test_pool().await;
+        let uid = create_test_user(&pool).await;
+        let tag_a = make_tag(&pool, &uid, "A").await;
+        let tag_b = make_tag(&pool, &uid, "B").await;
+        let l1 = make_list(&pool, &uid).await;
+        let l2 = make_list(&pool, &uid).await;
+        let i1 = make_item_in_list(&pool, &l1).await;
+        let i2 = make_item_in_list(&pool, &l2).await;
+        tag_item(&pool, &i1, &tag_a.id).await;
+        tag_item(&pool, &i1, &tag_b.id).await;
+        tag_item(&pool, &i2, &tag_b.id).await;
+
+        let result = filter_home_by_tags(
+            &pool,
+            &uid,
+            &[tag_a.id.clone()],
+            kartoteka_shared::FilterMode::Itemwise,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.matching_list_ids, vec![l1.clone()]);
+        assert!(result.related_tag_ids.contains(&tag_b.id));
+    }
+
+    #[tokio::test]
+    async fn test_filter_itemwise_multi_tag_collective() {
+        let pool = test_pool().await;
+        let uid = create_test_user(&pool).await;
+        let tag_a = make_tag(&pool, &uid, "A").await;
+        let tag_b = make_tag(&pool, &uid, "B").await;
+        let l1 = make_list(&pool, &uid).await;
+        let l2 = make_list(&pool, &uid).await;
+        let i1 = make_item_in_list(&pool, &l1).await;
+        let i2 = make_item_in_list(&pool, &l1).await;
+        let i3 = make_item_in_list(&pool, &l2).await;
+        tag_item(&pool, &i1, &tag_a.id).await;
+        tag_item(&pool, &i2, &tag_b.id).await;
+        tag_item(&pool, &i3, &tag_a.id).await;
+
+        let result = filter_home_by_tags(
+            &pool,
+            &uid,
+            &[tag_a.id.clone(), tag_b.id.clone()],
+            kartoteka_shared::FilterMode::Itemwise,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.matching_list_ids, vec![l1]);
+    }
+
+    #[tokio::test]
+    async fn test_filter_joined_union() {
+        let pool = test_pool().await;
+        let uid = create_test_user(&pool).await;
+        let tag_a = make_tag(&pool, &uid, "A").await;
+        let l1 = make_list(&pool, &uid).await;
+        let l2 = make_list(&pool, &uid).await;
+        tag_list(&pool, &l1, &tag_a.id).await;
+        let i1 = make_item_in_list(&pool, &l2).await;
+        tag_item(&pool, &i1, &tag_a.id).await;
+
+        let result = filter_home_by_tags(
+            &pool,
+            &uid,
+            &[tag_a.id.clone()],
+            kartoteka_shared::FilterMode::Joined,
+        )
+        .await
+        .unwrap();
+
+        let mut ids = result.matching_list_ids.clone();
+        ids.sort();
+        let mut expected = vec![l1, l2];
+        expected.sort();
+        assert_eq!(ids, expected);
     }
 }

--- a/crates/domain/src/tags.rs
+++ b/crates/domain/src/tags.rs
@@ -63,6 +63,23 @@ fn row_to_tag(row: db::types::TagRow) -> Tag {
     }
 }
 
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn push_ids<'a>(qb: &mut QueryBuilder<'a, sqlx::Sqlite>, ids: &'a [String]) {
+    let mut sep = qb.separated(", ");
+    for id in ids {
+        sep.push_bind(id);
+    }
+}
+
+fn dedup_strings(items: impl IntoIterator<Item = String>) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    items
+        .into_iter()
+        .filter(|id| seen.insert(id.clone()))
+        .collect()
+}
+
 // ── Public functions ──────────────────────────────────────────────────────────
 
 async fn listwise_matching(
@@ -80,10 +97,7 @@ async fn listwise_matching(
     );
     qb.push_bind(user_id);
     qb.push(" AND lt.tag_id IN (");
-    let mut sep = qb.separated(", ");
-    for tid in tag_ids {
-        sep.push_bind(tid);
-    }
+    push_ids(&mut qb, tag_ids);
     qb.push(") GROUP BY lt.list_id HAVING COUNT(DISTINCT lt.tag_id) = ");
     qb.push_bind(tag_ids.len() as i64);
     Ok(qb
@@ -104,17 +118,11 @@ async fn list_co_occurring_tags(
     let mut qb = QueryBuilder::<sqlx::Sqlite>::new(
         "SELECT DISTINCT tag_id FROM list_tags WHERE list_id IN (",
     );
-    let mut sep = qb.separated(", ");
-    for lid in list_ids {
-        sep.push_bind(lid);
-    }
+    push_ids(&mut qb, list_ids);
     qb.push(")");
     if !exclude_tag_ids.is_empty() {
         qb.push(" AND tag_id NOT IN (");
-        let mut sep2 = qb.separated(", ");
-        for tid in exclude_tag_ids {
-            sep2.push_bind(tid);
-        }
+        push_ids(&mut qb, exclude_tag_ids);
         qb.push(")");
     }
     Ok(qb
@@ -142,10 +150,7 @@ async fn itemwise_matching(
     );
     qb.push_bind(user_id);
     qb.push(" AND it.tag_id IN (");
-    let mut sep = qb.separated(", ");
-    for tid in tag_ids {
-        sep.push_bind(tid);
-    }
+    push_ids(&mut qb, tag_ids);
     qb.push(") GROUP BY i.list_id) WHERE covered = ");
     qb.push_bind(tag_ids.len() as i64);
     Ok(qb
@@ -168,17 +173,11 @@ async fn item_co_occurring_tags(
          JOIN items i ON i.id = it.item_id \
          WHERE i.list_id IN (",
     );
-    let mut sep = qb.separated(", ");
-    for lid in list_ids {
-        sep.push_bind(lid);
-    }
+    push_ids(&mut qb, list_ids);
     qb.push(")");
     if !exclude_tag_ids.is_empty() {
         qb.push(" AND it.tag_id NOT IN (");
-        let mut sep2 = qb.separated(", ");
-        for tid in exclude_tag_ids {
-            sep2.push_bind(tid);
-        }
+        push_ids(&mut qb, exclude_tag_ids);
         qb.push(")");
     }
     Ok(qb
@@ -217,24 +216,10 @@ pub async fn filter_home_by_tags(
         FilterMode::Joined => {
             let list_ids_l = listwise_matching(pool, user_id, tag_ids).await?;
             let list_ids_i = itemwise_matching(pool, user_id, tag_ids).await?;
-            let list_ids: Vec<String> = {
-                let mut seen = std::collections::HashSet::new();
-                list_ids_l
-                    .iter()
-                    .chain(list_ids_i.iter())
-                    .filter(|id| seen.insert(id.as_str()))
-                    .cloned()
-                    .collect()
-            };
+            let list_ids = dedup_strings(list_ids_l.iter().chain(list_ids_i.iter()).cloned());
             let mut related = list_co_occurring_tags(pool, &list_ids_l, tag_ids).await?;
             related.extend(item_co_occurring_tags(pool, &list_ids_i, tag_ids).await?);
-            let related_tag_ids: Vec<String> = {
-                let mut seen = std::collections::HashSet::new();
-                related
-                    .into_iter()
-                    .filter(|id| seen.insert(id.clone()))
-                    .collect()
-            };
+            let related_tag_ids = dedup_strings(related);
             Ok(HomeFilterResult {
                 matching_list_ids: list_ids,
                 related_tag_ids,

--- a/crates/domain/src/tags.rs
+++ b/crates/domain/src/tags.rs
@@ -160,6 +160,24 @@ async fn itemwise_matching(
         .map_err(db::DbError::Sqlx)?)
 }
 
+async fn container_ids_for_lists(
+    pool: &SqlitePool,
+    list_ids: &[String],
+) -> Result<Vec<String>, DomainError> {
+    if list_ids.is_empty() {
+        return Ok(vec![]);
+    }
+    let mut qb =
+        QueryBuilder::<sqlx::Sqlite>::new("SELECT DISTINCT container_id FROM lists WHERE id IN (");
+    push_ids(&mut qb, list_ids);
+    qb.push(") AND container_id IS NOT NULL");
+    Ok(qb
+        .build_query_scalar()
+        .fetch_all(pool)
+        .await
+        .map_err(db::DbError::Sqlx)?)
+}
+
 async fn item_co_occurring_tags(
     pool: &SqlitePool,
     list_ids: &[String],
@@ -199,17 +217,21 @@ pub async fn filter_home_by_tags(
     match mode {
         FilterMode::Listwise => {
             let list_ids = listwise_matching(pool, user_id, tag_ids).await?;
+            let matching_container_ids = container_ids_for_lists(pool, &list_ids).await?;
             let related_tag_ids = list_co_occurring_tags(pool, &list_ids, tag_ids).await?;
             Ok(HomeFilterResult {
                 matching_list_ids: list_ids,
+                matching_container_ids,
                 related_tag_ids,
             })
         }
         FilterMode::Itemwise => {
             let list_ids = itemwise_matching(pool, user_id, tag_ids).await?;
+            let matching_container_ids = container_ids_for_lists(pool, &list_ids).await?;
             let related_tag_ids = item_co_occurring_tags(pool, &list_ids, tag_ids).await?;
             Ok(HomeFilterResult {
                 matching_list_ids: list_ids,
+                matching_container_ids,
                 related_tag_ids,
             })
         }
@@ -217,11 +239,13 @@ pub async fn filter_home_by_tags(
             let list_ids_l = listwise_matching(pool, user_id, tag_ids).await?;
             let list_ids_i = itemwise_matching(pool, user_id, tag_ids).await?;
             let list_ids = dedup_strings(list_ids_l.iter().chain(list_ids_i.iter()).cloned());
+            let matching_container_ids = container_ids_for_lists(pool, &list_ids).await?;
             let mut related = list_co_occurring_tags(pool, &list_ids_l, tag_ids).await?;
             related.extend(item_co_occurring_tags(pool, &list_ids_i, tag_ids).await?);
             let related_tag_ids = dedup_strings(related);
             Ok(HomeFilterResult {
                 matching_list_ids: list_ids,
+                matching_container_ids,
                 related_tag_ids,
             })
         }

--- a/crates/frontend/CLAUDE.md
+++ b/crates/frontend/CLAUDE.md
@@ -41,6 +41,45 @@ Crate `kartoteka-frontend` — komponenty, server functions, routing, i18n.
 - Layout routes z `<Outlet>`: używaj `<ParentRoute>`, nie `<Route children=...>`
 - `<Outlet>` renderuje dopasowane child route w miejscu wywołania
 
+## Pułapki reaktywności
+
+### Hydration: zasoby muszą być wewnątrz Transition/Suspense
+Tylko `Resource` odczytywane wewnątrz `<Suspense>` lub `<Transition>` są serializowane przez SSR i dostępne dla WASM podczas hydracji. Resource **poza** granicą → SSR renderuje dane, WASM widzi `None` → różnica DOM → `unreachable!()` panic w tachys.
+
+```rust
+// ŹLE: tags_res poza Transition — WASM crash przy hydracji
+<HomeTagFilterBar all_tags=all_tags_signal ... />
+
+// DOBRZE: owinięte w Transition → tags_res serializowany
+<Transition fallback=|| view! {}>
+    <HomeTagFilterBar all_tags=all_tags_signal ... />
+</Transition>
+```
+
+### Filtrowanie hierarchiczne — propaguj do wszystkich poziomów
+Gdy filtr (`matching_list_ids`) ma działać na listach **i** kontenerach, musi być propagowany do wszystkich poziomów. Pominięcie kontenera powoduje, że listy w nim schowane są niewidoczne przy filtrze.
+
+```rust
+// ŹLE: tylko listy filtrowane, kontenery zawsze widoczne
+let filtered_lists = lists.filter(|l| filter.contains(&l.id));
+// root_containers renderowane bez filtrowania ↑
+
+// DOBRZE: oba poziomy filtrowane z oddzielnych sygnałów
+let filtered_lists = lists.filter(|l| list_filter.contains(&l.id));
+let filtered_containers = containers.filter(|c| container_filter.contains(&c.id));
+```
+
+### `get_untracked()` w komponentach renderowanych przez rodzica
+Sygnał czytany przez `get_untracked()` nie śledzi zmian — ale jest OK jeśli **rodzic** wyraźnie czyta ten sygnał przez `get()` (co wymusza re-render komponentu dziecka). Wzorzec w home:
+
+```rust
+// W rodzicu (home.rs) — `get()` wymusza re-render gdy filter się zmienia
+let _matching = matching_list_ids.get();
+// Powyższe sprawia, że sekcje renderują się ponownie
+// Wewnątrz sekcji get_untracked() jest wtedy bezpieczne
+let filter = matching_list_ids.get_untracked();
+```
+
 ## i18n (leptos-fluent + Fluent)
 
 ### Użycie

--- a/crates/frontend/src/components/home/mod.rs
+++ b/crates/frontend/src/components/home/mod.rs
@@ -1,3 +1,4 @@
 pub mod pinned_section;
 pub mod recent_section;
 pub mod root_section;
+pub mod tag_filter_bar;

--- a/crates/frontend/src/components/home/pinned_section.rs
+++ b/crates/frontend/src/components/home/pinned_section.rs
@@ -19,7 +19,7 @@ pub fn PinnedSection(
     let filter = matching_list_ids.get_untracked();
     let filtered_lists: Vec<List> = pinned_lists
         .into_iter()
-        .filter(|l| filter.as_ref().map_or(true, |ids| ids.contains(&l.id)))
+        .filter(|l| filter.as_ref().is_none_or(|ids| ids.contains(&l.id)))
         .collect();
 
     if filtered_lists.is_empty() && pinned_containers.is_empty() {

--- a/crates/frontend/src/components/home/pinned_section.rs
+++ b/crates/frontend/src/components/home/pinned_section.rs
@@ -12,17 +12,27 @@ pub fn PinnedSection(
     all_tags: Vec<Tag>,
     all_links: Vec<ListTagLink>,
     matching_list_ids: Signal<Option<HashSet<String>>>,
+    matching_container_ids: Signal<Option<HashSet<String>>>,
     on_tag_toggle: Callback<(String, String)>,
     on_delete_list: Callback<String>,
     on_pin_container: Callback<String>,
 ) -> impl IntoView {
-    let filter = matching_list_ids.get_untracked();
+    let list_filter = matching_list_ids.get_untracked();
+    let container_filter = matching_container_ids.get_untracked();
     let filtered_lists: Vec<List> = pinned_lists
         .into_iter()
-        .filter(|l| filter.as_ref().is_none_or(|ids| ids.contains(&l.id)))
+        .filter(|l| list_filter.as_ref().is_none_or(|ids| ids.contains(&l.id)))
+        .collect();
+    let filtered_containers: Vec<Container> = pinned_containers
+        .into_iter()
+        .filter(|c| {
+            container_filter
+                .as_ref()
+                .is_none_or(|ids| ids.contains(&c.id))
+        })
         .collect();
 
-    if filtered_lists.is_empty() && pinned_containers.is_empty() {
+    if filtered_lists.is_empty() && filtered_containers.is_empty() {
         return view! {}.into_any();
     }
 
@@ -34,7 +44,7 @@ pub fn PinnedSection(
             </div>
             <div class="collapse-content">
                 <div class="flex flex-col gap-3 pt-2">
-                    {pinned_containers.into_iter().map(|c| {
+                    {filtered_containers.into_iter().map(|c| {
                         let cid = c.id.clone();
                         let pin_cb = on_pin_container.clone();
                         view! {

--- a/crates/frontend/src/components/home/pinned_section.rs
+++ b/crates/frontend/src/components/home/pinned_section.rs
@@ -9,12 +9,23 @@ pub fn PinnedSection(
     pinned_containers: Vec<Container>,
     all_tags: Vec<Tag>,
     all_links: Vec<ListTagLink>,
-    _active_tag_filter: ReadSignal<Option<String>>,
+    active_tag_filter: ReadSignal<Option<String>>,
     on_tag_toggle: Callback<(String, String)>,
     on_delete_list: Callback<String>,
     on_pin_container: Callback<String>,
 ) -> impl IntoView {
-    if pinned_lists.is_empty() && pinned_containers.is_empty() {
+    let filter = active_tag_filter.get_untracked();
+    let filtered_lists: Vec<List> = pinned_lists
+        .into_iter()
+        .filter(|l| match &filter {
+            None => true,
+            Some(tid) => all_links
+                .iter()
+                .any(|lnk| lnk.list_id == l.id && &lnk.tag_id == tid),
+        })
+        .collect();
+
+    if filtered_lists.is_empty() && pinned_containers.is_empty() {
         return view! {}.into_any();
     }
 
@@ -36,7 +47,7 @@ pub fn PinnedSection(
                             />
                         }
                     }).collect::<Vec<_>>()}
-                    {pinned_lists.into_iter().map(|list| {
+                    {filtered_lists.into_iter().map(|list| {
                         let list_id = list.id.clone();
                         let tag_ids: Vec<String> = all_links.iter()
                             .filter(|l| l.list_id == list.id)

--- a/crates/frontend/src/components/home/pinned_section.rs
+++ b/crates/frontend/src/components/home/pinned_section.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use kartoteka_shared::types::{Container, List, ListTagLink, Tag};
 use leptos::prelude::*;
 
@@ -9,20 +11,15 @@ pub fn PinnedSection(
     pinned_containers: Vec<Container>,
     all_tags: Vec<Tag>,
     all_links: Vec<ListTagLink>,
-    active_tag_filter: ReadSignal<Option<String>>,
+    matching_list_ids: Signal<Option<HashSet<String>>>,
     on_tag_toggle: Callback<(String, String)>,
     on_delete_list: Callback<String>,
     on_pin_container: Callback<String>,
 ) -> impl IntoView {
-    let filter = active_tag_filter.get_untracked();
+    let filter = matching_list_ids.get_untracked();
     let filtered_lists: Vec<List> = pinned_lists
         .into_iter()
-        .filter(|l| match &filter {
-            None => true,
-            Some(tid) => all_links
-                .iter()
-                .any(|lnk| lnk.list_id == l.id && &lnk.tag_id == tid),
-        })
+        .filter(|l| filter.as_ref().map_or(true, |ids| ids.contains(&l.id)))
         .collect();
 
     if filtered_lists.is_empty() && pinned_containers.is_empty() {

--- a/crates/frontend/src/components/home/recent_section.rs
+++ b/crates/frontend/src/components/home/recent_section.rs
@@ -12,16 +12,26 @@ pub fn RecentSection(
     all_tags: Vec<Tag>,
     all_links: Vec<ListTagLink>,
     matching_list_ids: Signal<Option<HashSet<String>>>,
+    matching_container_ids: Signal<Option<HashSet<String>>>,
     on_tag_toggle: Callback<(String, String)>,
     on_delete_list: Callback<String>,
 ) -> impl IntoView {
-    let filter = matching_list_ids.get_untracked();
+    let list_filter = matching_list_ids.get_untracked();
+    let container_filter = matching_container_ids.get_untracked();
     let filtered_lists: Vec<List> = recent_lists
         .into_iter()
-        .filter(|l| filter.as_ref().is_none_or(|ids| ids.contains(&l.id)))
+        .filter(|l| list_filter.as_ref().is_none_or(|ids| ids.contains(&l.id)))
+        .collect();
+    let filtered_containers: Vec<Container> = recent_containers
+        .into_iter()
+        .filter(|c| {
+            container_filter
+                .as_ref()
+                .is_none_or(|ids| ids.contains(&c.id))
+        })
         .collect();
 
-    if filtered_lists.is_empty() && recent_containers.is_empty() {
+    if filtered_lists.is_empty() && filtered_containers.is_empty() {
         return view! {}.into_any();
     }
 
@@ -33,7 +43,7 @@ pub fn RecentSection(
             </div>
             <div class="collapse-content">
                 <div class="flex flex-col gap-3 pt-2">
-                    {recent_containers.into_iter().map(|c| {
+                    {filtered_containers.into_iter().map(|c| {
                         view! { <ContainerCard container=c /> }
                     }).collect::<Vec<_>>()}
                     {filtered_lists.into_iter().map(|list| {

--- a/crates/frontend/src/components/home/recent_section.rs
+++ b/crates/frontend/src/components/home/recent_section.rs
@@ -18,7 +18,7 @@ pub fn RecentSection(
     let filter = matching_list_ids.get_untracked();
     let filtered_lists: Vec<List> = recent_lists
         .into_iter()
-        .filter(|l| filter.as_ref().map_or(true, |ids| ids.contains(&l.id)))
+        .filter(|l| filter.as_ref().is_none_or(|ids| ids.contains(&l.id)))
         .collect();
 
     if filtered_lists.is_empty() && recent_containers.is_empty() {

--- a/crates/frontend/src/components/home/recent_section.rs
+++ b/crates/frontend/src/components/home/recent_section.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use kartoteka_shared::types::{Container, List, ListTagLink, Tag};
 use leptos::prelude::*;
 
@@ -9,19 +11,14 @@ pub fn RecentSection(
     recent_containers: Vec<Container>,
     all_tags: Vec<Tag>,
     all_links: Vec<ListTagLink>,
-    active_tag_filter: ReadSignal<Option<String>>,
+    matching_list_ids: Signal<Option<HashSet<String>>>,
     on_tag_toggle: Callback<(String, String)>,
     on_delete_list: Callback<String>,
 ) -> impl IntoView {
-    let filter = active_tag_filter.get_untracked();
+    let filter = matching_list_ids.get_untracked();
     let filtered_lists: Vec<List> = recent_lists
         .into_iter()
-        .filter(|l| match &filter {
-            None => true,
-            Some(tid) => all_links
-                .iter()
-                .any(|lnk| lnk.list_id == l.id && &lnk.tag_id == tid),
-        })
+        .filter(|l| filter.as_ref().map_or(true, |ids| ids.contains(&l.id)))
         .collect();
 
     if filtered_lists.is_empty() && recent_containers.is_empty() {

--- a/crates/frontend/src/components/home/root_section.rs
+++ b/crates/frontend/src/components/home/root_section.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use kartoteka_shared::types::{Container, List, ListTagLink, Tag};
 use leptos::prelude::*;
 
@@ -9,21 +11,16 @@ pub fn RootSection(
     root_lists: Vec<List>,
     all_tags: Vec<Tag>,
     all_links: Vec<ListTagLink>,
-    active_tag_filter: ReadSignal<Option<String>>,
+    matching_list_ids: Signal<Option<HashSet<String>>>,
     on_tag_toggle: Callback<(String, String)>,
     on_delete_list: Callback<String>,
     on_delete_container: Callback<String>,
     on_pin_container: Callback<String>,
 ) -> impl IntoView {
-    let filter = active_tag_filter.get_untracked();
+    let filter = matching_list_ids.get_untracked();
     let filtered_lists: Vec<List> = root_lists
         .into_iter()
-        .filter(|l| match &filter {
-            None => true,
-            Some(tid) => all_links
-                .iter()
-                .any(|lnk| lnk.list_id == l.id && &lnk.tag_id == tid),
-        })
+        .filter(|l| filter.as_ref().map_or(true, |ids| ids.contains(&l.id)))
         .collect();
 
     let has_containers = !root_containers.is_empty();

--- a/crates/frontend/src/components/home/root_section.rs
+++ b/crates/frontend/src/components/home/root_section.rs
@@ -12,19 +12,29 @@ pub fn RootSection(
     all_tags: Vec<Tag>,
     all_links: Vec<ListTagLink>,
     matching_list_ids: Signal<Option<HashSet<String>>>,
+    matching_container_ids: Signal<Option<HashSet<String>>>,
     on_tag_toggle: Callback<(String, String)>,
     on_delete_list: Callback<String>,
     on_delete_container: Callback<String>,
     on_pin_container: Callback<String>,
 ) -> impl IntoView {
-    let filter = matching_list_ids.get_untracked();
+    let list_filter = matching_list_ids.get_untracked();
+    let container_filter = matching_container_ids.get_untracked();
     let filtered_lists: Vec<List> = root_lists
         .into_iter()
-        .filter(|l| filter.as_ref().is_none_or(|ids| ids.contains(&l.id)))
+        .filter(|l| list_filter.as_ref().is_none_or(|ids| ids.contains(&l.id)))
+        .collect();
+    let filtered_containers: Vec<Container> = root_containers
+        .into_iter()
+        .filter(|c| {
+            container_filter
+                .as_ref()
+                .is_none_or(|ids| ids.contains(&c.id))
+        })
         .collect();
 
-    let has_containers = !root_containers.is_empty();
-    let total_visible = root_containers.len() + filtered_lists.len();
+    let has_containers = !filtered_containers.is_empty();
+    let total_visible = filtered_containers.len() + filtered_lists.len();
 
     view! {
         <div>
@@ -34,7 +44,7 @@ pub fn RootSection(
                 </h3>
             })}
             <div class="flex flex-col gap-3 mb-4">
-                {root_containers.into_iter().map(|c| {
+                {filtered_containers.into_iter().map(|c| {
                     let cid_del = c.id.clone();
                     let cid_pin = c.id.clone();
                     let del = on_delete_container.clone();

--- a/crates/frontend/src/components/home/root_section.rs
+++ b/crates/frontend/src/components/home/root_section.rs
@@ -20,7 +20,7 @@ pub fn RootSection(
     let filter = matching_list_ids.get_untracked();
     let filtered_lists: Vec<List> = root_lists
         .into_iter()
-        .filter(|l| filter.as_ref().map_or(true, |ids| ids.contains(&l.id)))
+        .filter(|l| filter.as_ref().is_none_or(|ids| ids.contains(&l.id)))
         .collect();
 
     let has_containers = !root_containers.is_empty();

--- a/crates/frontend/src/components/home/tag_filter_bar.rs
+++ b/crates/frontend/src/components/home/tag_filter_bar.rs
@@ -1,0 +1,130 @@
+use std::collections::{HashMap, HashSet};
+
+use kartoteka_shared::{FilterMode, types::Tag};
+use leptos::prelude::*;
+
+use crate::components::tags::tag_badge::TagBadge;
+
+#[component]
+pub fn HomeTagFilterBar(
+    all_tags: Signal<Vec<Tag>>,
+    ancestor_map: Memo<HashMap<String, String>>,
+    active_tags: RwSignal<HashSet<String>>,
+    filter_mode: RwSignal<FilterMode>,
+    related_tag_ids: Signal<HashSet<String>>,
+    is_loading: Signal<bool>,
+) -> impl IntoView {
+    view! {
+        <div class="mb-3 flex flex-col gap-2">
+
+            // Mode switch
+            <div class="flex items-center gap-2">
+                <div class="join">
+                    {[
+                        (FilterMode::Listwise, "Listy"),
+                        (FilterMode::Itemwise, "Elementy"),
+                        (FilterMode::Joined, "Oba"),
+                    ].map(|(mode, label)| {
+                        let mode_for_cmp = mode.clone();
+                        let mode_for_set = mode.clone();
+                        view! {
+                            <button
+                                type="button"
+                                class=move || if filter_mode.get() == mode_for_cmp {
+                                    "join-item btn btn-xs btn-primary"
+                                } else {
+                                    "join-item btn btn-xs"
+                                }
+                                on:click=move |_| filter_mode.set(mode_for_set.clone())
+                            >
+                                {label}
+                            </button>
+                        }
+                    })}
+                </div>
+                {move || is_loading.get().then(|| view! {
+                    <span class="loading loading-spinner loading-xs" />
+                })}
+            </div>
+
+            // Selected tags (shown with × to deselect)
+            {move || {
+                let active = active_tags.get();
+                if active.is_empty() { return view! {}.into_any(); }
+                let tags = all_tags.get();
+                let paths = ancestor_map.get();
+                let selected: Vec<Tag> = tags.into_iter()
+                    .filter(|t| active.contains(&t.id))
+                    .collect();
+                view! {
+                    <div class="flex flex-wrap gap-1">
+                        {selected.into_iter().map(|tag| {
+                            let tid = tag.id.clone();
+                            let label = format!(
+                                "{} ×",
+                                paths.get(&tid).cloned().unwrap_or_else(|| tag.name.clone())
+                            );
+                            view! {
+                                <TagBadge
+                                    tag=tag
+                                    active=true
+                                    label=label
+                                    on_click=Callback::new(move |id: String| {
+                                        active_tags.update(|s| { s.remove(&id); });
+                                    })
+                                />
+                            }
+                        }).collect::<Vec<_>>()}
+                    </div>
+                }.into_any()
+            }}
+
+            // Available tags (all when no filter, narrowed when filter active)
+            {move || {
+                let active = active_tags.get();
+                let all = all_tags.get();
+                let related = related_tag_ids.get();
+                let paths = ancestor_map.get();
+
+                let available: Vec<Tag> = if active.is_empty() {
+                    all
+                } else {
+                    all.into_iter()
+                        .filter(|t| related.contains(&t.id) && !active.contains(&t.id))
+                        .collect()
+                };
+
+                if available.is_empty() && !active.is_empty() {
+                    return view! {
+                        <p class="text-sm text-base-content/50">"Brak pasujących tagów"</p>
+                    }.into_any();
+                }
+                if available.is_empty() {
+                    return view! {}.into_any();
+                }
+
+                view! {
+                    <div class="flex flex-wrap gap-1">
+                        {available.into_iter().map(|tag| {
+                            let tid = tag.id.clone();
+                            let label = paths.get(&tid)
+                                .cloned()
+                                .unwrap_or_else(|| tag.name.clone());
+                            view! {
+                                <TagBadge
+                                    tag=tag
+                                    active=false
+                                    label=label
+                                    on_click=Callback::new(move |id: String| {
+                                        active_tags.update(|s| { s.insert(id); });
+                                    })
+                                />
+                            }
+                        }).collect::<Vec<_>>()}
+                    </div>
+                }.into_any()
+            }}
+
+        </div>
+    }
+}

--- a/crates/frontend/src/pages/home.rs
+++ b/crates/frontend/src/pages/home.rs
@@ -120,6 +120,17 @@ fn HomeContent() -> impl IntoView {
         }
     });
 
+    let matching_container_ids = Signal::derive(move || {
+        if active_tags.get().is_empty() {
+            None
+        } else {
+            filter_res
+                .get()
+                .and_then(|r| r.ok())
+                .map(|r| r.matching_container_ids.into_iter().collect::<HashSet<_>>())
+        }
+    });
+
     let related_tag_ids = Signal::derive(move || {
         filter_res
             .get()
@@ -313,6 +324,7 @@ fn HomeContent() -> impl IntoView {
                                         all_tags=tags.clone()
                                         all_links=all_links.clone()
                                         matching_list_ids=matching_list_ids
+                                        matching_container_ids=matching_container_ids
                                         on_tag_toggle=on_tag_toggle
                                         on_delete_list=del_cb
                                         on_pin_container=on_pin_container
@@ -323,6 +335,7 @@ fn HomeContent() -> impl IntoView {
                                         all_tags=tags.clone()
                                         all_links=all_links.clone()
                                         matching_list_ids=matching_list_ids
+                                        matching_container_ids=matching_container_ids
                                         on_tag_toggle=on_tag_toggle
                                         on_delete_list=del_cb
                                     />
@@ -332,6 +345,7 @@ fn HomeContent() -> impl IntoView {
                                         all_tags=tags.clone()
                                         all_links=all_links.clone()
                                         matching_list_ids=matching_list_ids
+                                        matching_container_ids=matching_container_ids
                                         on_tag_toggle=on_tag_toggle
                                         on_delete_list=del_cb
                                         on_delete_container=on_delete_container

--- a/crates/frontend/src/pages/home.rs
+++ b/crates/frontend/src/pages/home.rs
@@ -261,15 +261,17 @@ fn HomeContent() -> impl IntoView {
                 }
             })}
 
-            // Tag filter bar
-            <HomeTagFilterBar
-                all_tags=all_tags_signal
-                ancestor_map=ancestor_map
-                active_tags=active_tags
-                filter_mode=filter_mode
-                related_tag_ids=related_tag_ids
-                is_loading=filter_loading
-            />
+            // Tag filter bar — inside Transition so tags_res is serialized for hydration
+            <Transition fallback=|| view! {}>
+                <HomeTagFilterBar
+                    all_tags=all_tags_signal
+                    ancestor_map=ancestor_map
+                    active_tags=active_tags
+                    filter_mode=filter_mode
+                    related_tag_ids=related_tag_ids
+                    is_loading=filter_loading
+                />
+            </Transition>
 
             // Create form
             <CreateEntityInput

--- a/crates/frontend/src/pages/home.rs
+++ b/crates/frontend/src/pages/home.rs
@@ -1,3 +1,4 @@
+use kartoteka_shared::tag_utils::build_ancestor_map;
 use kartoteka_shared::types::{CreateContainerRequest, CreateListRequest};
 use leptos::prelude::*;
 use leptos_fluent::{I18n, move_tr};
@@ -73,6 +74,15 @@ fn HomeContent() -> impl IntoView {
         move || (refresh.get(), global_refresh.get()),
         |_| get_list_tag_links(),
     );
+
+    // Precomputed once when tags load; stable across filter changes
+    let ancestor_map = Memo::new(move |_| {
+        tags_res
+            .get()
+            .and_then(|r| r.ok())
+            .map(|tags| build_ancestor_map(&tags, "\\"))
+            .unwrap_or_default()
+    });
 
     // ── Mutation callbacks ─────────────────────────────────────────────
 
@@ -205,15 +215,18 @@ fn HomeContent() -> impl IntoView {
             <Transition fallback=|| view! {}>
                 {move || tags_res.get().map(|result| match result {
                     Ok(tags) if !tags.is_empty() => {
+                        let paths = ancestor_map.get();
                         view! {
                             <div class="flex flex-wrap gap-1 mb-3">
                                 {tags.into_iter().map(|tag| {
                                     let tid = tag.id.clone();
+                                    let label = paths.get(&tid).cloned().unwrap_or_else(|| tag.name.clone());
                                     let is_active = active_tag_filter.get().as_deref() == Some(&tid);
                                     view! {
                                         <TagBadge
                                             tag=tag
                                             active=is_active
+                                            label=label
                                             on_click=Callback::new(move |id: String| {
                                                 set_active_tag_filter.update(|f| {
                                                     *f = if f.as_deref() == Some(&id) { None } else { Some(id) };
@@ -239,6 +252,7 @@ fn HomeContent() -> impl IntoView {
             // Main content: sections
             <Transition fallback=|| view! { <LoadingSpinner/> }>
                 {move || {
+                    let _active = active_tag_filter.get();
                     let home = home_res.get();
                     let links = tag_links_res.get();
                     let all_tags = tags_res.get();
@@ -267,7 +281,7 @@ fn HomeContent() -> impl IntoView {
                                         pinned_containers=data.pinned_containers.clone()
                                         all_tags=tags.clone()
                                         all_links=all_links.clone()
-                                        _active_tag_filter=active_tag_filter
+                                        active_tag_filter=active_tag_filter
                                         on_tag_toggle=on_tag_toggle
                                         on_delete_list=del_cb
                                         on_pin_container=on_pin_container

--- a/crates/frontend/src/pages/home.rs
+++ b/crates/frontend/src/pages/home.rs
@@ -1,5 +1,8 @@
+use std::collections::HashSet;
+
 use kartoteka_shared::tag_utils::build_ancestor_map;
 use kartoteka_shared::types::{CreateContainerRequest, CreateListRequest};
+use kartoteka_shared::{FilterMode, HomeFilterResult};
 use leptos::prelude::*;
 use leptos_fluent::{I18n, move_tr};
 
@@ -10,9 +13,9 @@ use crate::components::common::{
 };
 use crate::components::home::{
     pinned_section::PinnedSection, recent_section::RecentSection, root_section::RootSection,
+    tag_filter_bar::HomeTagFilterBar,
 };
 use crate::components::lists::create_entity_input::CreateEntityInput;
-use crate::components::tags::tag_badge::TagBadge;
 use crate::context::GlobalRefresh;
 use crate::pages::landing::LandingPage;
 use crate::server_fns::auth::get_auth_status;
@@ -20,7 +23,10 @@ use crate::server_fns::{
     containers::{archive_container, create_container, delete_container, toggle_container_pin},
     home::{get_archived_containers, get_archived_lists, get_home_data},
     lists::{archive_list, create_list, delete_list},
-    tags::{assign_tag_to_list, get_all_tags, get_list_tag_links, remove_tag_from_list},
+    tags::{
+        assign_tag_to_list, filter_home_by_tags, get_all_tags, get_list_tag_links,
+        remove_tag_from_list,
+    },
 };
 
 #[component]
@@ -50,8 +56,9 @@ fn HomeContent() -> impl IntoView {
     let (refresh, set_refresh) = signal(0u32);
     let global_refresh = use_context::<GlobalRefresh>().expect("GlobalRefresh missing");
 
-    // Tag filter — which tag_id is active (None = no filter)
-    let (active_tag_filter, set_active_tag_filter) = signal(Option::<String>::None);
+    // Multi-tag AND filter
+    let active_tags: RwSignal<HashSet<String>> = RwSignal::new(HashSet::new());
+    let filter_mode: RwSignal<FilterMode> = RwSignal::new(FilterMode::default());
 
     // Pending delete state — (list_id, list_name)
     let pending_delete: RwSignal<Option<(String, String)>> = RwSignal::new(None);
@@ -83,6 +90,49 @@ fn HomeContent() -> impl IntoView {
             .map(|tags| build_ancestor_map(&tags, "\\"))
             .unwrap_or_default()
     });
+
+    let filter_res = Resource::new(
+        move || {
+            let mut tags: Vec<String> = active_tags.get().into_iter().collect();
+            tags.sort();
+            if tags.is_empty() {
+                None
+            } else {
+                Some((tags, filter_mode.get()))
+            }
+        },
+        |key| async move {
+            match key {
+                None => Ok(HomeFilterResult::default()),
+                Some((tags, mode)) => filter_home_by_tags(tags, mode).await,
+            }
+        },
+    );
+
+    let matching_list_ids = Signal::derive(move || {
+        if active_tags.get().is_empty() {
+            None
+        } else {
+            filter_res
+                .get()
+                .and_then(|r| r.ok())
+                .map(|r| r.matching_list_ids.into_iter().collect::<HashSet<_>>())
+        }
+    });
+
+    let related_tag_ids = Signal::derive(move || {
+        filter_res
+            .get()
+            .and_then(|r| r.ok())
+            .map(|r| r.related_tag_ids.into_iter().collect::<HashSet<_>>())
+            .unwrap_or_default()
+    });
+
+    let filter_loading =
+        Signal::derive(move || !active_tags.get().is_empty() && filter_res.get().is_none());
+
+    let all_tags_signal =
+        Signal::derive(move || tags_res.get().and_then(|r| r.ok()).unwrap_or_default());
 
     // ── Mutation callbacks ─────────────────────────────────────────────
 
@@ -212,35 +262,14 @@ fn HomeContent() -> impl IntoView {
             })}
 
             // Tag filter bar
-            <Transition fallback=|| view! {}>
-                {move || tags_res.get().map(|result| match result {
-                    Ok(tags) if !tags.is_empty() => {
-                        let paths = ancestor_map.get();
-                        view! {
-                            <div class="flex flex-wrap gap-1 mb-3">
-                                {tags.into_iter().map(|tag| {
-                                    let tid = tag.id.clone();
-                                    let label = paths.get(&tid).cloned().unwrap_or_else(|| tag.name.clone());
-                                    let is_active = active_tag_filter.get().as_deref() == Some(&tid);
-                                    view! {
-                                        <TagBadge
-                                            tag=tag
-                                            active=is_active
-                                            label=label
-                                            on_click=Callback::new(move |id: String| {
-                                                set_active_tag_filter.update(|f| {
-                                                    *f = if f.as_deref() == Some(&id) { None } else { Some(id) };
-                                                });
-                                            })
-                                        />
-                                    }
-                                }).collect::<Vec<_>>()}
-                            </div>
-                        }.into_any()
-                    }
-                    _ => view! {}.into_any(),
-                })}
-            </Transition>
+            <HomeTagFilterBar
+                all_tags=all_tags_signal
+                ancestor_map=ancestor_map
+                active_tags=active_tags
+                filter_mode=filter_mode
+                related_tag_ids=related_tag_ids
+                is_loading=filter_loading
+            />
 
             // Create form
             <CreateEntityInput
@@ -252,7 +281,7 @@ fn HomeContent() -> impl IntoView {
             // Main content: sections
             <Transition fallback=|| view! { <LoadingSpinner/> }>
                 {move || {
-                    let _active = active_tag_filter.get();
+                    let _matching = matching_list_ids.get();
                     let home = home_res.get();
                     let links = tag_links_res.get();
                     let all_tags = tags_res.get();
@@ -281,7 +310,7 @@ fn HomeContent() -> impl IntoView {
                                         pinned_containers=data.pinned_containers.clone()
                                         all_tags=tags.clone()
                                         all_links=all_links.clone()
-                                        active_tag_filter=active_tag_filter
+                                        matching_list_ids=matching_list_ids
                                         on_tag_toggle=on_tag_toggle
                                         on_delete_list=del_cb
                                         on_pin_container=on_pin_container
@@ -291,7 +320,7 @@ fn HomeContent() -> impl IntoView {
                                         recent_containers=data.recent_containers.clone()
                                         all_tags=tags.clone()
                                         all_links=all_links.clone()
-                                        active_tag_filter=active_tag_filter
+                                        matching_list_ids=matching_list_ids
                                         on_tag_toggle=on_tag_toggle
                                         on_delete_list=del_cb
                                     />
@@ -300,7 +329,7 @@ fn HomeContent() -> impl IntoView {
                                         root_lists=data.root_lists.clone()
                                         all_tags=tags.clone()
                                         all_links=all_links.clone()
-                                        active_tag_filter=active_tag_filter
+                                        matching_list_ids=matching_list_ids
                                         on_tag_toggle=on_tag_toggle
                                         on_delete_list=del_cb
                                         on_delete_container=on_delete_container

--- a/crates/frontend/src/server_fns/tags.rs
+++ b/crates/frontend/src/server_fns/tags.rs
@@ -398,3 +398,21 @@ pub async fn get_tag_detail_data(
         linked_lists,
     })
 }
+
+/// Filter home by selected tags. Returns matching list IDs and related tag IDs based on filter mode.
+#[server(prefix = "/leptos")]
+pub async fn filter_home_by_tags(
+    tag_ids: Vec<String>,
+    mode: kartoteka_shared::FilterMode,
+) -> Result<kartoteka_shared::HomeFilterResult, ServerFnError> {
+    let pool = expect_context::<SqlitePool>();
+    let auth = leptos_axum::extract::<AuthSession<KartotekaBackend>>()
+        .await
+        .map_err(|_| ServerFnError::new("auth extraction failed".to_string()))?;
+    let user = auth
+        .user
+        .ok_or_else(|| ServerFnError::new("unauthorized".to_string()))?;
+    domain::tags::filter_home_by_tags(&pool, &user.id, &tag_ids, mode)
+        .await
+        .map_err(|e| ServerFnError::new(e.to_string()))
+}

--- a/crates/mcp/src/server.rs
+++ b/crates/mcp/src/server.rs
@@ -707,7 +707,7 @@ impl KartotekaServer {
                 continue;
             }
             if let Some(eid) = db::tags::find_id_by_name_in_scope(
-                &self.pool,
+                &mut *tx,
                 &uid,
                 &tag.name,
                 parent_id.as_deref(),

--- a/crates/shared/src/dto/responses.rs
+++ b/crates/shared/src/dto/responses.rs
@@ -114,8 +114,7 @@ pub struct ParseLocationResponse {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct HomeFilterResult {
-    /// IDs of lists matching the active tag filter.
     pub matching_list_ids: Vec<String>,
-    /// IDs of tags that co-occur with the selected tags on matching lists/items.
+    pub matching_container_ids: Vec<String>,
     pub related_tag_ids: Vec<String>,
 }

--- a/crates/shared/src/dto/responses.rs
+++ b/crates/shared/src/dto/responses.rs
@@ -111,3 +111,11 @@ pub struct ParseLocationResponse {
     pub location_id: String,
     pub location: crate::models::Location,
 }
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct HomeFilterResult {
+    /// IDs of lists matching the active tag filter.
+    pub matching_list_ids: Vec<String>,
+    /// IDs of tags that co-occur with the selected tags on matching lists/items.
+    pub related_tag_ids: Vec<String>,
+}

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -4,6 +4,7 @@ pub mod date_utils;
 pub mod locale;
 pub mod tag_utils;
 pub use locale::Locale;
+pub use tag_utils::FilterMode;
 #[allow(dead_code)]
 pub(crate) mod deserializers;
 pub mod dto;

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -2,6 +2,7 @@ pub mod auth_ctx;
 pub mod constants;
 pub mod date_utils;
 pub mod locale;
+pub mod tag_utils;
 pub use locale::Locale;
 #[allow(dead_code)]
 pub(crate) mod deserializers;

--- a/crates/shared/src/tag_utils.rs
+++ b/crates/shared/src/tag_utils.rs
@@ -1,6 +1,17 @@
 use std::collections::HashMap;
 
+use serde::{Deserialize, Serialize};
+
 use crate::types::Tag;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum FilterMode {
+    #[default]
+    Listwise,
+    Itemwise,
+    Joined,
+}
 
 /// Returns the full ancestor path of a tag joined by `sep` (root → leaf).
 /// E.g. with sep `"\\"`: "Hobby\\Ogród\\Warzywa"

--- a/crates/shared/src/tag_utils.rs
+++ b/crates/shared/src/tag_utils.rs
@@ -1,0 +1,36 @@
+use std::collections::HashMap;
+
+use crate::types::Tag;
+
+/// Returns the full ancestor path of a tag joined by `sep` (root → leaf).
+/// E.g. with sep `"\\"`: "Hobby\\Ogród\\Warzywa"
+pub fn ancestor_path(tag: &Tag, all_tags: &[Tag], sep: &str) -> String {
+    let by_id: HashMap<&str, &Tag> = all_tags.iter().map(|t| (t.id.as_str(), t)).collect();
+    ancestor_path_with_map(tag, &by_id, sep)
+}
+
+/// Builds a map of `tag_id → ancestor_path` for all tags in one pass.
+/// Use this when you need paths for many tags — avoids rebuilding the lookup map per tag.
+pub fn build_ancestor_map(all_tags: &[Tag], sep: &str) -> HashMap<String, String> {
+    let by_id: HashMap<&str, &Tag> = all_tags.iter().map(|t| (t.id.as_str(), t)).collect();
+    all_tags
+        .iter()
+        .map(|tag| (tag.id.clone(), ancestor_path_with_map(tag, &by_id, sep)))
+        .collect()
+}
+
+fn ancestor_path_with_map<'a>(tag: &'a Tag, by_id: &HashMap<&str, &'a Tag>, sep: &str) -> String {
+    let mut parts = vec![tag.name.clone()];
+    let mut current = tag;
+    while let Some(ref pid) = current.parent_tag_id {
+        match by_id.get(pid.as_str()) {
+            Some(&parent) => {
+                parts.push(parent.name.clone());
+                current = parent;
+            }
+            None => break,
+        }
+    }
+    parts.reverse();
+    parts.join(sep)
+}


### PR DESCRIPTION
## Summary

- Add multi-tag AND filtering on the home page: select multiple tags, see only lists that have **all** selected tags
- Tag bar narrows to co-occurring tags when a filter is active
- Mode switch: **Listy** (list-level tags), **Elementy** (item-level tags), **Oba** (union of both)
- Filtering is server-side via a new `filter_home_by_tags` domain function + Leptos server function
- Tag labels show ancestor path (e.g. `Hobby\Ogród`) using `build_ancestor_map` from `shared`

## Changes

- `shared`: `FilterMode` enum, `HomeFilterResult` DTO, `build_ancestor_map` utility
- `domain`: `filter_home_by_tags` with listwise, itemwise, and joined modes using `QueryBuilder` dynamic IN clauses; 5 integration tests
- `server_fns`: `filter_home_by_tags` Leptos server function
- `frontend/components/home`: new `HomeTagFilterBar` component; updated `PinnedSection`, `RecentSection`, `RootSection` to accept `Signal<Option<HashSet<String>>>` instead of single-tag `ReadSignal`
- `frontend/pages/home`: replaced single-tag state with `RwSignal<HashSet<String>>` + `filter_res` Resource; wired new filter bar component

## Test plan

- [ ] `cargo test -p kartoteka-domain filter_home` — all 5 tests pass
- [ ] `cargo leptos build` — SSR + WASM build clean
- [ ] Manual: mode switch visible above tag list
- [ ] Manual: clicking a tag adds it to selected row with ×, clicking × removes it
- [ ] Manual: available tag list narrows to co-occurring tags when filter is active
- [ ] Manual: lists update to show only those matching selected tags
- [ ] Manual: switching mode (Listy → Elementy) with active tags re-fetches results

🤖 Generated with [Claude Code](https://claude.com/claude-code)