### PR TITLE
perf(mcp): embed timezone in JWT to eliminate per-request DB lookups

### DIFF
--- a/crates/domain/src/items.rs
+++ b/crates/domain/src/items.rs
@@ -502,6 +502,18 @@ pub async fn list_all_for_user(pool: &SqlitePool, user_id: &str) -> Result<Vec<I
     Ok(rows.into_iter().map(row_to_item).collect())
 }
 
+/// Returns incomplete items with `deadline` strictly before `today` (YYYY-MM-DD).
+/// Use this from MCP handlers where today is pre-computed from the user's timezone.
+#[tracing::instrument(skip(pool))]
+pub async fn overdue_for(
+    pool: &SqlitePool,
+    user_id: &str,
+    today: &str,
+) -> Result<Vec<Item>, DomainError> {
+    let rows = db::items::overdue(pool, user_id, today).await?;
+    Ok(rows.into_iter().map(row_to_item).collect())
+}
+
 /// Returns incomplete items with `deadline` strictly before today in the user's timezone.
 /// Hard deadlines are intentionally excluded — overdue means a missed `deadline` date.
 #[tracing::instrument(skip(pool))]
@@ -513,8 +525,7 @@ pub async fn overdue(pool: &SqlitePool, user_id: &str) -> Result<Vec<Item>, Doma
         .date_naive()
         .format("%Y-%m-%d")
         .to_string();
-    let rows = db::items::overdue(pool, user_id, &today).await?;
-    Ok(rows.into_iter().map(row_to_item).collect())
+    overdue_for(pool, user_id, &today).await
 }
 
 // ── Integration tests ─────────────────────────────────────────────────────────

--- a/crates/mcp/src/server.rs
+++ b/crates/mcp/src/server.rs
@@ -2,7 +2,7 @@ use http::request::Parts;
 use kartoteka_db::{self as db, lists::InsertListInput};
 use kartoteka_domain as domain;
 use kartoteka_shared::{
-    auth_ctx::{UserId, UserLocale},
+    auth_ctx::{UserId, UserLocale, UserTimezone},
     types::{CreateContainerRequest, MoveContainerRequest},
 };
 use rmcp::{
@@ -113,6 +113,14 @@ impl KartotekaServer {
     /// straight to a localized `ErrorData` so handlers can `?` it directly.
     fn auth(&self, parts: &Parts) -> Result<(String, String), ErrorData> {
         Self::extract_user_id_and_locale(parts).map_err(|e| self.map_err(e, "en"))
+    }
+
+    fn timezone(parts: &Parts) -> String {
+        parts
+            .extensions
+            .get::<UserTimezone>()
+            .map(|t| t.0.clone())
+            .unwrap_or_else(|| "UTC".to_string())
     }
 
     /// Closure factory that maps a `DomainError` to localized `ErrorData`.
@@ -454,6 +462,7 @@ impl KartotekaServer {
         Parameters(p): Parameters<ListItemsParams>,
     ) -> Result<CallToolResult, ErrorData> {
         let (uid, locale) = self.auth(&parts)?;
+        let tz = Self::timezone(&parts);
         let all = domain::items::list_for_list(&self.pool, &p.list_id, &uid)
             .await
             .map_err(self.domain_err(&locale))?;
@@ -468,6 +477,7 @@ impl KartotekaServer {
             .skip(offset)
             .take(limit as usize)
             .cloned()
+            .map(|i| localize_item(i, &tz))
             .collect();
         let next_cursor = if offset + page.len() < all.len() {
             Some((offset + page.len()).to_string())
@@ -494,6 +504,7 @@ impl KartotekaServer {
         Parameters(p): Parameters<ListContainerItemsParams>,
     ) -> Result<CallToolResult, ErrorData> {
         let (uid, locale) = self.auth(&parts)?;
+        let tz = Self::timezone(&parts);
         tracing::debug!(container_id = %p.container_id, recursive = p.recursive.unwrap_or(false));
         let limit = domain::paging::clamp_limit(p.limit);
         let offset: usize = p
@@ -518,6 +529,13 @@ impl KartotekaServer {
         } else {
             None
         };
+        let rows: Vec<_> = rows
+            .into_iter()
+            .map(|mut i| {
+                i.item = localize_item(i.item, &tz);
+                i
+            })
+            .collect();
         self.json_result(
             domain::paging::Paged {
                 data: rows,
@@ -798,9 +816,12 @@ impl KartotekaServer {
         Extension(parts): Extension<Parts>,
     ) -> Result<CallToolResult, ErrorData> {
         let (uid, locale) = self.auth(&parts)?;
-        let data = domain::items::by_date(&self.pool, &uid, "today")
+        let tz = Self::timezone(&parts);
+        let today = today_in_tz(&tz);
+        let data = domain::items::by_date(&self.pool, &uid, &today)
             .await
             .map_err(self.domain_err(&locale))?;
+        let data: Vec<_> = data.into_iter().map(|i| localize_item(i, &tz)).collect();
         self.json_result(data, &locale)
     }
 
@@ -826,6 +847,7 @@ impl KartotekaServer {
         Parameters(p): Parameters<GetItemParams>,
     ) -> Result<CallToolResult, ErrorData> {
         let (uid, locale) = self.auth(&parts)?;
+        let tz = Self::timezone(&parts);
         let data = domain::items::get_one(&self.pool, &p.item_id, &uid)
             .await
             .map_err(self.domain_err(&locale))?
@@ -835,7 +857,7 @@ impl KartotekaServer {
                     &locale,
                 )
             })?;
-        self.json_result(data, &locale)
+        self.json_result(localize_item(data, &tz), &locale)
     }
 
     #[rmcp::tool(name = "list_templates", description = "mcp-tool-list_templates-desc")]
@@ -856,9 +878,12 @@ impl KartotekaServer {
         Extension(parts): Extension<Parts>,
     ) -> Result<CallToolResult, ErrorData> {
         let (uid, locale) = self.auth(&parts)?;
-        let data = domain::items::overdue(&self.pool, &uid)
+        let tz = Self::timezone(&parts);
+        let today = today_in_tz(&tz);
+        let data = domain::items::overdue_for(&self.pool, &uid, &today)
             .await
             .map_err(self.domain_err(&locale))?;
+        let data: Vec<_> = data.into_iter().map(|i| localize_item(i, &tz)).collect();
         self.json_result(data, &locale)
     }
 
@@ -1366,6 +1391,11 @@ impl ServerHandler for KartotekaServer {
             .get::<UserLocale>()
             .map(|l| l.0.clone())
             .unwrap_or_else(|| "en".to_string());
+        let timezone = context
+            .extensions
+            .get::<UserTimezone>()
+            .map(|t| t.0.clone())
+            .unwrap_or_else(|| "UTC".to_string());
 
         let parsed = parse_uri(&request.uri).map_err(|_| {
             ErrorData::invalid_params(
@@ -1421,9 +1451,14 @@ impl ServerHandler for KartotekaServer {
                 serde_json::to_value(data).map_err(to_internal)?
             }
             ResourceUri::Today => {
-                let data = domain::items::by_date(&self.pool, &user_id, "today")
+                let today = today_in_tz(&timezone);
+                let data = domain::items::by_date(&self.pool, &user_id, &today)
                     .await
                     .map_err(self.domain_err(&locale))?;
+                let data: Vec<_> = data
+                    .into_iter()
+                    .map(|i| localize_item(i, &timezone))
+                    .collect();
                 serde_json::to_value(data).map_err(to_internal)?
             }
             ResourceUri::TimeSummary => {
@@ -1439,6 +1474,21 @@ impl ServerHandler for KartotekaServer {
             request.uri,
         )]))
     }
+}
+
+fn today_in_tz(tz_str: &str) -> String {
+    let tz: chrono_tz::Tz = tz_str.parse().unwrap_or(chrono_tz::UTC);
+    chrono::Utc::now()
+        .with_timezone(&tz)
+        .date_naive()
+        .format("%Y-%m-%d")
+        .to_string()
+}
+
+fn localize_item(mut item: domain::items::Item, tz: &str) -> domain::items::Item {
+    item.created_at = kartoteka_shared::date_utils::format_datetime_in_tz(&item.created_at, tz);
+    item.updated_at = kartoteka_shared::date_utils::format_datetime_in_tz(&item.updated_at, tz);
+    item
 }
 
 #[cfg(test)]

--- a/crates/oauth/src/bearer.rs
+++ b/crates/oauth/src/bearer.rs
@@ -5,7 +5,7 @@ use axum::{
     middleware::Next,
     response::{IntoResponse, Response},
 };
-use kartoteka_shared::auth_ctx::{UserId, UserLocale};
+use kartoteka_shared::auth_ctx::{UserId, UserLocale, UserTimezone};
 
 pub async fn bearer_auth_middleware(
     State(state): State<OAuthState>,
@@ -45,8 +45,18 @@ pub async fn bearer_auth_middleware(
             })
     };
 
+    let timezone = if !claims.timezone.is_empty() {
+        claims.timezone
+    } else {
+        // Backward compat: tokens issued before timezone was embedded — query DB once.
+        kartoteka_db::preferences::get_timezone(&state.pool, &user_id)
+            .await
+            .unwrap_or_else(|_| "UTC".to_string())
+    };
+
     req.extensions_mut().insert(UserId(user_id));
     req.extensions_mut().insert(UserLocale(locale));
+    req.extensions_mut().insert(UserTimezone(timezone));
 
     Ok(next.run(req).await)
 }
@@ -94,7 +104,7 @@ mod tests {
             signing_secret: secret.into(),
             public_base_url: "http://x".into(),
         };
-        let token = crate::storage::sign_access_token("u-1", "mcp", secret, "").unwrap();
+        let token = crate::storage::sign_access_token("u-1", "mcp", secret, "", "").unwrap();
         let req = Request::builder()
             .uri("/t")
             .header("authorization", format!("Bearer {token}"))
@@ -120,7 +130,8 @@ mod tests {
             signing_secret: secret.into(),
             public_base_url: "http://x".into(),
         };
-        let token = crate::storage::sign_access_token(&uid, "mcp", secret, "pl").unwrap();
+        let token =
+            crate::storage::sign_access_token(&uid, "mcp", secret, "pl", "Europe/Warsaw").unwrap();
         let req = Request::builder()
             .uri("/t")
             .header("authorization", format!("Bearer {token}"))
@@ -156,7 +167,8 @@ mod tests {
             signing_secret: secret.into(),
             public_base_url: "http://x".into(),
         };
-        let token = crate::storage::sign_access_token("u-1", "calendar", secret, "en").unwrap();
+        let token =
+            crate::storage::sign_access_token("u-1", "calendar", secret, "en", "UTC").unwrap();
         let req = Request::builder()
             .uri("/t")
             .header("authorization", format!("Bearer {token}"))

--- a/crates/oauth/src/handlers.rs
+++ b/crates/oauth/src/handlers.rs
@@ -308,11 +308,19 @@ async fn token_authorization_code(
         return Err(OAuthError::InvalidGrant("PKCE verification failed"));
     }
 
-    let locale = kartoteka_db::preferences::get_locale(&s.pool, &row.user_id)
-        .await
-        .unwrap_or_else(|_| "en".to_string());
-    let access_token =
-        storage::sign_access_token(&row.user_id, &row.scope, &s.signing_secret, &locale)?;
+    let (locale, timezone) = tokio::join!(
+        kartoteka_db::preferences::get_locale(&s.pool, &row.user_id),
+        kartoteka_db::preferences::get_timezone(&s.pool, &row.user_id),
+    );
+    let locale = locale.unwrap_or_else(|_| "en".to_string());
+    let timezone = timezone.unwrap_or_else(|_| "UTC".to_string());
+    let access_token = storage::sign_access_token(
+        &row.user_id,
+        &row.scope,
+        &s.signing_secret,
+        &locale,
+        &timezone,
+    )?;
     let (refresh_token, refresh_hash) = mint_refresh_token();
     let expires_at = Utc::now() + Duration::days(REFRESH_TTL_DAYS);
     oauth_refresh::insert(
@@ -355,11 +363,19 @@ async fn token_refresh(s: OAuthState, form: JsonValue) -> Result<Json<TokenRespo
         return Err(OAuthError::InvalidGrant("client_id mismatch"));
     }
 
-    let locale = kartoteka_db::preferences::get_locale(&s.pool, &row.user_id)
-        .await
-        .unwrap_or_else(|_| "en".to_string());
-    let access_token =
-        storage::sign_access_token(&row.user_id, &row.scope, &s.signing_secret, &locale)?;
+    let (locale, timezone) = tokio::join!(
+        kartoteka_db::preferences::get_locale(&s.pool, &row.user_id),
+        kartoteka_db::preferences::get_timezone(&s.pool, &row.user_id),
+    );
+    let locale = locale.unwrap_or_else(|_| "en".to_string());
+    let timezone = timezone.unwrap_or_else(|_| "UTC".to_string());
+    let access_token = storage::sign_access_token(
+        &row.user_id,
+        &row.scope,
+        &s.signing_secret,
+        &locale,
+        &timezone,
+    )?;
     let (new_refresh, new_hash) = mint_refresh_token();
 
     oauth_refresh::insert(

--- a/crates/oauth/src/storage.rs
+++ b/crates/oauth/src/storage.rs
@@ -16,6 +16,10 @@ pub struct Claims {
     /// existed — bearer middleware falls back to a single DB lookup in that case.
     #[serde(default)]
     pub locale: String,
+    /// User timezone baked in at token issuance (IANA name, e.g. "Europe/Warsaw").
+    /// Empty string on legacy tokens — bearer middleware falls back to a DB lookup in that case.
+    #[serde(default)]
+    pub timezone: String,
 }
 
 pub fn sign_access_token(
@@ -23,6 +27,7 @@ pub fn sign_access_token(
     scope: &str,
     secret: &str,
     locale: &str,
+    timezone: &str,
 ) -> Result<String, jsonwebtoken::errors::Error> {
     let now = Utc::now();
     let claims = Claims {
@@ -32,6 +37,7 @@ pub fn sign_access_token(
         iat: now.timestamp() as usize,
         exp: (now + Duration::seconds(ACCESS_TOKEN_TTL_SECS)).timestamp() as usize,
         locale: locale.into(),
+        timezone: timezone.into(),
     };
     encode(
         &Header::new(Algorithm::HS256),
@@ -60,30 +66,38 @@ mod tests {
             "mcp",
             "secret-at-least-32-chars-long-padding",
             "pl",
+            "Europe/Warsaw",
         )
         .unwrap();
         let c = verify_access_token(&t, "secret-at-least-32-chars-long-padding").unwrap();
         assert_eq!(c.sub, "user-123");
         assert_eq!(c.scope, "mcp");
         assert_eq!(c.locale, "pl");
+        assert_eq!(c.timezone, "Europe/Warsaw");
         assert!(!c.jti.is_empty());
         assert!(c.exp > c.iat);
     }
 
     #[test]
     fn verify_rejects_wrong_secret() {
-        let t =
-            sign_access_token("u", "mcp", "secret-at-least-32-chars-long-padding", "en").unwrap();
+        let t = sign_access_token(
+            "u",
+            "mcp",
+            "secret-at-least-32-chars-long-padding",
+            "en",
+            "UTC",
+        )
+        .unwrap();
         assert!(verify_access_token(&t, "different-secret-also-32-chars-lngpad").is_err());
     }
 
     #[test]
-    fn legacy_token_without_locale_deserializes_with_empty_string() {
-        // Tokens issued before the locale field was added have no `locale` claim.
-        // #[serde(default)] must produce "" rather than a deserialization error.
+    fn legacy_token_without_locale_or_timezone_deserializes_with_empty_strings() {
+        // Tokens issued before locale/timezone fields were added produce "" via #[serde(default)].
         let legacy =
-            sign_access_token("u", "mcp", "secret-at-least-32-chars-long-padding", "").unwrap();
+            sign_access_token("u", "mcp", "secret-at-least-32-chars-long-padding", "", "").unwrap();
         let c = verify_access_token(&legacy, "secret-at-least-32-chars-long-padding").unwrap();
         assert_eq!(c.locale, "");
+        assert_eq!(c.timezone, "");
     }
 }

--- a/crates/shared/src/auth_ctx.rs
+++ b/crates/shared/src/auth_ctx.rs
@@ -5,3 +5,6 @@ pub struct UserId(pub String);
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct UserLocale(pub String);
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct UserTimezone(pub String);


### PR DESCRIPTION
## Summary

- Extends the locale-in-JWT pattern from #271 to user timezone: adds `timezone` field to JWT `Claims` with `#[serde(default)]` for backward compat
- `bearer_auth_middleware` now injects `UserTimezone` extension; locale+timezone are fetched in parallel via `tokio::join!` at token issuance (both `authorization_code` and `refresh_token` flows)
- MCP handlers `get_today`, `list_overdue`, and `read_resource/Today` now resolve "today" from the JWT timezone — eliminating the `SELECT value FROM user_settings WHERE key='timezone'` query that fired on every tool call
- Adds `domain::items::overdue_for(pool, user_id, today: &str)` to accept a pre-computed date; existing `overdue()` delegates to it, keeping non-MCP callers unchanged
- All item-returning MCP handlers (`get_item`, `list_items`, `list_container_items`, `get_today`, `list_overdue`, `read_resource/Today`) now format `created_at`/`updated_at` in the user's local timezone via the existing `format_datetime_in_tz` utility

## Test plan

- [ ] `cargo test -p kartoteka-oauth --all-targets` — JWT round-trip, legacy token compat, bearer middleware locale/timezone injection
- [ ] `cargo test -p kartoteka-domain` — `overdue_for` covered by existing overdue tests
- [ ] `just ci` — full suite green
- [ ] Deploy to preview, call `get_today` + `list_overdue` via MCP, verify no `user_settings` queries for timezone in logs for new tokens
- [ ] Verify `created_at`/`updated_at` in item responses are formatted in local time (e.g. `"08.06.2026 11:23"` not `"2026-06-08 09:23:00"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)