### PR TITLE
perf(db): add indexes for list name dedup and container item queries

### DIFF
--- a/crates/db/migrations/010_idx_lists_name_normalized.sql
+++ b/crates/db/migrations/010_idx_lists_name_normalized.sql
@@ -1,0 +1,4 @@
+-- Expression index for list name dedup check in create_list.
+-- Turns LOWER(TRIM(name)) scan into an index lookup; covers full WHERE clause.
+CREATE INDEX IF NOT EXISTS idx_lists_name_normalized
+    ON lists(user_id, LOWER(TRIM(name)), container_id, parent_list_id);

--- a/crates/db/migrations/011_idx_lists_container_user.sql
+++ b/crates/db/migrations/011_idx_lists_container_user.sql
@@ -1,0 +1,6 @@
+-- Composite index for list_container_items non-recursive path.
+-- Existing idx_lists_container covers only container_id; this adds user_id + archived
+-- so the WHERE clause filters without a post-scan, reducing JOIN overhead.
+CREATE INDEX IF NOT EXISTS idx_lists_container_user
+    ON lists(container_id, user_id, archived)
+    WHERE container_id IS NOT NULL;


### PR DESCRIPTION
## Summary

- Adds expression index `idx_lists_name_normalized` on `lists(user_id, LOWER(TRIM(name)), container_id, parent_list_id)` — turns the duplicate-name scan in `create_list` from a per-row expression evaluation into an index lookup (closes #249)
- Adds composite index `idx_lists_container_user` on `lists(container_id, user_id, archived) WHERE container_id IS NOT NULL` — extends the existing `idx_lists_container` to cover `user_id` and `archived`, reducing join overhead in `list_container_items` non-recursive path (closes #250)

Both indexes are applied via SQLx migrations (`010`, `011`) and take effect on next server start.

## Test plan

- [ ] `just check` passes
- [ ] Deploy to preview, verify server starts and migrations apply cleanly
- [ ] Check prod logs: `list_container_items` latency drops from ~6ms baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)