### PR TITLE
chore(observability): NDJSON logging, span latencies, tracing filter, diagnostic scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ page-*.json
 # Local ops scripts (zawierają URL-e infrastruktury)
 scripts/coolify-*.sh
 scripts/coolify-*.py
+scripts/.docker-env.local
+*.pyc

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ CLOUDFLARE_ACCOUNT_ID=your-account-id
 HANKO_API_URL=https://your-project.hanko.io
 ```
 
+#### Optional env vars
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `LOG_HEALTH_REQUESTS` | *(unset)* | Set to `true` to include `/health` polling in HTTP trace logs. Unset by default — Docker healthchecks fire every 30s and would flood logs. |
+
 ### D1
 
 The project uses three environments with separate D1 databases:

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -78,9 +78,9 @@ pub async fn create_pool(url: &str) -> Result<SqlitePool, DbError> {
         // returning SQLITE_BUSY immediately when another write holds the lock.
         .busy_timeout(Duration::from_secs(5));
 
-    // min_connections stays at 0 (lazy): eager opening (min_connections>0) raced
-    // with migrations and caused sporadic "no such table" errors. Lazy opening is
-    // safe because connections are only acquired after migrations complete.
+    // min_connections stays at 0 so the pool does not eagerly open connections beyond
+    // the first one. min_connections>0 would race with migrations: the extra connections
+    // open concurrently and see an empty schema before migrations finish.
     let pool = SqlitePoolOptions::new()
         .max_connections(5)
         .connect_with(options)

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -73,15 +73,16 @@ pub async fn create_pool(url: &str) -> Result<SqlitePool, DbError> {
         .foreign_keys(true)
         .journal_mode(SqliteJournalMode::Wal)
         .synchronous(SqliteSynchronous::Normal)
-        .log_slow_statements(LevelFilter::Warn, Duration::from_millis(1));
+        .log_slow_statements(LevelFilter::Warn, Duration::from_millis(1))
+        // WAL allows concurrent reads; busy_timeout lets writers retry instead of
+        // returning SQLITE_BUSY immediately when another write holds the lock.
+        .busy_timeout(Duration::from_secs(5));
 
-    // SQLite is single-writer. SQLx docs canonical pattern:
-    // SqlitePoolOptions::new().max_connections(1).connect_with(options)
-    // Pre-opening connections (min_connections>0) opens them concurrently with
-    // migrations in the background, cached partial/empty schema views caused
-    // sporadic "no such table" errors on later requests.
+    // min_connections stays at 0 (lazy): eager opening (min_connections>0) raced
+    // with migrations and caused sporadic "no such table" errors. Lazy opening is
+    // safe because connections are only acquired after migrations complete.
     let pool = SqlitePoolOptions::new()
-        .max_connections(1)
+        .max_connections(5)
         .connect_with(options)
         .await?;
 

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -73,7 +73,7 @@ pub async fn create_pool(url: &str) -> Result<SqlitePool, DbError> {
         .foreign_keys(true)
         .journal_mode(SqliteJournalMode::Wal)
         .synchronous(SqliteSynchronous::Normal)
-        .log_slow_statements(LevelFilter::Warn, Duration::from_millis(10));
+        .log_slow_statements(LevelFilter::Warn, Duration::from_millis(1));
 
     // SQLite is single-writer. SQLx docs canonical pattern:
     // SqlitePoolOptions::new().max_connections(1).connect_with(options)

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -176,7 +176,9 @@ pub fn router(
         StreamableHttpServerConfig::default().with_allowed_hosts(mcp_allowed_hosts),
     );
 
-    Router::new()
+    let log_health = std::env::var("LOG_HEALTH_REQUESTS").as_deref() == Ok("true");
+
+    let traced = Router::new()
         .nest(
             "/.well-known",
             kartoteka_oauth::well_known_routes().with_state(oauth_state.clone()),
@@ -201,7 +203,6 @@ pub fn router(
             "/leptos/{*fn_name}",
             axum::routing::get(server_fn_handler).post(server_fn_handler),
         )
-        .route("/health", axum::routing::get(health::health))
         // SSR page rendering for all Leptos routes (/, /today, /lists/:id, etc.)
         .leptos_routes_with_handler(routes, axum::routing::get(leptos_routes_handler))
         // Static asset serving from target/site
@@ -218,6 +219,18 @@ pub fn router(
         )
         .layer(axum::middleware::from_fn(
             middleware::reject_file_like_paths,
-        ))
-        .with_state(state)
+        ));
+
+    // /health is excluded from TraceLayer by default (polled every 30s by Docker).
+    // Set LOG_HEALTH_REQUESTS=true to include it in traces.
+    if log_health {
+        traced
+            .route("/health", axum::routing::get(health::health))
+            .with_state(state)
+    } else {
+        Router::new()
+            .route("/health", axum::routing::get(health::health))
+            .merge(traced)
+            .with_state(state)
+    }
 }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -178,7 +178,7 @@ pub fn router(
 
     let log_health = std::env::var("LOG_HEALTH_REQUESTS").as_deref() == Ok("true");
 
-    let traced = Router::new()
+    let mut base = Router::new()
         .nest(
             "/.well-known",
             kartoteka_oauth::well_known_routes().with_state(oauth_state.clone()),
@@ -206,7 +206,16 @@ pub fn router(
         // SSR page rendering for all Leptos routes (/, /today, /lists/:id, etc.)
         .leptos_routes_with_handler(routes, axum::routing::get(leptos_routes_handler))
         // Static asset serving from target/site
-        .fallback(leptos_axum::file_and_error_handler::<AppState, _>(shell))
+        .fallback(leptos_axum::file_and_error_handler::<AppState, _>(shell));
+
+    // /health is excluded from TraceLayer by default (polled every 30s by Docker).
+    // Set LOG_HEALTH_REQUESTS=true to include it in traces.
+    // Must be added before .layer() — axum only wraps routes present at layer time.
+    if log_health {
+        base = base.route("/health", axum::routing::get(health::health));
+    }
+
+    let traced = base
         .layer(auth_layer)
         .layer(
             TraceLayer::new_for_http()
@@ -221,12 +230,8 @@ pub fn router(
             middleware::reject_file_like_paths,
         ));
 
-    // /health is excluded from TraceLayer by default (polled every 30s by Docker).
-    // Set LOG_HEALTH_REQUESTS=true to include it in traces.
     if log_health {
-        traced
-            .route("/health", axum::routing::get(health::health))
-            .with_state(state)
+        traced.with_state(state)
     } else {
         Router::new()
             .route("/health", axum::routing::get(health::health))

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -7,9 +7,9 @@ use tower_sessions_sqlx_store::SqliteStore;
 async fn main() {
     let app_env = std::env::var("APP_ENV").unwrap_or_default();
     let default_filter = match app_env.as_str() {
-        "production" => "kartoteka_server=info,tower_http=info,sqlx=warn",
-        "preview" => "kartoteka_server=trace,tower_http=trace,sqlx=debug",
-        _ => "kartoteka_server=debug,tower_http=debug,sqlx=debug",
+        "production" => "info,sqlx=warn",
+        "preview" => "debug,kartoteka_server=trace,tower_http=trace,sqlx=debug",
+        _ => "debug,kartoteka_server=debug,tower_http=debug,sqlx=debug",
     };
     let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| default_filter.into());

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -15,9 +15,10 @@ async fn main() {
         .unwrap_or_else(|_| default_filter.into());
 
     match app_env.as_str() {
-        "production" | "preview" => {
+        "production" | "preview" | "develop" => {
             tracing_subscriber::fmt()
                 .with_env_filter(env_filter)
+                .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
                 .json()
                 .init();
         }

--- a/scripts/_common.py
+++ b/scripts/_common.py
@@ -1,0 +1,70 @@
+"""Shared utilities for docker log analysis scripts."""
+import io
+import os
+import re
+import subprocess
+import sys
+
+_RESERVED_KEYS = {"ssh_host"}
+
+
+def load_env_map(path=None):
+    if path is None:
+        path = os.path.join(os.path.dirname(__file__), ".docker-env.local")
+    result = {}
+    if os.path.exists(path):
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if line and not line.startswith("#") and "=" in line:
+                    k, v = line.split("=", 1)
+                    result[k.strip()] = v.strip()
+    return result
+
+
+def known_envs():
+    """Return env names defined in .docker-env.local (keys excluding reserved ones like ssh_host)."""
+    return {k for k in load_env_map() if k not in _RESERVED_KEYS}
+
+
+def fetch_logs(env, tail=300):
+    cfg = load_env_map()
+    prefix = cfg.get(env)
+    host = cfg.get("ssh_host")
+    if not prefix or not host:
+        sys.exit(f"Unknown env '{env}' or missing ssh_host. Check scripts/.docker-env.local")
+    find = f"docker ps --format '{{{{.Names}}}}' | grep {prefix} | head -1"
+    name = subprocess.check_output(["ssh", host, find], text=True).strip()
+    if not name:
+        sys.exit(f"No running container found for env '{env}' (prefix: {prefix})")
+    print(f"[{env}] {name}", file=sys.stderr)
+    raw = subprocess.check_output(
+        ["ssh", host, f"docker logs {name} --tail {tail} 2>&1"], text=True
+    )
+    return io.StringIO(raw)
+
+
+def open_source(arg, tail=300):
+    """Return a readable stream: SSH fetch for env names, file open for paths, stdin otherwise."""
+    if arg in known_envs():
+        return fetch_logs(arg, tail)
+    if arg:
+        return open(arg)
+    return sys.stdin
+
+
+def strip_leptos_hash(uri):
+    """'/leptos/get_item123456789' → '/leptos/get_item'"""
+    return re.sub(r"(/leptos/[a-zA-Z_]+)\d+", r"\1", uri)
+
+
+def parse_duration_ms(s):
+    """Parse '341µs', '1.2ms', '3s' → float ms. Returns 0.0 on unrecognised input."""
+    s = s.strip()
+    if s.endswith("µs"):
+        return float(s[:-2]) / 1000
+    if s.endswith("ms"):
+        return float(s[:-2])
+    if s.endswith("s"):
+        return float(s[:-1]) * 1000
+    return 0.0

--- a/scripts/docker-logs.py
+++ b/scripts/docker-logs.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Parse raw NDJSON logs from `docker logs` (prod/preview/develop containers via SSH).
+
+Usage:
+    ssh niechybnie "docker logs <container> --tail 300 2>&1" | python3 scripts/docker-logs.py
+    ssh niechybnie "docker logs <container> --tail 300 2>&1" > /tmp/logs.json && python3 scripts/docker-logs.py /tmp/logs.json
+    python3 scripts/docker-logs.py /tmp/logs.json [lines] [filter]
+
+Container names (from `docker ps`):
+    prod:    y36bsm3jukhpg7i4cw7yp0hf-*   (ghcr.io/jpalczewski/kartoteka:latest)
+    develop: hpxmp0eeq02kj3qoqdjud8k8-*   (ghcr.io/jpalczewski/kartoteka:develop)
+    preview: wrpu74yku32jdqz74f54ljbq-*   (ghcr.io/jpalczewski/kartoteka:preview)
+"""
+import json
+import re
+import sys
+
+src = open(sys.argv[1]) if len(sys.argv) > 1 else sys.stdin
+lines_limit = int(sys.argv[2]) if len(sys.argv) > 2 else 0
+query = sys.argv[3].lower() if len(sys.argv) > 3 else ""
+
+entries = []
+for line in src:
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        obj = json.loads(line)
+        ts = obj.get("timestamp", "")[:19].replace("T", " ")
+        level = obj.get("level", "?").upper()
+        target = obj.get("target", "")
+        fields = obj.get("fields", {})
+        span = obj.get("span", {})
+        spans = obj.get("spans", [])
+
+        msg = fields.get("message", fields.get("summary", ""))
+        if not msg:
+            msg = json.dumps(fields)[:80]
+
+        # surface action from handler spans
+        action = next((s.get("action") for s in reversed(spans) if "action" in s), None)
+        # surface HTTP context from spans
+        http = next((f"{s['method']} {s['uri']}" for s in spans if "uri" in s), None)
+        # surface MCP tool name from request field
+        mcp_tool = None
+        if "request" in fields:
+            m = re.search(r'name: "(\w+)"', fields["request"])
+            if m:
+                mcp_tool = m.group(1)
+
+        out = f"{ts}  {level:<5}  {target:<42}  {msg[:70]}"
+        if action:
+            out += f"  [action={action}]"
+        if mcp_tool:
+            out += f"  [tool={mcp_tool}]"
+        if http and "tower_http" not in target:
+            out += f"  ({http})"
+        entries.append(out)
+    except (json.JSONDecodeError, KeyError):
+        entries.append(line[:120])
+
+if query:
+    entries = [e for e in entries if query in e.lower()]
+if lines_limit:
+    entries = entries[-lines_limit:]
+
+for e in entries:
+    print(e)
+print(f"\n--- {len(entries)} entries ---", file=sys.stderr)

--- a/scripts/docker-logs.py
+++ b/scripts/docker-logs.py
@@ -1,23 +1,35 @@
 #!/usr/bin/env python3
-"""Parse raw NDJSON logs from `docker logs` (prod/preview/develop containers via SSH).
+"""Parse raw NDJSON logs from `docker logs`.
 
 Usage:
-    ssh niechybnie "docker logs <container> --tail 300 2>&1" | python3 scripts/docker-logs.py
-    ssh niechybnie "docker logs <container> --tail 300 2>&1" > /tmp/logs.json && python3 scripts/docker-logs.py /tmp/logs.json
+    python3 scripts/docker-logs.py <env>              # SSH directly (needs scripts/.docker-env.local)
+    python3 scripts/docker-logs.py <env> 100 warn     # custom tail + filter
     python3 scripts/docker-logs.py /tmp/logs.json [lines] [filter]
 
-Container names (from `docker ps`):
-    prod:    y36bsm3jukhpg7i4cw7yp0hf-*   (ghcr.io/jpalczewski/kartoteka:latest)
-    develop: hpxmp0eeq02kj3qoqdjud8k8-*   (ghcr.io/jpalczewski/kartoteka:develop)
-    preview: wrpu74yku32jdqz74f54ljbq-*   (ghcr.io/jpalczewski/kartoteka:preview)
+scripts/.docker-env.local is gitignored — create it with:
+    <env-name>=<container-prefix>
+    ssh_host=<host>
 """
 import json
 import re
 import sys
+import os
 
-src = open(sys.argv[1]) if len(sys.argv) > 1 else sys.stdin
-lines_limit = int(sys.argv[2]) if len(sys.argv) > 2 else 0
-query = sys.argv[3].lower() if len(sys.argv) > 3 else ""
+sys.path.insert(0, os.path.dirname(__file__))
+from _common import known_envs, open_source, strip_leptos_hash
+
+arg1 = sys.argv[1] if len(sys.argv) > 1 else None
+envs = known_envs()
+
+if arg1 in envs:
+    tail_arg = int(sys.argv[2]) if len(sys.argv) > 2 and sys.argv[2].isdigit() else 300
+    query = sys.argv[3].lower() if len(sys.argv) > 3 else ""
+    lines_limit = 0
+    src = open_source(arg1, tail_arg)
+else:
+    lines_limit = int(sys.argv[2]) if len(sys.argv) > 2 and sys.argv[2].isdigit() else 0
+    query = sys.argv[3].lower() if len(sys.argv) > 3 else ""
+    src = open_source(arg1)
 
 entries = []
 for line in src:
@@ -37,18 +49,20 @@ for line in src:
         if not msg:
             msg = json.dumps(fields)[:80]
 
-        # surface action from handler spans
+        if msg == "close" and "time.busy" in fields:
+            msg = f"close  busy={fields['time.busy']} idle={fields['time.idle']}"
+
         action = next((s.get("action") for s in reversed(spans) if "action" in s), None)
-        # surface HTTP context from spans
-        http = next((f"{s['method']} {s['uri']}" for s in spans if "uri" in s), None)
-        # surface MCP tool name from request field
+        http = next((f"{s['method']} {strip_leptos_hash(s['uri'])}" for s in spans if "uri" in s), None)
         mcp_tool = None
         if "request" in fields:
             m = re.search(r'name: "(\w+)"', fields["request"])
             if m:
                 mcp_tool = m.group(1)
+        if "stream_duration" in fields:
+            msg += f"  [session {fields['stream_duration']}]"
 
-        out = f"{ts}  {level:<5}  {target:<42}  {msg[:70]}"
+        out = f"{ts}  {level:<5}  {target:<42}  {msg[:90]}"
         if action:
             out += f"  [action={action}]"
         if mcp_tool:

--- a/scripts/docker-perf.py
+++ b/scripts/docker-perf.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Analyze query performance and HTTP latencies from raw NDJSON docker logs.
+
+Usage:
+    ssh niechybnie "docker logs <container> --tail 500 2>&1" > /tmp/logs.json
+    python3 scripts/docker-perf.py /tmp/logs.json
+"""
+import json
+import re
+import sys
+from collections import Counter
+
+src = open(sys.argv[1]) if len(sys.argv) > 1 else sys.stdin
+lines = src.readlines()
+
+queries = []
+responses = []
+mcp_tools = []
+warns = []
+
+for line in lines:
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        obj = json.loads(line)
+        target = obj.get("target", "")
+        fields = obj.get("fields", {})
+        spans = obj.get("spans", [])
+        ts = obj.get("timestamp", "")[:19].replace("T", " ")
+        level = obj.get("level", "?").upper()
+
+        if target == "sqlx::query":
+            elapsed_ms = fields.get("elapsed_secs", 0) * 1000
+            http = next((f"{s['method']} {s['uri']}" for s in spans if "uri" in s), "internal")
+            span = obj.get("span", {})
+            span_name = span.get("name", "")
+            summary = fields.get("summary", "")[:60]
+            queries.append((elapsed_ms, summary, http, span_name, ts))
+
+        elif target == "tower_http::trace::on_response":
+            latency_str = fields.get("latency", "0 ms")
+            latency_ms = float(re.search(r"[\d.]+", latency_str).group())
+            status = fields.get("status", 0)
+            span = obj.get("span", {})
+            uri = span.get("uri", "")
+            method = span.get("method", "")
+            if uri != "/health":
+                responses.append((latency_ms, status, method, uri, ts))
+
+        elif target == "rmcp::service" and "received request" in fields.get("message", ""):
+            m = re.search(r'name: "(\w+)"', fields.get("request", ""))
+            if m:
+                mcp_tools.append(m.group(1))
+
+        elif level == "WARN":
+            msg = fields.get("message", "")
+            error = fields.get("error", "")
+            warns.append(f"{ts}  {target}  {msg}  {error}")
+
+    except (json.JSONDecodeError, KeyError, AttributeError):
+        pass
+
+print("=== SLOW QUERIES (>1ms) ===")
+slow = sorted([q for q in queries if q[0] > 1.0], reverse=True)
+if slow:
+    for ms, summary, http, span_name, ts in slow:
+        print(f"  {ms:7.2f}ms  [{span_name:<20}]  {summary:<55}  ({http})")
+else:
+    print("  none")
+
+print(f"\n=== QUERY STATS ===")
+if queries:
+    times = [q[0] for q in queries]
+    print(f"  count={len(times)}  min={min(times):.3f}ms  avg={sum(times)/len(times):.3f}ms  "
+          f"p90={sorted(times)[int(len(times)*0.9)]:.3f}ms  max={max(times):.3f}ms")
+else:
+    print("  no queries found")
+
+print(f"\n=== NON-HEALTH HTTP RESPONSES ===")
+if responses:
+    for ms, status, method, uri, ts in sorted(responses, key=lambda x: x[0], reverse=True):
+        flag = "  ⚠" if status >= 400 else ""
+        print(f"  {ts}  {method} {uri:<35} → {status}  {ms:.0f}ms{flag}")
+else:
+    print("  none")
+
+print(f"\n=== MCP TOOL USAGE ===")
+if mcp_tools:
+    for tool, count in Counter(mcp_tools).most_common():
+        print(f"  {tool}: {count}x")
+else:
+    print("  none")
+
+print(f"\n=== WARNINGS ===")
+if warns:
+    for w in warns:
+        print(f"  {w}")
+else:
+    print("  none")

--- a/scripts/docker-perf.py
+++ b/scripts/docker-perf.py
@@ -1,22 +1,38 @@
 #!/usr/bin/env python3
-"""Analyze query performance and HTTP latencies from raw NDJSON docker logs.
+"""Analyze query performance and HTTP latencies from NDJSON docker logs.
 
 Usage:
-    ssh niechybnie "docker logs <container> --tail 500 2>&1" > /tmp/logs.json
-    python3 scripts/docker-perf.py /tmp/logs.json
+    python3 scripts/docker-perf.py <env>           # SSH directly (needs scripts/.docker-env.local)
+    python3 scripts/docker-perf.py <env> 300       # custom tail lines
+    python3 scripts/docker-perf.py /tmp/logs.json  # from saved file
+
+scripts/.docker-env.local is gitignored — create it with:
+    <env-name>=<container-prefix>
+    ssh_host=<host>
 """
 import json
 import re
 import sys
-from collections import Counter
+import os
 
-src = open(sys.argv[1]) if len(sys.argv) > 1 else sys.stdin
+sys.path.insert(0, os.path.dirname(__file__))
+from _common import known_envs, open_source, strip_leptos_hash, parse_duration_ms
+
+from collections import Counter, defaultdict
+
+arg1 = sys.argv[1] if len(sys.argv) > 1 else None
+tail_arg = int(sys.argv[2]) if len(sys.argv) > 2 and sys.argv[2].isdigit() else 500
+src = open_source(arg1, tail_arg)
 lines = src.readlines()
 
 queries = []
 responses = []
 mcp_tools = []
 warns = []
+span_busy = defaultdict(list)
+mcp_sessions = []
+locale_calls = 0
+total_requests = 0
 
 for line in lines:
     line = line.strip()
@@ -27,14 +43,14 @@ for line in lines:
         target = obj.get("target", "")
         fields = obj.get("fields", {})
         spans = obj.get("spans", [])
+        span = obj.get("span", {})
         ts = obj.get("timestamp", "")[:19].replace("T", " ")
         level = obj.get("level", "?").upper()
+        span_name = span.get("name", "")
 
         if target == "sqlx::query":
             elapsed_ms = fields.get("elapsed_secs", 0) * 1000
-            http = next((f"{s['method']} {s['uri']}" for s in spans if "uri" in s), "internal")
-            span = obj.get("span", {})
-            span_name = span.get("name", "")
+            http = next((f"{s['method']} {strip_leptos_hash(s['uri'])}" for s in spans if "uri" in s), "internal")
             summary = fields.get("summary", "")[:60]
             queries.append((elapsed_ms, summary, http, span_name, ts))
 
@@ -42,16 +58,26 @@ for line in lines:
             latency_str = fields.get("latency", "0 ms")
             latency_ms = float(re.search(r"[\d.]+", latency_str).group())
             status = fields.get("status", 0)
-            span = obj.get("span", {})
-            uri = span.get("uri", "")
+            uri = strip_leptos_hash(span.get("uri", ""))
             method = span.get("method", "")
             if uri != "/health":
                 responses.append((latency_ms, status, method, uri, ts))
+                total_requests += 1
 
         elif target == "rmcp::service" and "received request" in fields.get("message", ""):
             m = re.search(r'name: "(\w+)"', fields.get("request", ""))
             if m:
                 mcp_tools.append(m.group(1))
+
+        elif "time.busy" in fields and fields.get("message") == "close":
+            busy_ms = parse_duration_ms(fields["time.busy"])
+            if span_name:
+                span_busy[span_name].append(busy_ms)
+            if span_name == "get_locale":
+                locale_calls += 1
+
+        elif "stream_duration" in fields:
+            mcp_sessions.append(fields["stream_duration"])
 
         elif level == "WARN":
             msg = fields.get("message", "")
@@ -77,11 +103,42 @@ if queries:
 else:
     print("  no queries found")
 
+print(f"\n=== SPAN LATENCIES (time.busy) ===")
+if span_busy:
+    rows = []
+    for name, times in span_busy.items():
+        s = sorted(times)
+        rows.append((max(s), name, len(s), sum(s)/len(s), s[int(len(s)*0.9)], max(s)))
+    for _, name, cnt, avg, p90, mx in sorted(rows, reverse=True):
+        print(f"  {name:<30}  n={cnt:<4}  avg={avg:.2f}ms  p90={p90:.2f}ms  max={mx:.2f}ms")
+else:
+    print("  none")
+
+if locale_calls > 0 and total_requests > 0:
+    ratio = locale_calls / total_requests
+    flag = "  ⚠ N+1 — consider caching (issue #264)" if ratio >= 0.5 else ""
+    print(f"\n=== LOCALE N+1 ===")
+    print(f"  get_locale calls: {locale_calls}  /  {total_requests} requests  (ratio {ratio:.1f}){flag}")
+
+if mcp_sessions:
+    print(f"\n=== MCP SESSIONS ===")
+    for d in mcp_sessions:
+        print(f"  session duration: {d}")
+
 print(f"\n=== NON-HEALTH HTTP RESPONSES ===")
 if responses:
+    mcp_404_count = 0
     for ms, status, method, uri, ts in sorted(responses, key=lambda x: x[0], reverse=True):
-        flag = "  ⚠" if status >= 400 else ""
-        print(f"  {ts}  {method} {uri:<35} → {status}  {ms:.0f}ms{flag}")
+        if status == 404 and uri == "/mcp":
+            mcp_404_count += 1
+            note = "  [session init]"
+        elif status >= 400:
+            note = "  ⚠"
+        else:
+            note = ""
+        print(f"  {ts}  {method} {uri:<40} → {status}  {ms:.0f}ms{note}")
+    if mcp_404_count:
+        print(f"  ({mcp_404_count}x /mcp 404 = normal rmcp session init, not errors)")
 else:
     print("  none")
 

--- a/scripts/test_docker_scripts.py
+++ b/scripts/test_docker_scripts.py
@@ -1,0 +1,195 @@
+"""Unit tests for _common.py and smoke tests for both analysis scripts."""
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(__file__))
+import _common
+
+SAMPLE_NDJSON = """\
+{"timestamp":"2026-06-07T10:00:00.000Z","level":"INFO","target":"sqlx::query","fields":{"elapsed_secs":0.0005,"summary":"SELECT * FROM items WHERE"},"spans":[{"method":"GET","uri":"/leptos/get_item1135330933350608713"}],"span":{"name":"handle_request"}}
+{"timestamp":"2026-06-07T10:00:01.000Z","level":"INFO","target":"sqlx::query","fields":{"elapsed_secs":0.003,"summary":"INSERT INTO items (id, title)"},"spans":[{"method":"POST","uri":"/api/items"}],"span":{"name":"create_item"}}
+{"timestamp":"2026-06-07T10:00:02.000Z","level":"INFO","target":"tower_http::trace::on_response","fields":{"latency":"12 ms","status":200},"spans":[],"span":{"name":"HTTP","method":"GET","uri":"/leptos/get_item1135330933350608713"}}
+{"timestamp":"2026-06-07T10:00:03.000Z","level":"INFO","target":"tower_http::trace::on_response","fields":{"latency":"5 ms","status":404},"spans":[],"span":{"name":"HTTP","method":"POST","uri":"/mcp"}}
+{"timestamp":"2026-06-07T10:00:04.000Z","level":"INFO","target":"tower_http::trace::on_response","fields":{"latency":"1 ms","status":200},"spans":[],"span":{"name":"HTTP","method":"GET","uri":"/health"}}
+{"timestamp":"2026-06-07T10:00:05.000Z","level":"WARN","target":"kartoteka_server","fields":{"message":"something odd","error":"timeout"},"spans":[],"span":{}}
+{"timestamp":"2026-06-07T10:00:06.000Z","level":"INFO","target":"kartoteka_db::preferences","fields":{"message":"close","time.busy":"341µs","time.idle":"257µs"},"spans":[],"span":{"name":"get_locale"}}
+{"timestamp":"2026-06-07T10:00:07.000Z","level":"INFO","target":"rmcp::service","fields":{"message":"received request","request":"CallTool { name: \\"list_lists\\", ... }"},"spans":[],"span":{}}
+{"timestamp":"2026-06-07T10:00:08.000Z","level":"INFO","target":"rmcp::session","fields":{"stream_duration":"4.321s"},"spans":[],"span":{}}
+not-json-at-all
+"""
+
+
+class TestStripLeptosHash(unittest.TestCase):
+    def test_strips_numeric_suffix(self):
+        self.assertEqual(
+            _common.strip_leptos_hash("/leptos/get_item1135330933350608713"),
+            "/leptos/get_item",
+        )
+
+    def test_strips_in_middle_of_url(self):
+        self.assertEqual(
+            _common.strip_leptos_hash("/leptos/create_list9876543210"),
+            "/leptos/create_list",
+        )
+
+    def test_leaves_non_leptos_unchanged(self):
+        self.assertEqual(_common.strip_leptos_hash("/api/items"), "/api/items")
+
+    def test_leaves_leptos_without_hash_unchanged(self):
+        self.assertEqual(_common.strip_leptos_hash("/leptos/get_item"), "/leptos/get_item")
+
+
+class TestParseDurationMs(unittest.TestCase):
+    def test_microseconds(self):
+        self.assertAlmostEqual(_common.parse_duration_ms("341µs"), 0.341)
+
+    def test_milliseconds(self):
+        self.assertAlmostEqual(_common.parse_duration_ms("1.2ms"), 1.2)
+
+    def test_seconds(self):
+        self.assertAlmostEqual(_common.parse_duration_ms("3s"), 3000.0)
+
+    def test_with_whitespace(self):
+        self.assertAlmostEqual(_common.parse_duration_ms("  500µs  "), 0.5)
+
+    def test_unknown_returns_zero(self):
+        self.assertEqual(_common.parse_duration_ms("unknown"), 0.0)
+
+
+class TestLoadEnvMap(unittest.TestCase):
+    def test_parses_key_value(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".local", delete=False) as f:
+            f.write("myenv=abc123\n# comment\nssh_host=myhost\n")
+            name = f.name
+        try:
+            result = _common.load_env_map(name)
+            self.assertEqual(result["myenv"], "abc123")
+            self.assertEqual(result["ssh_host"], "myhost")
+            self.assertNotIn("# comment", result)
+        finally:
+            os.unlink(name)
+
+    def test_missing_file_returns_empty(self):
+        result = _common.load_env_map("/nonexistent/path/.docker-env.local")
+        self.assertEqual(result, {})
+
+    def test_known_envs_excludes_ssh_host(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".local", delete=False) as f:
+            f.write("myenv=abc123\nssh_host=myhost\n")
+            name = f.name
+        try:
+            # Temporarily patch load_env_map path
+            orig = _common.load_env_map
+            _common.load_env_map = lambda path=None: orig(name)
+            envs = _common.known_envs()
+            self.assertIn("myenv", envs)
+            self.assertNotIn("ssh_host", envs)
+        finally:
+            _common.load_env_map = orig
+            os.unlink(name)
+
+
+class TestSmokeDockerLogs(unittest.TestCase):
+    def _run(self, *args):
+        script = os.path.join(os.path.dirname(__file__), "docker-logs.py")
+        result = subprocess.run(
+            [sys.executable, script] + list(args),
+            input=SAMPLE_NDJSON,
+            capture_output=True,
+            text=True,
+        )
+        return result
+
+    def test_reads_from_stdin(self):
+        r = self._run()
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("sqlx::query", r.stdout)
+
+    def test_filter_by_keyword(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write(SAMPLE_NDJSON)
+            name = f.name
+        try:
+            r = self._run(name, "0", "warn")
+            self.assertEqual(r.returncode, 0)
+            self.assertIn("WARN", r.stdout)
+            self.assertNotIn("sqlx::query", r.stdout)
+        finally:
+            os.unlink(name)
+
+    def test_leptos_hash_stripped(self):
+        r = self._run()
+        self.assertNotIn("1135330933350608713", r.stdout)
+        self.assertIn("/leptos/get_item", r.stdout)
+
+    def test_close_enriched_with_times(self):
+        r = self._run()
+        self.assertIn("busy=341µs", r.stdout)
+
+    def test_invalid_json_lines_skipped(self):
+        r = self._run()
+        self.assertEqual(r.returncode, 0)
+
+
+class TestSmokeDockerPerf(unittest.TestCase):
+    def _run(self, *args):
+        script = os.path.join(os.path.dirname(__file__), "docker-perf.py")
+        result = subprocess.run(
+            [sys.executable, script] + list(args),
+            input=SAMPLE_NDJSON,
+            capture_output=True,
+            text=True,
+        )
+        return result
+
+    def test_reads_from_stdin(self):
+        r = self._run()
+        self.assertEqual(r.returncode, 0)
+
+    def test_slow_queries_section(self):
+        r = self._run()
+        self.assertIn("SLOW QUERIES", r.stdout)
+
+    def test_slow_query_detected(self):
+        r = self._run()
+        # 3ms INSERT should appear as slow (>1ms)
+        self.assertIn("3.00ms", r.stdout)
+
+    def test_health_endpoint_excluded(self):
+        r = self._run()
+        # /health should not appear in HTTP responses
+        self.assertNotIn("/health", r.stdout)
+
+    def test_mcp_404_noted(self):
+        r = self._run()
+        self.assertIn("session init", r.stdout)
+
+    def test_mcp_tool_counted(self):
+        r = self._run()
+        self.assertIn("list_lists", r.stdout)
+
+    def test_warnings_section(self):
+        r = self._run()
+        self.assertIn("WARNINGS", r.stdout)
+        self.assertIn("something odd", r.stdout)
+
+    def test_span_latencies_section(self):
+        r = self._run()
+        self.assertIn("SPAN LATENCIES", r.stdout)
+        self.assertIn("get_locale", r.stdout)
+
+    def test_mcp_sessions_section(self):
+        r = self._run()
+        self.assertIn("MCP SESSIONS", r.stdout)
+        self.assertIn("4.321s", r.stdout)
+
+    def test_leptos_hash_stripped(self):
+        r = self._run()
+        self.assertNotIn("1135330933350608713", r.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

### Server / tracing
- `develop` env now uses NDJSON logging (same as `production`/`preview`) — all three deployed envs parseable by diagnostic scripts
- `FmtSpan::CLOSE` on all deployed envs: every `#[instrument]` span emits `time.busy`/`time.idle` on close — per-handler and per-MCP-tool latency lands in structured logs
- `/health` excluded from `TraceLayer` by default (30s Docker healthcheck was flooding logs); opt back in with `LOG_HEALTH_REQUESTS=true`
- Slow query threshold lowered 10ms → 1ms
- Production tracing filter changed from `kartoteka_server=info,tower_http=info,sqlx=warn` to `info,sqlx=warn` — crates not explicitly listed (kartoteka_oauth, kartoteka_auth, kartoteka_db, …) previously defaulted to OFF, hiding their errors; global `info` baseline fixes that

### DB pool
- `max_connections` 1 → 5: WAL allows concurrent reads; single connection serialised all MCP + SSR queries unnecessarily
- `busy_timeout(5s)`: write-write contention retries instead of returning `SQLITE_BUSY` immediately
- Clarified `min_connections` comment (misleading "lazy" claim — `connect_with` always opens one connection eagerly)

### Diagnostic scripts
- `scripts/_common.py`: shared helpers (`load_env_map`, `fetch_logs`, `open_source`, `strip_leptos_hash`, `parse_duration_ms`) extracted from both scripts
- Env names, container prefixes, and SSH hostname moved to gitignored `scripts/.docker-env.local` — nothing sensitive in public repo
- `scripts/docker-perf.py`: new sections — span latencies (time.busy), locale N+1 detection, MCP session durations; Leptos hash stripping; MCP 404s labelled as normal session init
- `scripts/docker-logs.py`: span close lines enriched with busy/idle times; MCP tool and session surfaced inline
- `scripts/test_docker_scripts.py`: 27 unit + smoke tests against synthetic NDJSON input

## Test plan

- [ ] `python3 scripts/test_docker_scripts.py` — 27/27 green
- [ ] Deploy to develop, run MCP tool calls — verify `time.busy` in logs
- [ ] Verify `/health` absent from logs by default; present with `LOG_HEALTH_REQUESTS=true`
- [ ] After production deploy — verify `kartoteka_oauth` errors visible on next OAuth failure